### PR TITLE
feat: phase 2 read-side API (blocks → html/markdown) — v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,28 @@
 A WordPress plugin that orchestrates bidirectional content format conversion (HTML, Blocks, Markdown) through a unified
 adapter API.
 
-The bridge owns no parsing logic of its own. It composes existing tools — [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter),
-WordPress core's `serialize_blocks()` / `do_blocks()`, and [`league/commonmark`](https://github.com/thephpleague/commonmark) — behind one
-contract. New formats become available by registering a new adapter; the bridge core never grows.
+The bridge owns no parsing logic of its own. It composes existing libraries — [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter),
+WordPress core's `serialize_blocks()` / `do_blocks()`, [`league/commonmark`](https://github.com/thephpleague/commonmark),
+and [`league/html-to-markdown`](https://github.com/thephpleague/html-to-markdown) — behind one contract. New formats
+become available by registering a new adapter; the bridge core never grows.
 
-> **Status:** Phase 1 (write side). Markdown → Blocks and HTML → Blocks both work end-to-end. The read side
-> (Blocks → Markdown) is Phase 2.
+> **Status (v0.2.0):** Phase 2 read side ships. Both write (HTML/Markdown → Blocks) and read (Blocks → HTML/Markdown)
+> directions work end-to-end, plus a `?content_format=` REST query param.
 
 ## What it does
 
-| Conversion direction | Underlying tool                       |
-|----------------------|---------------------------------------|
-| HTML → Blocks        | `chubes4/html-to-blocks-converter`    |
-| Blocks → HTML        | `serialize_blocks()` (core)           |
-| Markdown → HTML      | `league/commonmark` (vendor-prefixed) |
-| Markdown → Blocks    | composition: Markdown → HTML → Blocks |
-| Blocks → Markdown    | _Phase 2 — not yet implemented_       |
-| HTML → Markdown      | _Phase 2 — not yet implemented_       |
+| Conversion direction | Underlying tool                        |
+|----------------------|----------------------------------------|
+| HTML → Blocks        | `chubes4/html-to-blocks-converter`     |
+| Blocks → HTML        | `do_blocks()` (WordPress core)         |
+| Markdown → HTML      | `league/commonmark` (vendor-prefixed)  |
+| Markdown → Blocks    | composition: Markdown → HTML → Blocks  |
+| Blocks → Markdown    | `do_blocks()` + `league/html-to-markdown` (vendor-prefixed) |
+| HTML → Markdown      | composition: HTML → Blocks → Markdown  |
 
 ## Architecture
 
-Two adapters ship in v0.1.0:
-
-- **`BFB_HTML_Adapter`** — delegates `to_blocks()` to `html_to_blocks_raw_handler()` from `html-to-blocks-converter`,
-  and `from_blocks()` to `serialize_blocks()`.
-- **`BFB_Markdown_Adapter`** — runs CommonMark + GFM via `league/commonmark`, then routes the resulting HTML through
-  the HTML adapter to land in block form. `from_blocks()` is a no-op until Phase 2.
-
-Both implement the `BFB_Format_Adapter` interface:
+Every adapter implements the `BFB_Format_Adapter` contract:
 
 ```php
 interface BFB_Format_Adapter {
@@ -41,7 +35,14 @@ interface BFB_Format_Adapter {
 }
 ```
 
-Every cross-format conversion routes through the block array pivot:
+Two adapters ship in v0.2.0:
+
+- **`BFB_HTML_Adapter`** — `to_blocks()` delegates to `html_to_blocks_raw_handler()` from `html-to-blocks-converter`;
+  `from_blocks()` returns rendered HTML via `render_block()` (so dynamic blocks resolve to their server-side output).
+- **`BFB_Markdown_Adapter`** — `to_blocks()` runs CommonMark + GFM and routes the resulting HTML through the HTML
+  adapter. `from_blocks()` renders blocks via `render_block()` and pipes the HTML through league/html-to-markdown.
+
+Every cross-format conversion routes through the block-array pivot:
 
 ```
 $blocks = $from_adapter->to_blocks( $content );
@@ -67,14 +68,14 @@ present, but you'll get much better block fidelity with it active.
 git clone https://github.com/chubes4/block-format-bridge.git
 cd block-format-bridge
 composer install
-composer build  # runs php-scoper to vendor-prefix league/commonmark into vendor_prefixed/
+composer build  # runs php-scoper to vendor-prefix league/commonmark + league/html-to-markdown
 ```
 
 ## Usage
 
 ### `bfb_convert( $content, $from, $to ): string`
 
-Universal conversion. Routes through the block pivot via the adapter registry.
+Universal conversion. Routes through the block-array pivot via the adapter registry.
 
 ```php
 // Markdown → blocks (serialised block markup)
@@ -83,32 +84,77 @@ $blocks = bfb_convert( "# Hello\n\nWorld", 'markdown', 'blocks' );
 // HTML → blocks
 $blocks = bfb_convert( '<h1>Hello</h1><p>World</p>', 'html', 'blocks' );
 
-// Blocks → HTML
+// Blocks → HTML (rendered through do_blocks())
 $html = bfb_convert( $serialised_blocks, 'blocks', 'html' );
+
+// Blocks → markdown
+$md = bfb_convert( $serialised_blocks, 'blocks', 'markdown' );
+
+// HTML → markdown (composes via blocks)
+$md = bfb_convert( '<h1>X</h1>', 'html', 'markdown' );
 ```
+
+### `bfb_render_post( $post, $format ): string`
+
+Read a post's `post_content` in the requested format. Routes through `bfb_convert()` with `'blocks'` as the source.
+
+```php
+$html = bfb_render_post( $post_id, 'html' );      // do_blocks() output
+$md   = bfb_render_post( $post_id, 'markdown' );  // GFM
+```
+
+### REST: `?content_format=<slug>`
+
+Every REST-enabled post type accepts a `content_format` query parameter. When present, the response gains a sibling
+`content.formatted` field rendered via `bfb_render_post()`. The existing `content.raw` and `content.rendered` fields
+are left untouched.
+
+```bash
+curl 'https://example.com/wp-json/wp/v2/posts/123?content_format=markdown'
+```
+
+```json
+{
+  "content": {
+    "raw": "<!-- wp:heading ...",
+    "rendered": "<h1 class=\"wp-block-heading\">...</h1>",
+    "format": "markdown",
+    "formatted": "# Hello\n\nBody."
+  }
+}
+```
+
+Full HTTP content negotiation (`Accept: text/markdown`, `.md` URL suffix, q-values, 406 Not Acceptable) is intentionally
+out of scope here — that's the job of [`roots/post-content-to-markdown`](https://github.com/roots/post-content-to-markdown)
+when active. The bridge surface is the simpler, programmatic query-param form.
 
 ### `bfb_get_adapter( $slug ): ?BFB_Format_Adapter`
 
-Look up a registered adapter directly. Useful when you want to skip the universal router and do block-array work
+Resolve a registered adapter directly. Useful when you want to skip the universal router and operate on block arrays
 without re-serialising.
 
-### `bfb_default_format` filter
+### Filters
 
-Declare which format a post type writes in by default. Hooks into `wp_insert_post_data` so any code path that calls
-`wp_insert_post()` — REST, WP-CLI, code abilities, plugin internals — gets the same conversion behaviour.
+- **`bfb_default_format( $format, $post_type, $content ): string`** — declares which format a CPT writes in by default.
+  Hooks into `wp_insert_post_data` so any code path that calls `wp_insert_post()` (REST, WP-CLI, abilities, plugin
+  internals) gets the same conversion behaviour.
 
-```php
-add_filter( 'bfb_default_format', function ( $format, $post_type, $content ) {
-    if ( $post_type === 'wiki' ) {
-        return 'markdown';
-    }
-    return $format;
-}, 10, 3 );
-```
+  ```php
+  add_filter( 'bfb_default_format', function ( $format, $post_type ) {
+      return $post_type === 'wiki' ? 'markdown' : $format;
+  }, 10, 2 );
+  ```
 
-### `_bfb_format` per-call hint
+- **`bfb_register_format_adapter( $adapter, $slug ): ?BFB_Format_Adapter`** — lazy adapter registration.
+- **`bfb_rest_supported_post_types( $post_types ): array`** — restricts which CPTs honour `?content_format=`.
+- **`bfb_html_to_markdown_options( $options, $html ): array`** — option array passed to league/html-to-markdown
+  (mirrors `roots/post-content-to-markdown`'s `converter_options`).
+- **`bfb_markdown_output( $markdown, $html, $blocks ): string`** — final filter on the markdown produced by
+  `from_blocks()`.
 
-Bypass the filter for a single insert by setting the `_bfb_format` key on the `$postarr` argument:
+### Per-call hint: `_bfb_format` on `$postarr`
+
+Bypass the filter for a single insert by setting the `_bfb_format` key:
 
 ```php
 wp_insert_post( array(
@@ -140,11 +186,20 @@ add_filter( 'bfb_register_format_adapter', function ( $adapter, $slug ) {
 }, 10, 2 );
 ```
 
+## Known limitations
+
+- **Code-fence language hints round-trip lossily.** `\`\`\`php` becomes `\`\`\`` after Blocks → Markdown. The block
+  carries `className: language-php` but league/html-to-markdown doesn't reconstruct the fence info string. Track in
+  follow-up issue.
+- **Tables degrade through Blocks → Markdown.** `<wp:table>` blocks render to HTML tables that league/html-to-markdown
+  collapses to inline text. Custom converters (or swap-in `roots/post-content-to-markdown`) are the v0.3.0 candidate
+  fix.
+- **Custom blocks without sensible HTML rendering produce garbage markdown.** Out of bridge scope; document in your
+  block.
+
 ## Design
 
-The full architectural rationale — including why DM stays substrate-agnostic, why the bridge is a separate plugin
-instead of a feature of `html-to-blocks-converter`, and the prior-art evaluation for each conversion direction — lives
-in the design doc on the author's personal wiki under
+The full architectural rationale lives on the author's personal wiki at
 `projects/block-format-bridge-bidirectional-content-format-plugin-design`.
 
 ## License

--- a/block-format-bridge.php
+++ b/block-format-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Block Format Bridge
  * Plugin URI: https://github.com/chubes4/block-format-bridge
  * Description: Orchestrates bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API. Composes existing plugins/libraries — owns no parsing logic of its own.
- * Version: 0.1.0
+ * Version: 0.2.0
  * Author: Chris Huber
  * Author URI: https://chubes.net
  * License: GPL-2.0-or-later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'BFB_VERSION', '0.1.0' );
+define( 'BFB_VERSION', '0.2.0' );
 define( 'BFB_PATH', plugin_dir_path( __FILE__ ) );
 define( 'BFB_FILE', __FILE__ );
 define( 'BFB_MIN_WP', '6.4' );
@@ -71,6 +71,7 @@ require_once BFB_PATH . 'includes/class-bfb-html-adapter.php';
 require_once BFB_PATH . 'includes/class-bfb-markdown-adapter.php';
 require_once BFB_PATH . 'includes/api.php';
 require_once BFB_PATH . 'includes/hooks.php';
+require_once BFB_PATH . 'includes/rest.php';
 
 /**
  * Registers the built-in adapters at plugin load.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require": {
         "php": "^8.1",
-        "league/commonmark": "^2.5"
+        "league/commonmark": "^2.5",
+        "league/html-to-markdown": "^5.1"
     },
     "require-dev": {
         "humbug/php-scoper": "^0.18.19"

--- a/includes/api.php
+++ b/includes/api.php
@@ -84,3 +84,36 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 		return $to_adapter->from_blocks( $blocks );
 	}
 }
+
+if ( ! function_exists( 'bfb_render_post' ) ) {
+	/**
+	 * Render a post's `post_content` in the requested format.
+	 *
+	 * Reads the raw `post_content` and routes it through `bfb_convert`
+	 * with `'blocks'` as the source format (so dynamic blocks render
+	 * via their server-side callbacks).
+	 *
+	 * Returns an empty string when the post is missing, the post type
+	 * does not support content, or the requested format is unknown.
+	 *
+	 * @param int|WP_Post $post   Post ID or WP_Post.
+	 * @param string      $format Target format slug (e.g. 'html', 'markdown').
+	 * @return string Rendered content. Empty string on failure.
+	 */
+	function bfb_render_post( $post, string $format ): string {
+		$post_obj = get_post( $post );
+		if ( ! $post_obj ) {
+			return '';
+		}
+
+		$content = (string) $post_obj->post_content;
+		if ( '' === $content ) {
+			return '';
+		}
+
+		// post_content is always serialised block markup (or raw HTML on
+		// pre-Gutenberg installs); route through the 'blocks' source so
+		// dynamic blocks resolve.
+		return bfb_convert( $content, 'blocks', $format );
+	}
+}

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -5,12 +5,11 @@
  * `to_blocks()` delegates to `html_to_blocks_raw_handler()` from the
  * `chubes4/html-to-blocks-converter` plugin, which must be installed
  * and active for HTML conversion to work. If the function is missing,
