### PR TITLE
feat(markdown): table support, code-fence cleanup, input filter — v0.3.0

### DIFF
--- a/block-format-bridge.php
+++ b/block-format-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Block Format Bridge
  * Plugin URI: https://github.com/chubes4/block-format-bridge
  * Description: Orchestrates bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API. Composes existing plugins/libraries — owns no parsing logic of its own.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Author: Chris Huber
  * Author URI: https://chubes.net
  * License: GPL-2.0-or-later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'BFB_VERSION', '0.2.0' );
+define( 'BFB_VERSION', '0.3.0' );
 define( 'BFB_PATH', plugin_dir_path( __FILE__ ) );
 define( 'BFB_FILE', __FILE__ );
 define( 'BFB_MIN_WP', '6.4' );

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -41,6 +41,19 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 			return array();
 		}
 
+		/**
+		 * Pre-process raw markdown before it reaches CommonMark.
+		 *
+		 * Useful for opinionated transformations that the bridge should
+		 * not encode itself (e.g. linkifying bare domain URLs to
+		 * `https://`, normalising smart quotes, etc.).
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param string $markdown Markdown source.
+		 */
+		$content = (string) apply_filters( 'bfb_markdown_input', $content );
+
 		$html = $this->markdown_to_html( $content );
 		if ( '' === $html ) {
 			return array();
@@ -75,8 +88,7 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 		}
 
 		// Render dynamic blocks through their server-side callbacks, then
-		// serialise. We pass the rendered HTML straight to the html-to-md
-		// converter so dynamic content shows up as resolved HTML.
+		// pass the rendered HTML to the html-to-md converter.
 		$html = '';
 		foreach ( $blocks as $block ) {
 			$html .= render_block( $block );
@@ -86,7 +98,22 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 			return '';
 		}
 
+		// Flatten <pre> blocks so syntax-highlighter wrapper markup
+		// (Prism, highlight.js, etc.) doesn't leak into the code fence.
+		// Mirrors the approach in roots/post-content-to-markdown.
+		$html = (string) preg_replace_callback(
+			'#<pre\b[^>]*>(.*?)</pre>#is',
+			static function ( array $match ): string {
+				$inner = html_entity_decode( strip_tags( $match[1] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				return '<pre><code>' . htmlspecialchars( $inner, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) . '</code></pre>';
+			},
+			$html
+		);
+
 		$markdown = $this->html_to_markdown( $html );
+
+		// Collapse runs of 3+ newlines (league emits them on nested lists).
+		$markdown = trim( (string) preg_replace( "/\n{3,}/", "\n\n", $markdown ) );
 
 		/**
 		 * Filters the markdown output produced by the markdown adapter.
@@ -204,10 +231,66 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 
 		try {
 			$converter = new $class( $options );
+
+			// Register the league/html-to-markdown TableConverter — it
+			// ships with the library but isn't enabled by default. Without
+			// it, <table> blocks collapse to inline text.
+			$this->register_table_converter( $converter );
+
+			/**
+			 * Fires after the html-to-markdown converter has been built but
+			 * before it runs. Allows consumers to register additional
+			 * league/html-to-markdown Converter implementations on the
+			 * converter's environment.
+			 *
+			 * The converter is the prefixed `HtmlConverter` instance;
+			 * consumers should pull `getEnvironment()` and call
+			 * `addConverter()` with prefixed Converter classes if they
+			 * ship under the same namespace.
+			 *
+			 * @since 0.3.0
+			 *
+			 * @param object $converter HtmlConverter instance.
+			 */
+			do_action( 'bfb_html_to_markdown_converter', $converter );
+
 			return (string) $converter->convert( $html );
 		} catch ( \Throwable $e ) {
 			error_log( sprintf( '[Block Format Bridge] HTML→markdown conversion failed: %s', $e->getMessage() ) );
 			return '';
+		}
+	}
+
+	/**
+	 * Register league/html-to-markdown's TableConverter on the converter's
+	 * environment.
+	 *
+	 * Picks the prefixed class first, then unprefixed dev-mode fallback.
+	 * Silent no-op if neither class is present (older library versions).
+	 *
+	 * @param object $converter HtmlConverter instance.
+	 * @return void
+	 */
+	protected function register_table_converter( $converter ): void {
+		$prefixed   = '\\BlockFormatBridge\\Vendor\\League\\HTMLToMarkdown\\Converter\\TableConverter';
+		$unprefixed = '\\League\\HTMLToMarkdown\\Converter\\TableConverter';
+
+		$class = null;
+		if ( class_exists( $prefixed ) ) {
+			$class = $prefixed;
+		} elseif ( class_exists( $unprefixed ) ) {
+			$class = $unprefixed;
+		}
+
+		if ( null === $class ) {
+			return;
+		}
+
+		try {
+			$env = $converter->getEnvironment();
+			$env->addConverter( new $class() );
+		} catch ( \Throwable $e ) {
+			error_log( sprintf( '[Block Format Bridge] TableConverter registration failed: %s', $e->getMessage() ) );
 		}
 	}
 }

