### PR TITLE
feat: bundle html-to-blocks-converter as package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Package mode loads the full bridge service: adapters, `bfb_convert()`, `bfb_rend
 `wp_insert_post_data` integration, and the REST `?content_format=` integration. If multiple plugins bundle BFB while
 the standalone plugin is also active, the registry initializes the highest loaded version once.
 
-For full HTML → Blocks support you also need [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter)
-installed and active alongside the bridge. The bridge fails soft (returns a `core/freeform` block) when it isn't
-present, but you'll get much better block fidelity with it active.
+HTML → Blocks support is bundled via [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter)
+as a Composer package. You do **not** need the standalone html-to-blocks-converter plugin active for BFB to convert
+HTML/Markdown into block markup.
 
 ### Build from source
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         ]
     },
     "require": {
+        "chubes4/html-to-blocks-converter": "dev-main",
         "php": "^8.1",
         "league/commonmark": "^2.5",
         "league/html-to-markdown": "^5.1"
@@ -32,11 +33,12 @@
         {
             "type": "composer",
             "url": "https://wp-packages.org"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/chubes4/html-to-blocks-converter"
         }
     ],
-    "suggest": {
-        "chubes4/html-to-blocks-converter": "Required at runtime for HTML → Blocks conversion. Install as a separate WordPress plugin via wp-packages.org."
-    },
     "config": {
         "allow-plugins": {
             "composer/installers": true

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -2,11 +2,10 @@
 /**
  * HTML format adapter.
  *
- * `to_blocks()` delegates to `html_to_blocks_raw_handler()` from the
- * `chubes4/html-to-blocks-converter` plugin, which must be installed
- * and active for HTML conversion to work. If the function is missing,
- * the adapter falls back to a `core/freeform` block so the system
- * fails soft rather than hard.
+ * `to_blocks()` delegates to `html_to_blocks_raw_handler()` from
+ * `chubes4/html-to-blocks-converter`, which BFB bundles as a Composer
+ * dependency. Built distributions call the vendor-prefixed function;
+ * dev-mode/plugin installs can still call the unprefixed global.
  *
  * `from_blocks()` renders blocks through `do_blocks()` so dynamic
  * blocks resolve to their server-side HTML output.
@@ -44,13 +43,20 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 			return is_array( $parsed ) ? $parsed : array();
 		}
 
+		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
+			$blocks = \BlockFormatBridge\Vendor\html_to_blocks_raw_handler( array( 'HTML' => $content ) );
+			return is_array( $blocks ) ? $blocks : array();
+		}
+
 		if ( function_exists( 'html_to_blocks_raw_handler' ) ) {
 			$blocks = html_to_blocks_raw_handler( array( 'HTML' => $content ) );
 			return is_array( $blocks ) ? $blocks : array();
 		}
 
-		// html-to-blocks-converter is not installed; fail soft by
-		// returning a single freeform block carrying the raw HTML.
+		// Should only happen in a broken build: BFB requires
+		// chubes4/html-to-blocks-converter and built distributions ship
+		// the prefixed function above.
+		error_log( '[Block Format Bridge] html-to-blocks-converter is unavailable; falling back to a freeform block.' );
 		return array(
 			array(
 				'blockName'    => 'core/freeform',

--- a/library.php
+++ b/library.php
@@ -14,17 +14,39 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	return;
 }
 
 $bfb_library_path    = __DIR__;
 $bfb_library_version = '0.3.0';
+
+// Load Composer/php-scoper dependencies as soon as the bridge package is
+// included, not when the winning BFB version initializes on
+// `plugins_loaded:1`. Some dependencies (notably html-to-blocks-converter)
+// register their own Action-Scheduler-style version callbacks at
+// `plugins_loaded:0`; loading them from BFB's initializer would be too late.
+if ( file_exists( $bfb_library_path . '/vendor_prefixed/autoload.php' ) ) {
+	require_once $bfb_library_path . '/vendor_prefixed/autoload.php';
+} elseif ( file_exists( $bfb_library_path . '/vendor/autoload.php' ) ) {
+	require_once $bfb_library_path . '/vendor/autoload.php';
+}
 
 if ( ! class_exists( 'BFB_Versions', false ) ) {
 	require_once $bfb_library_path . '/includes/class-bfb-versions.php';
 }
 
 $bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_version ): void {
+	// BFB bundles html-to-blocks-converter as a package. Its library
+	// registers with its own version registry when Composer autoload runs;
+	// initialize that registry now so BFB's HTML adapter can call the
+	// raw-handler during this same request even when the standalone h2bc
+	// plugin is inactive.
+	if ( class_exists( '\BlockFormatBridge\Vendor\HTML_To_Blocks_Versions' ) ) {
+		\BlockFormatBridge\Vendor\HTML_To_Blocks_Versions::initialize_latest_version();
+	} elseif ( class_exists( 'HTML_To_Blocks_Versions' ) ) {
+		HTML_To_Blocks_Versions::initialize_latest_version();
+	}
+
 	if ( ! defined( 'BFB_VERSION' ) ) {
 		define( 'BFB_VERSION', $bfb_library_version );
 	}
@@ -40,14 +62,6 @@ $bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_vers
 	}
 	if ( ! defined( 'BFB_MIN_PHP' ) ) {
 		define( 'BFB_MIN_PHP', '8.1' );
-	}
-
-	// Load the prefixed dependency autoloader if present (built
-	// distribution), otherwise fall back to dev-mode Composer autoload.
-	if ( file_exists( $bfb_library_path . '/vendor_prefixed/autoload.php' ) ) {
-		require_once $bfb_library_path . '/vendor_prefixed/autoload.php';
-	} elseif ( file_exists( $bfb_library_path . '/vendor/autoload.php' ) ) {
-		require_once $bfb_library_path . '/vendor/autoload.php';
 	}
 
 	require_once $bfb_library_path . '/includes/interface-bfb-format-adapter.php';

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -17,12 +17,23 @@ use Isolated\Symfony\Component\Finder\Finder;
 return [
 	'prefix'     => 'BlockFormatBridge\\Vendor',
 	'output-dir' => 'vendor_prefixed',
+	'exclude-classes' => [
+		'WP_Block_Type',
+		'WP_Block_Type_Registry',
+		'WP_HTML_Processor',
+		'WP_HTML_Tag_Processor',
+		'WP_Post',
+		'WP_REST_Request',
+		'WP_REST_Response',
+	],
 	'finders'    => [
 		Finder::create()
 			->files()
 			->name( [ '*.php', 'composer.json', 'LICENSE*' ] )
 			->in(
 				[
+					// chubes4/html-to-blocks-converter (HTML → Blocks).
+					'vendor/chubes4/html-to-blocks-converter',
 					// league/commonmark + transitive deps (Markdown → HTML).
 					'vendor/league/commonmark',
 					'vendor/league/config',


### PR DESCRIPTION
## Summary

BFB now composer-requires `chubes4/html-to-blocks-converter` and ships it in the built distribution, so HTML → Blocks works without the standalone html-to-blocks-converter plugin being active.

Depends on the dual-mode h2bc work merged in:
- chubes4/html-to-blocks-converter#8
- chubes4/html-to-blocks-converter#9

## Changes

### Composer

- Adds `chubes4/html-to-blocks-converter: dev-main` as a required package.
- Adds the h2bc VCS repository until the package is available through the normal wp-packages flow.
- Removes the old `suggest` entry that told users to install h2bc separately.

### Build/runtime

- `scoper.inc.php` includes `vendor/chubes4/html-to-blocks-converter` in `vendor_prefixed/`.
- WordPress core classes used by h2bc are excluded from php-scoper:
  - `WP_HTML_Processor`
  - `WP_HTML_Tag_Processor`
  - `WP_Block_Type`
  - `WP_Block_Type_Registry`
  - REST/Post DTO classes used in hook docs/types
- `library.php` loads dependency autoloaders at package include time (before `plugins_loaded`) so h2bc's own version registry can register.
- BFB's initializer explicitly initializes h2bc's version registry before the HTML adapter can run.
- `BFB_HTML_Adapter` prefers the bundled scoped raw handler:
  - `BlockFormatBridge\Vendor\html_to_blocks_raw_handler()`
  - then falls back to global `html_to_blocks_raw_handler()` in dev/plugin setups.

### Docs

README now says the standalone html-to-blocks-converter plugin is no longer required for BFB; HTML → Blocks is bundled.

## Verification

Tested on `intelligence-chubes4` with the standalone html-to-blocks-converter plugin inactive.

- `composer build` succeeds and produces `vendor_prefixed/autoload.php`.
- 19/19 BFB smoke checks pass.
- Package-mode include of BFB library:
  - exposes the prefixed h2bc raw handler,
  - keeps the global h2bc raw handler absent,
  - converts HTML to block markup,
  - and `wp_insert_post()` with `_bfb_format=markdown` stores serialized block markup.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Wiring h2bc as a BFB Composer dependency, updating php-scoper exclusions, resolving BFB/h2bc version-registry boot order, and verifying bundled conversion on `intelligence-chubes4`.