- * the adapter falls back to `parse_blocks()` so the system fails soft
- * (returning a single core/freeform block) rather than hard.
+ * the adapter falls back to a `core/freeform` block so the system
+ * fails soft rather than hard.
  *
- * `from_blocks()` returns serialized block markup. Phase 1 does not
- * call `do_blocks()`; that is reserved for the read-side API in
- * Phase 2.
+ * `from_blocks()` renders blocks through `do_blocks()` so dynamic
+ * blocks resolve to their server-side HTML output.
  *
  * @package BlockFormatBridge
  */
@@ -65,13 +64,21 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * Renders each block through `render_block()` so dynamic blocks
+	 * resolve to their server-side HTML output. Static blocks pass
+	 * through their inner HTML untouched.
 	 */
 	public function from_blocks( array $blocks ): string {
 		if ( empty( $blocks ) ) {
 			return '';
 		}
 
-		return serialize_blocks( $blocks );
+		$html = '';
+		foreach ( $blocks as $block ) {
+			$html .= render_block( $block );
+		}
+		return $html;
 	}
 
 	/**

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -2,17 +2,17 @@
 /**
  * Markdown format adapter.
  *
- * `to_blocks()` runs CommonMark + GFM via league/commonmark to convert
- * the markdown source to HTML, then routes the HTML through the
- * registered HTML adapter to land in block form.
+ * Write side (`to_blocks()`):
+ *   Runs CommonMark + GFM via league/commonmark to convert the markdown
+ *   source to HTML, then routes the HTML through the registered HTML
+ *   adapter to land in block form.
  *
- * The `BlockFormatBridge\Vendor` namespace is preferred (php-scoped
- * build distribution); the unprefixed `League\CommonMark` namespace is
- * used in development mode when the package is installed via
- * `composer install` without running the build script.
- *
- * `from_blocks()` is reserved for Phase 2 (read side) — see the design
- * doc at `projects/block-format-bridge-bidirectional-content-format-plugin-design`.
+ * Read side (`from_blocks()`):
+ *   Renders blocks → HTML via `do_blocks()`, then converts HTML → markdown
+ *   via league/html-to-markdown. Both libraries are vendor-prefixed under
+ *   the `BlockFormatBridge\Vendor` namespace by the build pipeline; the
+ *   adapter prefers the prefixed namespace and falls back to unprefixed
+ *   (dev-mode `composer install` without the build step).
  *
  * @package BlockFormatBridge
  */
