### PR TITLE
feat: support dual-mode package loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Block Format Bridge
 
-A WordPress plugin that orchestrates bidirectional content format conversion (HTML, Blocks, Markdown) through a unified
-adapter API.
+A WordPress plugin **and Composer package** that orchestrates bidirectional content format conversion (HTML, Blocks,
+Markdown) through a unified adapter API.
 
 The bridge owns no parsing logic of its own. It composes existing libraries — [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter),
 WordPress core's `serialize_blocks()` / `do_blocks()`, [`league/commonmark`](https://github.com/thephpleague/commonmark),
 and [`league/html-to-markdown`](https://github.com/thephpleague/html-to-markdown) — behind one contract. New formats
 become available by registering a new adapter; the bridge core never grows.
 
-> **Status (v0.2.0):** Phase 2 read side ships. Both write (HTML/Markdown → Blocks) and read (Blocks → HTML/Markdown)
-> directions work end-to-end, plus a `?content_format=` REST query param.
+> **Status:** Both write (HTML/Markdown → Blocks) and read (Blocks → HTML/Markdown) directions work end-to-end, plus
+> a `?content_format=` REST query param.
 
 ## What it does
 
@@ -51,12 +51,19 @@ return    $to_adapter->from_blocks( $blocks );
 
 ## Install
 
-The plugin is distributed via [wp-packages.org](https://wp-packages.org). Add it to a Composer-managed WordPress site:
+Install it as a standalone plugin, or bundle it as a Composer package.
+
+The package is distributed via [wp-packages.org](https://wp-packages.org). Add it to a Composer-managed WordPress site:
 
 ```bash
 composer config repositories.wp-packages composer https://wp-packages.org
 composer require chubes4/block-format-bridge
 ```
+
+Composer autoloads `library.php`, which registers the bridge through an Action-Scheduler-style version registry.
+Package mode loads the full bridge service: adapters, `bfb_convert()`, `bfb_render_post()`, the write-side
+`wp_insert_post_data` integration, and the REST `?content_format=` integration. If multiple plugins bundle BFB while
+the standalone plugin is also active, the registry initializes the highest loaded version once.
 
 For full HTML → Blocks support you also need [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter)
 installed and active alongside the bridge. The bridge fails soft (returns a `core/freeform` block) when it isn't

--- a/block-format-bridge.php
+++ b/block-format-bridge.php
@@ -19,11 +19,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'BFB_VERSION', '0.3.0' );
-define( 'BFB_PATH', plugin_dir_path( __FILE__ ) );
-define( 'BFB_FILE', __FILE__ );
-define( 'BFB_MIN_WP', '6.4' );
-define( 'BFB_MIN_PHP', '8.1' );
+if ( ! defined( 'BFB_PLUGIN_PATH' ) ) {
+	define( 'BFB_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'BFB_MIN_WP' ) ) {
+	define( 'BFB_MIN_WP', '6.4' );
+}
+if ( ! defined( 'BFB_MIN_PHP' ) ) {
+	define( 'BFB_MIN_PHP', '8.1' );
+}
 
 if ( version_compare( get_bloginfo( 'version' ), BFB_MIN_WP, '<' ) ) {
 	add_action(
@@ -57,39 +61,4 @@ if ( version_compare( PHP_VERSION, BFB_MIN_PHP, '<' ) ) {
 	return;
 }
 
-// Load the prefixed CommonMark autoloader if present (built distribution),
-// otherwise fall back to the dev-mode unscoped autoloader.
-if ( file_exists( BFB_PATH . 'vendor_prefixed/autoload.php' ) ) {
-	require_once BFB_PATH . 'vendor_prefixed/autoload.php';
-} elseif ( file_exists( BFB_PATH . 'vendor/autoload.php' ) ) {
-	require_once BFB_PATH . 'vendor/autoload.php';
-}
-
-require_once BFB_PATH . 'includes/interface-bfb-format-adapter.php';
-require_once BFB_PATH . 'includes/class-bfb-adapter-registry.php';
-require_once BFB_PATH . 'includes/class-bfb-html-adapter.php';
-require_once BFB_PATH . 'includes/class-bfb-markdown-adapter.php';
-require_once BFB_PATH . 'includes/api.php';
-require_once BFB_PATH . 'includes/hooks.php';
-require_once BFB_PATH . 'includes/rest.php';
-
-/**
- * Registers the built-in adapters at plugin load.
- *
- * Other plugins can register additional adapters by hooking into
- * the `bfb_register_format_adapter` filter, which fires for each
- * lookup in the registry.
- */
-function bfb_bootstrap() {
-	BFB_Adapter_Registry::register( new BFB_HTML_Adapter() );
-	BFB_Adapter_Registry::register( new BFB_Markdown_Adapter() );
-
-	/**
-	 * Fires after the built-in adapters are registered, so consumers
-	 * can register additional format adapters.
-	 *
-	 * @since 0.1.0
-	 */
-	do_action( 'bfb_adapters_registered' );
-}
-add_action( 'plugins_loaded', 'bfb_bootstrap', 5 );
+require_once BFB_PLUGIN_PATH . 'library.php';

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
     "scripts": {
         "build": "./build.sh"
     },
+    "autoload": {
+        "files": [
+            "library.php"
+        ]
+    },
     "require": {
         "php": "^8.1",
         "league/commonmark": "^2.5",

--- a/homeboy.json
+++ b/homeboy.json
@@ -9,6 +9,10 @@
     {
       "file": "block-format-bridge.php",
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "library.php",
+      "pattern": "(?m)^\\$bfb_library_version\\s*=\\s*'([0-9.]+)'"
     }
   ]
 }

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Runtime bootstrap for the winning bridge version.
+ *
+ * Loaded by `library.php` after the version registry selects this copy.
+ * Registers built-in adapters and installs the bridge's write/read hooks.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'bfb_bootstrap' ) ) {
+	/**
+	 * Registers the built-in adapters exactly once.
+	 *
+	 * Other plugins can register additional adapters by hooking into
+	 * the `bfb_register_format_adapter` filter, which fires for each
+	 * lookup in the registry.
+	 *
+	 * @return void
+	 */
+	function bfb_bootstrap(): void {
+		static $bootstrapped = false;
+		if ( $bootstrapped ) {
+			return;
+		}
+		$bootstrapped = true;
+
+		BFB_Adapter_Registry::register( new BFB_HTML_Adapter() );
+		BFB_Adapter_Registry::register( new BFB_Markdown_Adapter() );
+
+		/**
+		 * Fires after the built-in adapters are registered, so consumers
+		 * can register additional format adapters.
+		 *
+		 * @since 0.1.0
+		 */
+		do_action( 'bfb_adapters_registered' );
+	}
+}
+
+bfb_bootstrap();

--- a/includes/class-bfb-versions.php
+++ b/includes/class-bfb-versions.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Version registry for dual-mode package/plugin loading.
+ *
+ * Multiple plugins may bundle block-format-bridge as a Composer package
+ * while the standalone plugin is also installed. Every copy registers
+ * its version + initializer; on `plugins_loaded:1`, the latest version
+ * wins and only that initializer loads the bridge, registers adapters,
+ * and installs hooks.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'BFB_Versions', false ) ) {
+	/**
+	 * Tracks loaded block-format-bridge versions and initializes one.
+	 */
+	class BFB_Versions {
+
+		/**
+		 * Singleton instance.
+		 *
+		 * @var self|null
+		 */
+		private static $instance = null;
+
+		/**
+		 * Version => initializer callback.
+		 *
+		 * @var array<string, callable>
+		 */
+		private $versions = array();
+
+		/**
+		 * Whether the winning version has initialized.
+		 *
+		 * @var bool
+		 */
+		private $initialized = false;
+
+		/**
+		 * Whether the plugins_loaded hook has been registered.
+		 *
+		 * @var bool
+		 */
+		private static $hooked = false;
+
+		/**
+		 * Get singleton.
+		 *
+		 * @return self
+		 */
+		public static function instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Ensure latest-version initialization runs once per request.
+		 *
+		 * @return void
+		 */
+		public static function register_hooks(): void {
+			if ( self::$hooked || ! function_exists( 'add_action' ) ) {
+				return;
+			}
+
+			add_action( 'plugins_loaded', array( __CLASS__, 'initialize_latest_version' ), 1 );
+			self::$hooked = true;
+		}
+
+		/**
+		 * Register one copy of the bridge.
+		 *
+		 * @param string   $version     Semantic version string.
+		 * @param callable $initializer Initializer that loads this copy's files.
+		 * @return void
+		 */
+		public function register( string $version, callable $initializer ): void {
+			if ( $this->initialized ) {
+				return;
+			}
+
+			$this->versions[ $version ] = $initializer;
+		}
+
+		/**
+		 * Initialize the highest registered version.
+		 *
+		 * @return void
+		 */
+		public static function initialize_latest_version(): void {
+			self::instance()->initialize_latest();
+		}
+
+		/**
+		 * Initialize the highest registered version.
+		 *
+		 * @return void
+		 */
+		public function initialize_latest(): void {
+			if ( $this->initialized || empty( $this->versions ) ) {
+				return;
+			}
+
+			uksort( $this->versions, 'version_compare' );
+			$version     = array_key_last( $this->versions );
+			$initializer = $this->versions[ $version ];
+
+			$this->initialized = true;
+			$initializer();
+
+			/**
+			 * Fires after the winning block-format-bridge version loads.
+			 *
+			 * @param string $version Loaded version.
+			 */
+			do_action( 'bfb_loaded', $version );
+		}
+	}
+}

--- a/library.php
+++ b/library.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Library entry point for block-format-bridge.
+ *
+ * Composer consumers autoload this file (`autoload.files`) to make the
+ * bridge APIs and hooks available without installing the standalone
+ * plugin. The standalone plugin also loads this file.
+ *
+ * Multiple bundled copies can coexist: each registers its version and
+ * initializer, then `BFB_Versions` initializes the highest registered
+ * version on `plugins_loaded:1`.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$bfb_library_path    = __DIR__;
+$bfb_library_version = '0.3.0';
+
+if ( ! class_exists( 'BFB_Versions', false ) ) {
+	require_once $bfb_library_path . '/includes/class-bfb-versions.php';
+}
+
+$bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_version ): void {
+	if ( ! defined( 'BFB_VERSION' ) ) {
+		define( 'BFB_VERSION', $bfb_library_version );
+	}
+	if ( ! defined( 'BFB_PATH' ) ) {
+		define( 'BFB_PATH', trailingslashit( $bfb_library_path ) );
+	}
+	if ( ! defined( 'BFB_FILE' ) ) {
+		$plugin_file = $bfb_library_path . '/block-format-bridge.php';
+		define( 'BFB_FILE', file_exists( $plugin_file ) ? $plugin_file : __FILE__ );
+	}
+	if ( ! defined( 'BFB_MIN_WP' ) ) {
+		define( 'BFB_MIN_WP', '6.4' );
+	}
+	if ( ! defined( 'BFB_MIN_PHP' ) ) {
+		define( 'BFB_MIN_PHP', '8.1' );
+	}
+
+	// Load the prefixed dependency autoloader if present (built
+	// distribution), otherwise fall back to dev-mode Composer autoload.
+	if ( file_exists( $bfb_library_path . '/vendor_prefixed/autoload.php' ) ) {
+		require_once $bfb_library_path . '/vendor_prefixed/autoload.php';
+	} elseif ( file_exists( $bfb_library_path . '/vendor/autoload.php' ) ) {
+		require_once $bfb_library_path . '/vendor/autoload.php';
+	}
+
+	require_once $bfb_library_path . '/includes/interface-bfb-format-adapter.php';
+	require_once $bfb_library_path . '/includes/class-bfb-adapter-registry.php';
+	require_once $bfb_library_path . '/includes/class-bfb-html-adapter.php';
+	require_once $bfb_library_path . '/includes/class-bfb-markdown-adapter.php';
+	require_once $bfb_library_path . '/includes/api.php';
+	require_once $bfb_library_path . '/includes/hooks.php';
+	require_once $bfb_library_path . '/includes/rest.php';
+	require_once $bfb_library_path . '/includes/bootstrap.php';
+};
+
+$bfb_register = static function () use ( $bfb_library_version, $bfb_initializer ): void {
+	BFB_Versions::instance()->register( $bfb_library_version, $bfb_initializer );
+};
+
+BFB_Versions::register_hooks();
+
+if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) ) {
+	$bfb_register();
+	BFB_Versions::initialize_latest_version();
+} else {
+	add_action( 'plugins_loaded', $bfb_register, 0 );
+}


