### PR TITLE
build: refresh vendor_prefixed/ for h2bc php-scoper callback fix

### DIFF
--- a/vendor_prefixed/chubes4/html-to-blocks-converter/library.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/library.php
@@ -37,7 +37,8 @@ $html_to_blocks_initializer = static function () use ($html_to_blocks_library_pa
     if (!\class_exists('BlockFormatBridge\Vendor\HTML_To_Blocks_Transform_Registry', \false)) {
         require_once $html_to_blocks_library_path . '/includes/class-transform-registry.php';
     }
-    if (!\function_exists('BlockFormatBridge\Vendor\html_to_blocks_raw_handler')) {
+    $html_to_blocks_raw_handler_callback = __NAMESPACE__ ? __NAMESPACE__ . '\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+    if (!\function_exists($html_to_blocks_raw_handler_callback)) {
         require_once $html_to_blocks_library_path . '/raw-handler.php';
     }
     require_once $html_to_blocks_library_path . '/includes/hooks.php';

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
@@ -107,7 +107,8 @@ function html_to_blocks_convert($html)
         } else {
             $transform_fn = $raw_transform['transform'] ?? null;
             if ($transform_fn && \is_callable($transform_fn)) {
-                $block = \call_user_func($transform_fn, $element, 'html_to_blocks_raw_handler');
+                $raw_handler_callback = __NAMESPACE__ ? __NAMESPACE__ . '\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+                $block = \call_user_func($transform_fn, $element, $raw_handler_callback);
                 if ($element->has_attribute('class')) {
                     $existing_class = $block['attrs']['className'] ?? '';
                     $node_class = $element->get_attribute('class');

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-php-scoper-callback.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-php-scoper-callback.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Smoke test: php-scoper callback safety.
+ *
+ * Catches the regression class where string-literal function-name callbacks
+ * do not survive php-scoper's namespace rewriting, leading to fatals like
+ * "Call to undefined function html_to_blocks_raw_handler()" when the library
+ * is consumed via a vendor_prefixed/ build (e.g. Block Format Bridge).
+ *
+ * Strategy:
+ *   1. Static source-content assertions — every callback construction site
+ *      that names html_to_blocks_raw_handler MUST gate the resolution on
+ *      __NAMESPACE__ so the same source compiles correctly in both the
+ *      unscoped global namespace and a scoped namespace.
+ *   2. Dynamic equivalence — declare functions inside a synthetic namespace
+ *      (mimicking what php-scoper does) and assert the __NAMESPACE__-derived
+ *      callable resolves to that namespaced function via call_user_func.
+ *
+ * Run: php tests/smoke-php-scoper-callback.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ */
+// phpcs:disable
+namespace BlockFormatBridge\Vendor\HTMLToBlocksConverterSmoke\Synthetic\Vendor;
+
+/**
+ * Synthetic stand-in for the real raw handler, declared inside a faux
+ * scoped namespace. Mimics what php-scoper produces when h2bc is
+ * vendored under BlockFormatBridge\Vendor\.
+ */
+function html_to_blocks_raw_handler($args)
+{
+    return array('called_in_namespace' => __NAMESPACE__, 'args' => $args);
+}
+/**
+ * Builds the recursive-handler callable using the same
+ * __NAMESPACE__-aware expression that lives in raw-handler.php and
+ * library.php. Must yield a string that resolves correctly inside this
+ * namespace.
+ */
+function build_callback()
+{
+    return __NAMESPACE__ ? __NAMESPACE__ . '\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+}
+namespace BlockFormatBridge\Vendor;
+
+$failures = array();
+$assertions = 0;
+$smoke_assert = function ($condition, $label, $detail = '') use (&$failures, &$assertions) {
+    $assertions++;
+    if (!$condition) {
+        $failures[] = "FAIL [{$label}]" . ($detail !== '' ? ": {$detail}" : '');
+    }
+};
+// -----------------------------------------------------------------------
+// 1. Static source assertions
+// -----------------------------------------------------------------------
+$repo_root = \dirname(__DIR__);
+$raw_handler_source = \file_get_contents($repo_root . '/raw-handler.php');
+$library_source = \file_get_contents($repo_root . '/library.php');
+$smoke_assert(\is_string($raw_handler_source) && $raw_handler_source !== '', 'raw-handler-readable');
+$smoke_assert(\is_string($library_source) && $library_source !== '', 'library-readable');
+// The bare string literal must not appear as a callback argument to
+// call_user_func. Docblocks/comments are fine; we only fail on the exact
+// dangerous shape.
+$smoke_assert(\strpos($raw_handler_source, "call_user_func( \$transform_fn, \$element, 'html_to_blocks_raw_handler' )") === \false, 'raw-handler-no-string-literal-callback', 'raw-handler.php still passes the bare string "html_to_blocks_raw_handler" into call_user_func; will fatal under php-scoper');
+// And it must use __NAMESPACE__ to build the callable.
+$smoke_assert(\preg_match('/__NAMESPACE__\s*\?\s*__NAMESPACE__\s*\.\s*[\'"]\\\\\\\\html_to_blocks_raw_handler[\'"]\s*:\s*[\'"]html_to_blocks_raw_handler[\'"]/', $raw_handler_source) === 1, 'raw-handler-uses-namespace-aware-callback', 'raw-handler.php must build the recursive handler callback via __NAMESPACE__');
+// library.php must use the same pattern for its function_exists guard.
+$smoke_assert(\strpos($library_source, "function_exists( 'html_to_blocks_raw_handler' )") === \false, 'library-no-string-literal-function-exists', 'library.php still calls function_exists with bare string; will mis-guard under scoping');
+$smoke_assert(\preg_match('/__NAMESPACE__\s*\?\s*__NAMESPACE__\s*\.\s*[\'"]\\\\\\\\html_to_blocks_raw_handler[\'"]\s*:\s*[\'"]html_to_blocks_raw_handler[\'"]/', $library_source) === 1, 'library-uses-namespace-aware-function-exists', 'library.php must guard the require_once via a __NAMESPACE__-derived callable');
+// -----------------------------------------------------------------------
+// 2. Dynamic equivalence inside a synthetic namespace
+// -----------------------------------------------------------------------
+$scoped_callable = \BlockFormatBridge\Vendor\HTMLToBlocksConverterSmoke\Synthetic\Vendor\build_callback();
+$smoke_assert($scoped_callable === 'HTMLToBlocksConverterSmoke\Synthetic\Vendor\html_to_blocks_raw_handler', 'scoped-callable-string-shape', "got: {$scoped_callable}");
+$smoke_assert(\is_callable($scoped_callable), 'scoped-callable-resolves', "php cannot resolve {$scoped_callable} to a function");
+$smoke_assert(\function_exists($scoped_callable), 'scoped-function-exists', "function_exists() rejects {$scoped_callable}");
+$invoke_result = \call_user_func($scoped_callable, array('HTML' => '<p>x</p>'));
+$smoke_assert(\is_array($invoke_result) && isset($invoke_result['called_in_namespace']) && $invoke_result['called_in_namespace'] === 'HTMLToBlocksConverterSmoke\Synthetic\Vendor', 'scoped-callable-invokes-namespaced-function', 'invocation did not land in the synthetic namespace');
+// And in the unscoped path: the same expression evaluated in the global
+// namespace (where __NAMESPACE__ === '') must collapse to the bare name.
+function html_to_blocks_raw_handler_global_smoke($args)
+{
+    return array('called_in_namespace' => '', 'args' => $args);
+}
+$unscoped_callable = __NAMESPACE__ ? __NAMESPACE__ . '\html_to_blocks_raw_handler_global_smoke' : 'html_to_blocks_raw_handler_global_smoke';
+$smoke_assert($unscoped_callable === 'html_to_blocks_raw_handler_global_smoke', 'unscoped-callable-string-shape', "got: {$unscoped_callable}");
+$smoke_assert(\is_callable($unscoped_callable), 'unscoped-callable-resolves', "global function not resolvable: {$unscoped_callable}");
+// -----------------------------------------------------------------------
+// Report
+// -----------------------------------------------------------------------
+echo "Assertions: {$assertions}" . \PHP_EOL;
+if (empty($failures)) {
+    echo 'ALL PASS' . \PHP_EOL;
+    exit(0);
+}
+echo 'FAILURES (' . \count($failures) . '):' . \PHP_EOL;
+foreach ($failures as $f) {
+    echo "  - {$f}" . \PHP_EOL;
+}
+exit(1);


### PR DESCRIPTION
## Summary

Refreshes BFB's `vendor_prefixed/` build artifact to pick up the h2bc php-scoper callback fix shipped in [chubes4/html-to-blocks-converter#11](https://github.com/chubes4/html-to-blocks-converter/pull/11) (merged as `a25eb44`).

Without this rebuild, BFB's bundled h2bc copy continued to fatal on any HTML containing a `<blockquote>` or `<pre><code>` element processed through the recursive transform path. This affects every consumer that calls `bfb_convert($content, 'html', 'blocks')` with non-trivial HTML, OR any markdown route that compiles to such HTML (since the markdown adapter routes through the HTML adapter).

## Why this is a separate PR

PR #9 shipped the `vendor_prefixed/` distribution architecture, which was a **prerequisite** for surfacing this bug — pre-#9, consumers got h2bc as raw global functions (string callback resolved fine), so the latent php-scoper incompatibility in h2bc was invisible. Once #9 made consumers actually use the scoped output, the fatal showed up immediately on any non-trivial conversion.

The fix lives in h2bc upstream (PR #11, merged). This PR just regenerates BFB's distributed copy.

## Changes

- **`vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php`** — regenerated. Now uses `__NAMESPACE__`-derived callback for the recursive `$handler` invocation. At runtime in BFB's vendored copy, `__NAMESPACE__` resolves to `BlockFormatBridge\Vendor`, so the callback string becomes `BlockFormatBridge\Vendor\html_to_blocks_raw_handler` — which IS the function declared at the top of the same file.
- **`vendor_prefixed/chubes4/html-to-blocks-converter/library.php`** — same fix applied to the `function_exists()` guard.
- **`vendor_prefixed/chubes4/html-to-blocks-converter/tests/`** — h2bc's new smoke test landed in the prefixed tree. Harmless (it's pure-PHP and never autoloaded), but worth filtering out in a future scoper.inc.php cleanup.

## Live verification

On `intelligence-chubes4` against this branch:

```php
$tick = chr(96);
$md = "# Test\n\n> A blockquote\n\n" . str_repeat($tick, 3) . "\ncode_here();\n" . str_repeat($tick, 3);
$blocks = bfb_convert($md, "markdown", "blocks");

// Pre-rebuild (BFB main):
//   FATAL: Call to undefined function html_to_blocks_raw_handler()

// Post-rebuild:
//   wp:heading: YES
//   wp:quote:   YES
//   wp:code:    YES
```

Full block markup output:
```html
<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Test</h1><!-- /wp:heading -->
<!-- wp:quote --><blockquote class="wp-block-quote"><!-- wp:paragraph --><p>A blockquote</p><!-- /wp:paragraph --></blockquote><!-- /wp:quote -->
<!-- wp:code --><pre class="wp-block-code"><code>code_here();</code></pre><!-- /wp:code -->
```

The `<blockquote>` correctly nests its inner `<p>` as a child block (proving the recursive `$handler` callback resolves through the scoped namespace).

## Followup

A defense-in-depth smoke test on the BFB side that exercises the diverse-HTML transform paths through `bfb_convert()` would have caught the gap between PR #9 merging and PR #11 being needed. Worth filing as a follow-up issue.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Ran `composer update chubes4/html-to-blocks-converter && composer build`, staged the regenerated `vendor_prefixed/` tree, live-verified end-to-end via `bfb_convert` on intelligence-chubes4, and authored this PR. Chris reviewed the architectural framing.