@@ -57,18 +57,52 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 	/**
 	 * @inheritDoc
 	 *
-	 * Phase 2 will route through roots/post-content-to-markdown (or a
-	 * direct league/html-to-markdown integration). Phase 1 returns an
-	 * empty string — the read side is intentionally out of scope until
-	 * the dependency choice is finalised.
+	 * Renders blocks → HTML (via `do_blocks()` + `serialize_blocks()`)
+	 * and converts the resulting HTML to markdown via
+	 * league/html-to-markdown.
+	 *
+	 * Dynamic blocks render through their PHP callback, so server-side
+	 * blocks (latest-posts, navigation, query loop, etc.) appear in the
+	 * markdown as their rendered HTML output rather than block-comment
+	 * markup.
+	 *
+	 * @param array $blocks Block array (parse_blocks() shape).
+	 * @return string Markdown representation. Empty string on failure.
 	 */
 	public function from_blocks( array $blocks ): string {
-		// TODO(phase-2): convert blocks → HTML (do_blocks) → markdown
-		// using roots/post-content-to-markdown or a direct
-		// league/html-to-markdown integration. See the design doc:
-		// projects/block-format-bridge-bidirectional-content-format-plugin-design
-		unset( $blocks );
-		return '';
+		if ( empty( $blocks ) ) {
+			return '';
+		}
+
+		// Render dynamic blocks through their server-side callbacks, then
+		// serialise. We pass the rendered HTML straight to the html-to-md
+		// converter so dynamic content shows up as resolved HTML.
+		$html = '';
+		foreach ( $blocks as $block ) {
+			$html .= render_block( $block );
+		}
+
+		if ( '' === trim( $html ) ) {
+			return '';
+		}
+
+		$markdown = $this->html_to_markdown( $html );
+
+		/**
+		 * Filters the markdown output produced by the markdown adapter.
+		 *
+		 * Mirrors `roots/post-content-to-markdown`'s
+		 * `post_content_to_markdown/markdown_output` filter so consumers
+		 * can swap in a richer implementation without changing the
+		 * bridge contract.
+		 *
+		 * @since 0.2.0
+		 *
+		 * @param string $markdown Markdown produced by the converter.
+		 * @param string $html     Source HTML that was converted.
+		 * @param array  $blocks   Original block array.
+		 */
+		return (string) apply_filters( 'bfb_markdown_output', $markdown, $html, $blocks );
 	}
 
 	/**
@@ -111,6 +145,68 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 			return (string) $result;
 		} catch ( \Throwable $e ) {
 			error_log( sprintf( '[Block Format Bridge] CommonMark conversion failed: %s', $e->getMessage() ) );
+			return '';
+		}
+	}
+
+	/**
+	 * Convert HTML to markdown using league/html-to-markdown.
+	 *
+	 * Picks the prefixed namespace from the build distribution when
+	 * available, falling back to the unprefixed namespace for dev mode.
+	 *
+	 * Default converter options:
+	 *   - header_style: 'atx'    (`#` prefix instead of underline)
+	 *   - strip_tags:   true     drop unsupported HTML
+	 *   - remove_nodes: 'script style'
+	 *   - hard_break:   true     `<br>` → newline
+	 *
+	 * Filterable via `bfb_html_to_markdown_options`.
+	 *
+	 * @param string $html Source HTML.
+	 * @return string Markdown. Empty string on failure.
+	 */
+	protected function html_to_markdown( string $html ): string {
+		$prefixed   = '\\BlockFormatBridge\\Vendor\\League\\HTMLToMarkdown\\HtmlConverter';
+		$unprefixed = '\\League\\HTMLToMarkdown\\HtmlConverter';
+
+		$class = null;
+		if ( class_exists( $prefixed ) ) {
+			$class = $prefixed;
+		} elseif ( class_exists( $unprefixed ) ) {
+			$class = $unprefixed;
+		}
+
+		if ( null === $class ) {
+			error_log( '[Block Format Bridge] league/html-to-markdown is not loaded; HTML→markdown conversion unavailable.' );
+			return '';
+		}
+
+		$defaults = array(
+			'header_style' => 'atx',
+			'strip_tags'   => true,
+			'remove_nodes' => 'script style',
+			'hard_break'   => true,
+		);
+
+		/**
+		 * Filters the option array passed to league/html-to-markdown.
+		 *
+		 * Mirrors `roots/post-content-to-markdown`'s
+		 * `post_content_to_markdown/converter_options`.
+		 *
+		 * @since 0.2.0
+		 *
+		 * @param array  $options Converter options.
+		 * @param string $html    Source HTML.
+		 */
+		$options = (array) apply_filters( 'bfb_html_to_markdown_options', $defaults, $html );
+
+		try {
+			$converter = new $class( $options );
+			return (string) $converter->convert( $html );
+		} catch ( \Throwable $e ) {
+			error_log( sprintf( '[Block Format Bridge] HTML→markdown conversion failed: %s', $e->getMessage() ) );
 			return '';
 		}
 	}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * REST integration — read-as-format query param.