### PR DESCRIPTION
## Summary

Refactors `block-format-bridge` into an Action-Scheduler-style package-and-plugin service.

## What changes

### Package mode

- Adds `library.php` as the Composer autoload entrypoint.
- Adds `BFB_Versions` registry (`includes/class-bfb-versions.php`).
- Every loaded copy registers its version + initializer; on `plugins_loaded:1`, the registry initializes the highest version exactly once.
- The winning initializer loads:
  - `vendor_prefixed/autoload.php` (built distribution) or `vendor/autoload.php` (dev mode)
  - adapter contract + registry
  - HTML + Markdown adapters
  - `bfb_convert()` / `bfb_render_post()` public API
  - write-side hook (`wp_insert_post_data`)
  - REST `?content_format=` integration
  - built-in adapter bootstrap

Unlike `html-to-blocks-converter`'s package mode, BFB package mode intentionally loads the full service, including hooks. BFB owns the `wp_insert_post_data` and REST `content_format` integration.

### Plugin mode

- `block-format-bridge.php` becomes a tiny plugin shell: runtime requirement notices, then `require library.php`.
- Adapter registration moved to `includes/bootstrap.php` and is idempotent.

### Composer / release tooling

- `composer.json` now autoloads `library.php`.
- `homeboy.json` includes `library.php`'s plain version string as a version target so release automation owns it.
- No manual version bump in this PR.

## Verification

Tested on `intelligence-chubes4`.

**Plugin mode**

- `wp plugin deactivate block-format-bridge && wp plugin activate block-format-bridge` succeeds.
- 19/19 BFB smoke checks pass.

**Package mode**

With the plugin skipped, including `library.php` twice:

```
before bfb_convert: no
after bfb_convert: yes
after bfb_render_post: yes
adapter slugs: html,markdown
insert hook registered: yes
<!-- wp:heading {"level":1} -->...<!-- /wp:paragraph -->
```

**Package-mode write hook**

With the plugin skipped and `library.php` loaded manually, `wp_insert_post()` with `_bfb_format=markdown` stores serialized block markup.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the BFB version registry, package entrypoint, plugin shell reduction, Composer autoload metadata, README update, and WP-CLI plugin/package-mode smoke verification. Chris selected the shared `BlockFormatBridge\Vendor` namespace strategy.