### PR TITLE
revert: keep HTML insert automation in h2bc

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -8,10 +8,10 @@
  *     wp_insert_post_data.
  *   - `bfb_default_format` filter declares which format a CPT writes
  *     in by default. Defaults to 'html'.
- *   - Runs at priority 5 — BEFORE the standalone html-to-blocks-converter
- *     plugin (which fires at priority 10) — so every supported format is
- *     normalised to block markup first, then html-to-blocks-converter sees
- *     nothing to do (its `<!-- wp:` short-circuit triggers).
+ *   - Runs at priority 5 — BEFORE html-to-blocks-converter (which
+ *     fires at priority 10) — so non-HTML formats are normalised to
+ *     block markup first, then html-to-blocks-converter sees nothing
+ *     to do (its `<!-- wp:` short-circuit triggers).
  *
  * @package BlockFormatBridge
  */
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Resolution order:
  *   1. `_bfb_format` key on $postarr (per-call override)
  *   2. `bfb_default_format` filter result for the post type
- *   3. 'html' (default source format)
+ *   3. 'html' (default — no conversion needed)
  *
  * @param array $data    Sanitized post data destined for wp_posts.
  * @param array $postarr Original post-insert array.
@@ -45,7 +45,7 @@ function bfb_resolve_format_for_insert( array $data, array $postarr ): string {
 	 *
 	 * Return one of the registered adapter slugs ('html', 'markdown',
 	 * or any third-party registered slug). Return 'html' (or skip the
-	 * filter) for the default HTML source format.
+	 * filter) for no-op conversion.
 	 *
 	 * @since 0.1.0
 	 *