+ *
+ * Adds a `?content_format=<slug>` query parameter to every REST-enabled
+ * post type. When set, the response gains a sibling `content.formatted`
+ * field rendered by `bfb_render_post()`. The existing `content.rendered`
+ * and `content.raw` fields are left untouched so existing consumers keep
+ * working unchanged.
+ *
+ * Full HTTP content negotiation (Accept header, q-values, .md URL
+ * suffix, 406 Not Acceptable) is intentionally out of scope here — that
+ * is the job of `roots/post-content-to-markdown` when active. The
+ * bridge surface is the simpler, programmatic query-param form.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the `content_format` REST query argument and the
+ * `rest_prepare_*` filters that honour it.
+ *
+ * Runs at priority 20 to mirror html-to-blocks-converter's pattern of
+ * waiting until after every other plugin has registered its CPTs at
+ * the default `init` priority.
+ */
+function bfb_register_rest_filters() {
+	$default_types = array_keys( get_post_types( array( 'show_in_rest' => true ) ) );
+
+	/**
+	 * Filters the post types that opt into the `content_format` REST
+	 * query argument.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string[] $post_types REST-enabled post type slugs.
+	 */
+	$supported = (array) apply_filters( 'bfb_rest_supported_post_types', $default_types );
+
+	foreach ( $supported as $post_type ) {
+		add_filter( "rest_{$post_type}_collection_params", 'bfb_rest_add_collection_param' );
+		add_filter( "rest_prepare_{$post_type}", 'bfb_rest_prepare_response', 20, 3 );
+	}
+}
+add_action( 'init', 'bfb_register_rest_filters', 20 );
+
+/**
+ * Add `content_format` to the REST collection schema so clients can
+ * discover the parameter and pass it through validation.
+ *
+ * @param array $params Existing query params.
+ * @return array
+ */
+function bfb_rest_add_collection_param( $params ) {
+	if ( ! is_array( $params ) ) {
+		return $params;
+	}
+
+	$params['content_format'] = array(
+		'description' => __( 'Render post content in the requested format and expose it as `content.formatted` on each post.', 'block-format-bridge' ),
+		'type'        => 'string',
+	);
+
+	return $params;
+}
+
+/**
+ * Inject `content.formatted` into a REST response when the request
+ * includes a `content_format` query param.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     The post object.
+ * @param WP_REST_Request  $request  The request object.
+ * @return WP_REST_Response
+ */
+function bfb_rest_prepare_response( $response, $post, $request ) {
+	if ( ! ( $response instanceof WP_REST_Response ) || ! ( $post instanceof WP_Post ) ) {
+		return $response;
+	}
+
+	$format = $request->get_param( 'content_format' );
+	if ( ! is_string( $format ) || '' === $format ) {
+		return $response;
+	}
+
+	// HTML is a no-op — `content.rendered` already holds rendered HTML.
+	if ( 'html' === $format ) {
+		return $response;
+	}
+
+	$adapter = function_exists( 'bfb_get_adapter' ) ? bfb_get_adapter( $format ) : null;
+	if ( ! $adapter ) {
+		return $response;
+	}
+
+	$rendered = bfb_render_post( $post, $format );
+	if ( '' === $rendered ) {
+		return $response;
+	}
+
+	$data = $response->get_data();
+	if ( ! is_array( $data ) ) {
+		return $response;
+	}
+
+	if ( ! isset( $data['content'] ) || ! is_array( $data['content'] ) ) {
+		$data['content'] = array();
+	}
+
+	$data['content']['formatted'] = $rendered;
+	$data['content']['format']    = $format;
+
+	$response->set_data( $data );
+	return $response;
+}

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -23,6 +23,7 @@ return [
 			->name( [ '*.php', 'composer.json', 'LICENSE*' ] )
 			->in(
 				[
+					// league/commonmark + transitive deps (Markdown → HTML).
 					'vendor/league/commonmark',
 					'vendor/league/config',
 					'vendor/dflydev/dot-access-data',
@@ -31,6 +32,8 @@ return [
 					'vendor/psr/event-dispatcher',
 					'vendor/symfony/deprecation-contracts',
 					'vendor/symfony/polyfill-php80',
+					// league/html-to-markdown (HTML → Markdown). No further composer deps.
+					'vendor/league/html-to-markdown',
 				]
 			),
 	],

--- a/tools/smoke-test.php
+++ b/tools/smoke-test.php
@@ -8,11 +8,20 @@
  *   studio wp eval-file ~/Developer/block-format-bridge/tools/smoke-test.php
  *
  * Verifies:
- *   1. Markdown → blocks conversion produces serialised block markup with
- *      a heading and paragraph.
- *   2. HTML → blocks conversion produces equivalent shape.
- *   3. The bfb_default_format filter routes a wp_insert_post() through
- *      markdown conversion when the post type opts in.
+ *   Phase 1 (write side):
+ *     1. Markdown → blocks conversion produces serialised block markup
+ *        with a heading and paragraph.
+ *     2. HTML → blocks conversion produces equivalent shape.
+ *     3. The bfb_default_format filter routes a wp_insert_post()
+ *        through markdown conversion when the post type opts in.
+ *   Phase 2 (read side):
+ *     4. Markdown adapter from_blocks() round-trips a heading +
+ *        formatted paragraph back to clean GFM.
+ *     5. HTML adapter from_blocks() renders dynamic blocks via
+ *        do_blocks().
+ *     6. bfb_render_post() returns markdown / html for a stored post.
+ *     7. REST GET /wp/v2/posts/{id}?content_format=markdown adds
+ *        content.formatted without disturbing content.rendered.
  *
  * @package BlockFormatBridge
  */
@@ -117,6 +126,116 @@ if ( is_wp_error( $post_id ) ) {
 		'stored: ' . substr( $saved, 0, 200 )
 	);
 	wp_delete_post( $post_id, true );
+}
+
+// --- Test 4: Markdown adapter from_blocks() round-trips ---
+$md_adapter = bfb_get_adapter( 'markdown' );
+assert_true( 'markdown adapter resolves', $md_adapter instanceof BFB_Format_Adapter );
+
+$source_blocks = parse_blocks(
+	'<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Title</h1><!-- /wp:heading -->'
+	. '<!-- wp:paragraph --><p>Body with <strong>bold</strong> and <em>italic</em>.</p><!-- /wp:paragraph -->'
+);
+
+$round_md = $md_adapter ? $md_adapter->from_blocks( $source_blocks ) : '';
+assert_true(
+	'markdown from_blocks() emits ATX heading',
+	false !== strpos( $round_md, '# Title' ),
+	'got: ' . substr( $round_md, 0, 200 )
+);
+assert_true(
+	'markdown from_blocks() preserves bold (**) and italic (*)',
+	false !== strpos( $round_md, '**bold**' ) && false !== strpos( $round_md, '*italic*' ),
+	'got: ' . substr( $round_md, 0, 200 )
+);
+
+// --- Test 5: HTML adapter from_blocks() renders blocks ---
+$html_adapter = bfb_get_adapter( 'html' );
+$rendered     = $html_adapter ? $html_adapter->from_blocks( $source_blocks ) : '';
+assert_true(
+	'html from_blocks() renders heading',
+	false !== strpos( $rendered, '<h1' ) && false !== strpos( $rendered, 'Title' ),
+	'got: ' . substr( $rendered, 0, 200 )
+);
+assert_true(
+	'html from_blocks() does NOT contain block-comment markup (it is rendered HTML)',
+	false === strpos( $rendered, '<!-- wp:' ),
+	'got: ' . substr( $rendered, 0, 200 )
+);
+
+// --- Test 6: bfb_render_post() ---
+$render_post_id = wp_insert_post(
+	array(
+		'post_type'    => 'post',
+		'post_status'  => 'draft',
+		'post_title'   => 'Render Smoke',
+		'post_content' => '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">Render</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Para.</p><!-- /wp:paragraph -->',
+	),
+	true
+);
+if ( is_wp_error( $render_post_id ) ) {
+	assert_true( 'render-test post inserted', false, $render_post_id->get_error_message() );
+} else {
+	$rendered_html = bfb_render_post( $render_post_id, 'html' );
+	$rendered_md   = bfb_render_post( $render_post_id, 'markdown' );
+
+	assert_true(
+		'bfb_render_post(html) returns rendered HTML (no block-comments)',
+		false !== strpos( $rendered_html, '<h2' ) && false === strpos( $rendered_html, '<!-- wp:' ),
+		'got: ' . substr( $rendered_html, 0, 200 )
+	);
+	assert_true(
+		'bfb_render_post(markdown) returns clean GFM',
+		false !== strpos( $rendered_md, '## Render' ) && false !== strpos( $rendered_md, 'Para.' ),
+		'got: ' . substr( $rendered_md, 0, 200 )
+	);
+	wp_delete_post( $render_post_id, true );
+}
+
+// --- Test 7: REST ?content_format=markdown ---
+$rest_post_id = wp_insert_post(
+	array(
+		'post_type'    => 'post',
+		'post_status'  => 'publish',
+		'post_title'   => 'REST Smoke',
+		'post_content' => '<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">REST</h1><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Body.</p><!-- /wp:paragraph -->',
+	),
+	true
+);
+if ( is_wp_error( $rest_post_id ) ) {
+	assert_true( 'rest-test post inserted', false, $rest_post_id->get_error_message() );
+} else {
+	$req = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $rest_post_id );
+	$req->set_param( 'content_format', 'markdown' );
+	$resp = rest_do_request( $req );
+	$data = $resp->get_data();
+
+	assert_true(
+		'REST adds content.formatted when content_format=markdown',
+		isset( $data['content']['formatted'] ) && '' !== $data['content']['formatted'],
+		isset( $data['content']['formatted'] ) ? 'got: ' . substr( $data['content']['formatted'], 0, 200 ) : 'missing'
+	);
+	assert_true(
+		'REST sets content.format = markdown',
+		( $data['content']['format'] ?? '' ) === 'markdown'
+	);
+	assert_true(
+		'REST leaves content.rendered intact',
+		isset( $data['content']['rendered'] ) && false !== strpos( $data['content']['rendered'], '<h1' )
+	);
+
+	$req2  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $rest_post_id );
+	$resp2 = rest_do_request( $req2 );
+	$data2 = $resp2->get_data();
+
+	assert_true(
+		'REST does NOT add content.formatted when no query param given',
+		! isset( $data2['content']['formatted'] )
+	);
+
+	wp_delete_post( $rest_post_id, true );
 }
 
 // --- Summary ---


