### PR TITLE
feat(hooks): add bfb_skip_insert_conversion filter for storage-layer veto

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -68,6 +68,9 @@ function bfb_resolve_format_for_insert( array $data, array $postarr ): string {
  *     handles HTML→blocks at priority 10)
  *   - post_content is already block markup (`<!-- wp:`)
  *   - no adapter is registered for the resolved format
+ *   - a `bfb_skip_insert_conversion` filter callback returns true
+ *     (consumer veto for storage layers that own their own
+ *     post_content shape — see the filter docblock below)
  *
  * @param array $data    Sanitized post data.
  * @param array $postarr Original post-insert array.
@@ -86,6 +89,39 @@ function bfb_convert_on_insert( $data, $postarr ) {
 	if ( 'html' === $format ) {
 		// HTML is the no-op format; let html-to-blocks-converter handle it
 		// at its own priority.
+		return $data;
+	}
+
+	/**
+	 * Filters whether the bridge should skip its insert-time conversion
+	 * for this `wp_insert_post_data` call.
+	 *
+	 * Storage layers that own the canonical shape of `post_content`
+	 * (e.g. a markdown-on-disk store that wants `post_content` to stay
+	 * as raw markdown) hook this filter to opt out of the
+	 * markdown-/format-→blocks normalisation that happens by default.
+	 *
+	 * Returning `true` short-circuits the conversion; `post_content` is
+	 * passed through to WordPress untouched. The bridge stays unaware of
+	 * any specific consumer — the filter is the seam consumers hook.
+	 *
+	 * Use cases:
+	 *   - markdown-database-integration in any mode: post_content is
+	 *     authoritative markdown; conversion to blocks would force a
+	 *     lossy blocks→markdown round-trip on the disk-write side.
+	 *   - any future "post_content holds raw <X>" storage layer.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param bool   $skip    Whether to skip insert-time conversion.
+	 *                        Default false.
+	 * @param array  $data    Sanitized post data destined for wp_posts.
+	 * @param array  $postarr Original `wp_insert_post()` array.
+	 * @param string $format  Resolved source format slug
+	 *                        (e.g. 'markdown'). Never 'html'.
+	 */
+	$skip = (bool) apply_filters( 'bfb_skip_insert_conversion', false, $data, $postarr, $format );
+	if ( $skip ) {
 		return $data;
 	}
 

--- a/tools/smoke-test.php
+++ b/tools/smoke-test.php
@@ -128,6 +128,54 @@ if ( is_wp_error( $post_id ) ) {
 	wp_delete_post( $post_id, true );
 }
 
+// --- Test 3b: bfb_skip_insert_conversion vetoes the conversion ---
+// Storage layers that own the canonical post_content shape (e.g. MDI in
+// any mode wants markdown to stay as markdown) hook this filter to
+// short-circuit the insert-time conversion. The filter receives the
+// resolved format so consumers can scope the veto by source format.
+add_filter( 'bfb_default_format', $filter, 10, 2 );
+
+$skip_seen_format = null;
+$skip_filter      = function ( $skip, $data, $postarr, $format ) use ( $test_post_type, &$skip_seen_format ) {
+	if ( ( $data['post_type'] ?? '' ) === $test_post_type ) {
+		$skip_seen_format = $format;
+		return true;
+	}
+	return $skip;
+};
+add_filter( 'bfb_skip_insert_conversion', $skip_filter, 10, 4 );
+
+$skip_post_id = wp_insert_post(
+	array(
+		'post_type'    => $test_post_type,
+		'post_status'  => 'draft',
+		'post_title'   => 'BFB Skip',
+		'post_content' => "# Test\n\nBody",
+	),
+	true
+);
+
+remove_filter( 'bfb_skip_insert_conversion', $skip_filter, 10 );
+remove_filter( 'bfb_default_format', $filter, 10 );
+
+if ( is_wp_error( $skip_post_id ) ) {
+	assert_true( 'wp_insert_post (skip path) succeeded', false, $skip_post_id->get_error_message() );
+} else {
+	$skipped_saved = get_post_field( 'post_content', $skip_post_id );
+	assert_true(
+		'bfb_skip_insert_conversion=true leaves post_content untouched',
+		false === strpos( $skipped_saved, '<!-- wp:' )
+			&& false !== strpos( $skipped_saved, '# Test' ),
+		'stored: ' . substr( $skipped_saved, 0, 200 )
+	);
+	assert_true(
+		'bfb_skip_insert_conversion receives the resolved format slug',
+		'markdown' === $skip_seen_format,
+		'got: ' . var_export( $skip_seen_format, true )
+	);
+	wp_delete_post( $skip_post_id, true );
+}
+
 // --- Test 4: Markdown adapter from_blocks() round-trips ---
 $md_adapter = bfb_get_adapter( 'markdown' );
 assert_true( 'markdown adapter resolves', $md_adapter instanceof BFB_Format_Adapter );


### PR DESCRIPTION
## Summary

Adds `bfb_skip_insert_conversion`, a filter that lets storage-layer plugins veto BFB's `wp_insert_post_data` markdown→blocks normalisation when they own the canonical shape of `post_content`.

The motivating consumer is [`markdown-database-integration`](https://github.com/Automattic/markdown-database-integration) (MDI). MDI stores `post_content` as raw markdown on disk and treats SQLite as an index/map. With BFB active and a CPT declaring `bfb_default_format='markdown'`, the round-trip becomes:

```
markdown agent input
    ↓ bfb_convert_on_insert (BFB) — markdown → serialised blocks
post_content stored as block markup
    ↓ MDI write engine — blocks → markdown for the .md file
.md file on disk
```

The blocks→markdown hop loses fidelity (heading/list/paragraph re-ordering, attribution prose duplicating across sibling blocks). Independently of BFB's read-side adapter quality, the issue is the round-trip itself — there is no good reason for the round-trip to happen when the storage layer never wanted blocks in the first place.

This filter is the seam consumers hook to opt out.

## Behaviour

`bfb_convert_on_insert` already had four early-return conditions (empty content, format = `'html'`, content already block markup, no adapter). This adds a fifth: a `bfb_skip_insert_conversion` filter callback may return `true` to short-circuit. The filter fires AFTER format resolution (so consumers can scope by source format — `'markdown'` only, or all non-html slugs) and BEFORE the conversion call.

```php
add_filter( 'bfb_skip_insert_conversion', function ( $skip, $data, $postarr, $format ) {
    if ( 'markdown' !== $format ) {
        return $skip;
    }
    if ( ! WP_Markdown_Storage::is_markdown_type_static( $data['post_type'] ?? '' ) ) {
        return $skip;
    }
    return true;
}, 10, 4 );
```

When `true`, `post_content` passes through to WordPress untouched — i.e. exactly the markdown the agent sent.

## CLI surface

None. Pure filter addition.

## Tests

`tools/smoke-test.php` test 3b covers:

1. With the filter callback returning `true`, `post_content` survives the insert verbatim (no `<!-- wp:` markers; original `# Test\n\nBody` markdown intact).
2. The filter callback receives the resolved format slug (`'markdown'` in the test fixture), enabling consumers to scope the veto by source format.

Plus all 17 pre-existing checks still pass on `intelligence-chubes4` (live-verified).

## Out of scope

- Doesn't change the default behaviour at all — every existing call site keeps converting on insert.
- Doesn't introduce any consumer-specific knowledge into BFB. The filter contract is "should I skip this conversion?", not "is MDI installed?".

## Related

- Closes the upstream gap blocking [`markdown-database-integration#82`](https://github.com/Automattic/markdown-database-integration/issues/82).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the architectural collision while cooking MDI #82, designed the filter contract (BFB-substrate-aware vocabulary, no consumer knowledge), implemented the hook + smoke test, drafted this PR body. Live-verified on intelligence-chubes4 against the worktree.