@@ -59,30 +59,13 @@ function bfb_resolve_format_for_insert( array $data, array $postarr ): string {
 }
 
 /**
- * Check whether automatic HTML → blocks conversion should run for a post type.
- *
- * Mirrors html-to-blocks-converter's standalone plugin support policy so BFB's
- * bundled package mode has the same default write behavior without loading
- * h2bc's hook file.
- *
- * @param string $post_type Post type slug.
- * @return bool Whether the post type is supported for automatic HTML writes.
- */
-function bfb_html_insert_supported_post_type( string $post_type ): bool {
-	$default_types   = array_keys( get_post_types( array( 'show_in_rest' => true, 'public' => true ) ) );
-	$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
-
-	return in_array( $post_type, (array) $supported_types, true );
-}
-
-/**
- * Convert post_content from the resolved source format to serialised block
- * markup before WordPress writes it.
+ * Convert post_content from a non-HTML source format to serialised
+ * block markup before WordPress writes it.
  *
  * Skips when:
  *   - post_content is empty
- *   - the resolved format is 'html' and the post type is not supported by
- *     html-to-blocks-converter's automatic write policy
+ *   - the resolved format is 'html' (existing html-to-blocks-converter
+ *     handles HTML→blocks at priority 10)
  *   - post_content is already block markup (`<!-- wp:`)
  *   - no adapter is registered for the resolved format
  *
@@ -99,10 +82,10 @@ function bfb_convert_on_insert( $data, $postarr ) {
 		return $data;
 	}
 
-	$format    = bfb_resolve_format_for_insert( $data, $postarr );
-	$post_type = isset( $data['post_type'] ) ? (string) $data['post_type'] : 'post';
-
-	if ( 'html' === $format && ! bfb_html_insert_supported_post_type( $post_type ) ) {
+	$format = bfb_resolve_format_for_insert( $data, $postarr );
+	if ( 'html' === $format ) {
+		// HTML is the no-op format; let html-to-blocks-converter handle it
+		// at its own priority.
 		return $data;
 	}
 

--- a/tools/smoke-test.php
+++ b/tools/smoke-test.php
@@ -12,17 +12,15 @@
  *     1. Markdown → blocks conversion produces serialised block markup
  *        with a heading and paragraph.
  *     2. HTML → blocks conversion produces equivalent shape.
- *     3. The insert hook converts default HTML input without requiring the
- *        standalone html-to-blocks-converter hook file.
- *     4. The bfb_default_format filter routes a wp_insert_post()
+ *     3. The bfb_default_format filter routes a wp_insert_post()
  *        through markdown conversion when the post type opts in.
  *   Phase 2 (read side):
- *     5. Markdown adapter from_blocks() round-trips a heading +
+ *     4. Markdown adapter from_blocks() round-trips a heading +
  *        formatted paragraph back to clean GFM.
- *     6. HTML adapter from_blocks() renders dynamic blocks via
+ *     5. HTML adapter from_blocks() renders dynamic blocks via
  *        do_blocks().
- *     7. bfb_render_post() returns markdown / html for a stored post.
- *     8. REST GET /wp/v2/posts/{id}?content_format=markdown adds
+ *     6. bfb_render_post() returns markdown / html for a stored post.
+ *     7. REST GET /wp/v2/posts/{id}?content_format=markdown adds
  *        content.formatted without disturbing content.rendered.
  *
  * @package BlockFormatBridge
@@ -90,25 +88,7 @@ assert_true(
 	'output: ' . substr( $html_result, 0, 200 )
 );
 
-// --- Test 3: wp_insert_post_data handles default HTML package mode ---
-$insert_data = array(
-	'post_type'    => 'post',
-	'post_content' => wp_slash( '<h2>Stored</h2><p>Body</p>' ),
-);
-$insert_result = bfb_convert_on_insert( $insert_data, $insert_data );
-$insert_saved  = wp_unslash( $insert_result['post_content'] ?? '' );
-assert_true(
-	'wp_insert_post_data converts default HTML to block markup',
-	false !== strpos( $insert_saved, '<!-- wp:' ),
-	'got: ' . substr( $insert_saved, 0, 200 )
-);
-assert_true(
-	'wp_insert_post_data HTML route includes a heading block',
-	false !== strpos( $insert_saved, '<!-- wp:heading' ),
-	'got: ' . substr( $insert_saved, 0, 200 )
-);
-
-// --- Test 4: bfb_default_format routes wp_insert_post through markdown ---
+// --- Test 3: bfb_default_format routes wp_insert_post through markdown ---
 $test_post_type = 'bfb_smoke_test';
 register_post_type(
 	$test_post_type,
@@ -148,7 +128,7 @@ if ( is_wp_error( $post_id ) ) {
 	wp_delete_post( $post_id, true );
 }
 
-// --- Test 5: Markdown adapter from_blocks() round-trips ---
+// --- Test 4: Markdown adapter from_blocks() round-trips ---
 $md_adapter = bfb_get_adapter( 'markdown' );
 assert_true( 'markdown adapter resolves', $md_adapter instanceof BFB_Format_Adapter );
 
@@ -169,7 +149,7 @@ assert_true(
 	'got: ' . substr( $round_md, 0, 200 )
 );
 
-// --- Test 6: HTML adapter from_blocks() renders blocks ---
+// --- Test 5: HTML adapter from_blocks() renders blocks ---
 $html_adapter = bfb_get_adapter( 'html' );
 $rendered     = $html_adapter ? $html_adapter->from_blocks( $source_blocks ) : '';
 assert_true(
@@ -183,7 +163,7 @@ assert_true(
 	'got: ' . substr( $rendered, 0, 200 )
 );
 
-// --- Test 7: bfb_render_post() ---
+// --- Test 6: bfb_render_post() ---
 $render_post_id = wp_insert_post(
 	array(
 		'post_type'    => 'post',
@@ -213,7 +193,7 @@ if ( is_wp_error( $render_post_id ) ) {
 	wp_delete_post( $render_post_id, true );
 }
 
-// --- Test 8a: TableConverter round-trips GFM tables ---
+// --- Test 7a: TableConverter round-trips GFM tables ---
 $table_md       = "| col1 | col2 |\n| --- | --- |\n| a | b |\n";
 $table_round    = bfb_convert( bfb_convert( $table_md, 'markdown', 'blocks' ), 'blocks', 'markdown' );
 assert_true(
@@ -222,7 +202,7 @@ assert_true(
 	'got: ' . $table_round
 );
 
-// --- Test 8b: bfb_markdown_input filter pre-processes raw markdown ---
+// --- Test 7b: bfb_markdown_input filter pre-processes raw markdown ---
 $linkify = static function ( string $md ): string {
 	return preg_replace( '#(?<![:/])(?<![a-zA-Z0-9])(example\.com)#', 'https://$1', $md );
 };
@@ -235,7 +215,7 @@ assert_true(
 	'got: ' . substr( $linkified_blocks, 0, 200 )
 );
 
-// --- Test 9: REST ?content_format=markdown ---
+// --- Test 8: REST ?content_format=markdown ---
 $rest_post_id = wp_insert_post(
 	array(
 		'post_type'    => 'post',


### PR DESCRIPTION
## Summary
- Revert BFB PR #6 so BFB no longer duplicates html-to-blocks-converter's default HTML write policy.
- Keep BFB focused on format orchestration and non-HTML source conversion; h2bc now owns zero-config HTML automation in both plugin and package mode.
- Remove the BFB smoke assertion that called BFB's insert hook directly for default HTML input.

## Tests
- `composer validate --strict`
- `php -l includes/hooks.php tools/smoke-test.php`
- `git diff --check HEAD~1..HEAD`
- `studio wp --skip-plugins=block-format-bridge,html-to-blocks-converter,intelligence eval 'require "/Users/chubes/Developer/block-format-bridge@revert-package-html-inserts/vendor/autoload.php"; if (function_exists("bfb_register_rest_filters")) { bfb_register_rest_filters(); } require "/Users/chubes/Developer/block-format-bridge@revert-package-html-inserts/tools/smoke-test.php";'`
- BFB + fixed h2bc package-mode `wp_insert_post()` smoke verified default HTML still stores block markup through h2bc's package hook

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reverted the misplaced BFB workaround after fixing h2bc package mode, then validated BFB still works with h2bc-owned HTML automation.