### PR DESCRIPTION
## Summary

Phase 2 ships the read direction. Both adapters now have `from_blocks()`, plus a programmatic `bfb_render_post()` helper and a `?content_format=<slug>` REST query parameter. Lifts v0.1.0 → v0.2.0.

| Direction          | Underlying tool                                              |
|--------------------|--------------------------------------------------------------|
| HTML → Blocks      | `chubes4/html-to-blocks-converter`                           |
| Blocks → HTML      | `do_blocks()` (WordPress core)                               |
| Markdown → HTML    | `league/commonmark` (vendor-prefixed)                        |
| Markdown → Blocks  | composition: Markdown → HTML → Blocks                        |
| **Blocks → Markdown** | **`do_blocks()` + `league/html-to-markdown` (vendor-prefixed)** |
| **HTML → Markdown**   | **composition: HTML → Blocks → Markdown**                  |

## What's new

### Adapters
- `BFB_HTML_Adapter::from_blocks()` — renders via `render_block()` so dynamic blocks resolve to their server-side HTML output.
- `BFB_Markdown_Adapter::from_blocks()` — `do_blocks()` → `league/html-to-markdown` (under `BlockFormatBridge\Vendor\League\HTMLToMarkdown`).

### Public API
- `bfb_render_post( $post, $format ): string` — reads `post_content` and routes through `bfb_convert()` with `'blocks'` as the source.