--- a/tools/smoke-test.php
+++ b/tools/smoke-test.php
@@ -193,7 +193,29 @@ if ( is_wp_error( $render_post_id ) ) {
 	wp_delete_post( $render_post_id, true );
 }
 
-// --- Test 7: REST ?content_format=markdown ---
+// --- Test 7a: TableConverter round-trips GFM tables ---
+$table_md       = "| col1 | col2 |\n| --- | --- |\n| a | b |\n";
+$table_round    = bfb_convert( bfb_convert( $table_md, 'markdown', 'blocks' ), 'blocks', 'markdown' );
+assert_true(
+	'Tables round-trip through markdown→blocks→markdown',
+	false !== strpos( $table_round, '| col1 | col2 |' ),
+	'got: ' . $table_round
+);
+
+// --- Test 7b: bfb_markdown_input filter pre-processes raw markdown ---
+$linkify = static function ( string $md ): string {
+	return preg_replace( '#(?<![:/])(?<![a-zA-Z0-9])(example\.com)#', 'https://$1', $md );
+};
+add_filter( 'bfb_markdown_input', $linkify );
+$linkified_blocks = bfb_convert( 'See example.com for details.', 'markdown', 'blocks' );
+remove_filter( 'bfb_markdown_input', $linkify );
+assert_true(
+	'bfb_markdown_input filter linkified bare URL',
+	false !== strpos( $linkified_blocks, 'href="https://example.com"' ),
+	'got: ' . substr( $linkified_blocks, 0, 200 )
+);
+
+// --- Test 8: REST ?content_format=markdown ---
 $rest_post_id = wp_insert_post(
 	array(
 		'post_type'    => 'post',


### PR DESCRIPTION
## Summary

Closes the parity gap between BFB v0.2.0 and Intelligence's hand-rolled `Intelligence_Wiki_Content::to_markdown()`, so the upcoming Phase 3 Intelligence migration doesn't regress wiki output.

## Changes to `BFB_Markdown_Adapter::from_blocks()`

1. **TableConverter registered** on the html-to-markdown converter environment. league/html-to-markdown ships the converter but doesn't enable it by default; without it, `<table>` blocks collapse to inline text. New `bfb_html_to_markdown_converter` action hook lets consumers register additional Converter implementations.
2. **`<pre>`-block flattener** strips syntax-highlighter wrapper markup (Prism, highlight.js, token spans) before converting, so code fences contain just the source. Mirrors `roots/post-content-to-markdown` and Intelligence's existing helper.
3. **Newline normalisation** collapses runs of 3+ newlines to 2 (league emits them on nested lists).

## Changes to `BFB_Markdown_Adapter::to_blocks()`

4. **New `bfb_markdown_input` filter** pre-processes raw markdown before CommonMark parses it. Lets consumers run opinionated transformations (bare-URL linkification, smart-quote normalisation) without the bridge encoding domain knowledge. Intelligence will use this for its a8c.com / wordpress.com bare-URL handling.

## Verification

19/19 smoke checks pass on intelligence-chubes4. New cases:

```
✓ Tables round-trip through markdown→blocks→markdown
✓ bfb_markdown_input filter linkified bare URL
```

All Phase 1 + Phase 2 checks remain green.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the TableConverter + pre-processor changes after auditing Intelligence's `Intelligence_Wiki_Content` helper. Chris reviewed and verified end-to-end via the smoke test on `intelligence-chubes4`.