### REST
- `GET /wp/v2/{post_type}/{id}?content_format=<slug>` adds sibling `content.formatted` + `content.format` fields on responses. `content.rendered` and `content.raw` stay untouched.
- Filter: `bfb_rest_supported_post_types`.

### Conversion filters
- `bfb_html_to_markdown_options` — mirrors `roots/post-content-to-markdown`'s `converter_options`.
- `bfb_markdown_output` — mirrors `roots/post-content-to-markdown`'s `markdown_output`.

### Build pipeline
- `scoper.inc.php` now also scopes `league/html-to-markdown` (no transitive composer deps). The autoloader generator picks it up automatically — no other build changes.

## Open-question resolutions

**Q3 (read-as REST surface):** `?content_format=<slug>` + sibling `content.formatted` field, NOT replacing `content.rendered`. Full HTTP content negotiation (`Accept: text/markdown`, `.md` URL suffix, q-values, 406 Not Acceptable) intentionally deferred to `roots/post-content-to-markdown` when active.

**Q2 (roots/post-content-to-markdown vs league/html-to-markdown direct):** depend on `league/html-to-markdown` directly. BFB already vendor-prefixes its dep graph; depending on `roots/post-content-to-markdown` would pull a second php-scoped copy. Library-level dep matches the Phase 1 shape (compose libraries, not plugins, when the library is the right unit). Roots' plugin remains a complementary install — it owns Accept-header content negotiation; BFB owns the programmatic adapter API.

## Verification

17/17 smoke checks pass on `intelligence-chubes4`, run from BOTH the dev symlink AND the BUILT distribution path (no `vendor/`, only `vendor_prefixed/`):

```
== block-format-bridge smoke test ==
  ✓ Markdown → blocks returns non-empty serialised markup
  ✓ Markdown → blocks contains a heading block
  ✓ Markdown → blocks contains a paragraph block
  ✓ HTML → blocks returns non-empty serialised markup
  ✓ HTML → blocks contains a heading block
  ✓ wp_insert_post stored block markup (filter-driven markdown route)
  ✓ markdown adapter resolves
  ✓ markdown from_blocks() emits ATX heading
  ✓ markdown from_blocks() preserves bold (**) and italic (*)
  ✓ html from_blocks() renders heading
  ✓ html from_blocks() does NOT contain block-comment markup (it is rendered HTML)
  ✓ bfb_render_post(html) returns rendered HTML (no block-comments)
  ✓ bfb_render_post(markdown) returns clean GFM
  ✓ REST adds content.formatted when content_format=markdown
  ✓ REST sets content.format = markdown
  ✓ REST leaves content.rendered intact
  ✓ REST does NOT add content.formatted when no query param given
```

Edge cases verified by hand: empty `post_content`, missing post id, unknown format slug — all return empty strings without fatals.

## Known round-trip limitations (documented in README)

- **Code-fence language hint lost** — `` ```php `` becomes `` ``` `` after Blocks → Markdown. The block carries `className: language-php` but `league/html-to-markdown` doesn't reconstruct the fence info string.
- **Tables collapse through league/html-to-markdown's default converter** — `<wp:table>` blocks render to HTML tables that get flattened.

Both are upstream library limits, not BFB bugs. v0.3.0 may swap in custom converters or `roots/post-content-to-markdown` delegation for the Markdown read side.

## Out of scope (Phase 3)

- Migrating Intelligence's wiki abilities to use `bfb_default_format` and dropping `Intelligence_Wiki_Content::markdown_to_html()` / `to_markdown()` (~150 line deletion).
- Closing/commenting on DM #1165.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the read-side adapter implementations, REST integration, scoper config update, README rewrite, and extended smoke test against the Phase 2 design doc. Chris reviewed and verified end-to-end via WP-CLI smoke tests on both the dev symlink and the BUILT distribution path on `intelligence-chubes4`.