### PR TITLE
fix(scoper): suppress class_alias emission to enable multi-consumer coexistence

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -26,6 +26,37 @@ return [
 		'WP_REST_Request',
 		'WP_REST_Response',
 	],
+	// Disable php-scoper's default class_alias emission so the build does
+	// NOT write `\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_*',
+	// 'HTML_To_Blocks_*', false)` shims back to the bare global names.
+	//
+	// Bundling via vendor_prefixed/ is meant to insulate BFB's bundled
+	// copies of html-to-blocks-converter, league/commonmark, etc. from
+	// every other plugin on the site. The default global aliases re-couple
+	// the bundled copies to the global symbol surface — when two BFB
+	// consumers (e.g. Intelligence + MDI) ship their own vendor_prefixed/,
+	// both try to register the same `class_alias HTML_To_Blocks_*` lines
+	// and the second-loaded copy fatals with "Cannot declare class".
+	//
+	// BFB itself never references the bare global names; library.php and
+	// includes/class-bfb-html-adapter.php both call the scoped FQNs
+	// (`\BlockFormatBridge\Vendor\HTML_To_Blocks_Versions`,
+	// `\BlockFormatBridge\Vendor\html_to_blocks_raw_handler`) and only
+	// fall through to the bare names when the standalone h2bc plugin is
+	// the source of truth (i.e. BFB has no vendor_prefixed/ build).
+	//
+	// We only flip `expose-global-classes` — leaving `expose-global-functions`
+	// and `expose-global-constants` at their `true` defaults so scoper still
+	// knows global functions/constants like `defined()`, `function_exists()`,
+	// `'ABSPATH'`, etc. are global references, not symbols belonging to the
+	// prefix. Flipping all three at once mis-prefixes the `defined('ABSPATH')`
+	// guard in vendored library files (the string scalar gets rewritten to
+	// `'BlockFormatBridge\Vendor\ABSPATH'`, an unreachable constant), which
+	// makes those library.php entrypoints early-return and silently disables
+	// the bundled package.
+	//
+	// See: https://github.com/chubes4/block-format-bridge/issues/10
+	'expose-global-classes' => false,
 	'finders'    => [
 		Finder::create()
 			->files()

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-attribute-parser.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-attribute-parser.php
@@ -364,4 +364,3 @@ class HTML_To_Blocks_Attribute_Parser
         return \true;
     }
 }
-\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_Attribute_Parser', 'HTML_To_Blocks_Attribute_Parser', \false);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
@@ -294,4 +294,3 @@ class HTML_To_Blocks_Block_Factory
         return '';
     }
 }
-\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_Block_Factory', 'HTML_To_Blocks_Block_Factory', \false);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-element.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-element.php
@@ -473,4 +473,3 @@ class HTML_To_Blocks_HTML_Element
         return null;
     }
 }
-\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_HTML_Element', 'HTML_To_Blocks_HTML_Element', \false);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php
@@ -120,8 +120,4 @@ if (!\class_exists('BlockFormatBridge\Vendor\HTML_To_Blocks_Versions', \false)) 
             do_action('html_to_blocks_loaded', $version);
         }
     }
-    /**
-     * Tracks loaded html-to-blocks-converter versions and initializes one.
-     */
-    \class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_Versions', 'HTML_To_Blocks_Versions', \false);
 }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -504,4 +504,3 @@ class HTML_To_Blocks_Transform_Registry
         }]];
     }
 }
-\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_Transform_Registry', 'HTML_To_Blocks_Transform_Registry', \false);


### PR DESCRIPTION
## Summary

Closes #10.

php-scoper's default behaviour exposes every globally-declared class under its bare global name via auto-generated `class_alias` calls in the scoped output:

```php
\class_alias(
    'BlockFormatBridge\Vendor\HTML_To_Blocks_HTML_Element',
    'HTML_To_Blocks_HTML_Element',
    \false
);
```

These aliases re-couple the bundled `vendor_prefixed/` copies to the global symbol surface that scoping was supposed to insulate them from. When two BFB-consuming plugins (e.g. Intelligence + MDI) ship their own `vendor_prefixed/` on the same site, both try to register the same `class_alias HTML_To_Blocks_*` lines and the second-loaded copy fatals with `Cannot declare class HTML_To_Blocks_*`. The `HTML_To_Blocks_Versions` version-registry pattern can't help — the registry class itself is one of the colliding names.

This is the structural problem documented in #10.

## Changes

- **`scoper.inc.php`** — set `expose-global-classes => false`. Leaves `expose-global-functions` and `expose-global-constants` at their `true` defaults (see "Why only one toggle" below).
- **`vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-{attribute-parser,block-factory,html-element,html-to-blocks-versions,transform-registry}.php`** — rebuild artifacts. Each loses its trailing `\class_alias(...)` line. Otherwise byte-identical.

## BFB consumer-source audit

Both BFB callsites that name h2bc were already written for the scoped path with a graceful global-name fallback:

- **`includes/class-bfb-html-adapter.php:46-54`** — checks `function_exists('\BlockFormatBridge\Vendor\html_to_blocks_raw_handler')` first; only falls through to the bare `html_to_blocks_raw_handler` when the standalone h2bc plugin is the source of truth (i.e. BFB has no `vendor_prefixed/` build of its own).
- **`library.php:44-48`** — same pattern: `class_exists('\BlockFormatBridge\Vendor\HTML_To_Blocks_Versions')` first, bare-name fallback second.

So no BFB source changes are needed; the scoped FQNs already work, and the global fallback path is reserved for the standalone-plugin scenario where the bare names DO exist (because the standalone h2bc plugin owns them, not BFB).

## Why only one toggle

First draft of this PR flipped all three exposure toggles (`classes`, `functions`, `constants`) since the issue body's worked example showed all three. That broke the build subtly:

- Setting `expose-global-constants => false` causes scoper to treat string scalars that look like constant names as belonging to the prefix.
- The vendored `library.php` has `if ( ! defined( 'ABSPATH' ) ) { return; }` at the top — a standard "don't run outside WordPress" guard.
- Under the all-three config, scoper rewrites the scalar to `defined('BlockFormatBridge\Vendor\ABSPATH')`. That namespaced constant is never defined → `!defined(...)` is always true → `library.php` always early-returns → none of h2bc's classes or functions ever load → `bfb_convert()` silently falls back to `core/freeform`.

Same class of footgun would apply to any vendored package that uses `defined()` / `function_exists()` with a string literal naming a WordPress / PHP global. We only need to drop class_alias emission; leave the function/constant toggles alone so scoper continues to recognize global references in scalar form.

## Live verification

End-to-end test on a Studio site (intelligence-chubes4) with both standalone BFB plugin AND markdown-database-integration's bundled BFB active:

```php
$md = "# Test\n\n> A blockquote\n\n```\ncode\n```";
$blocks = bfb_convert($md, 'markdown', 'blocks');
```

Result:
```
<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Test</h1><!-- /wp:heading -->
<!-- wp:quote --><blockquote class="wp-block-quote">
  <!-- wp:paragraph --><p>A blockquote</p><!-- /wp:paragraph -->
</blockquote><!-- /wp:quote -->
<!-- wp:code --><pre class="wp-block-code"><code>code</code></pre><!-- /wp:code -->
```

Symbol-table state confirms the structural fix:

```
HTML_To_Blocks_Versions:           global=NO  scoped=YES
HTML_To_Blocks_HTML_Element:       global=NO  scoped=YES
HTML_To_Blocks_Block_Factory:      global=NO  scoped=YES
HTML_To_Blocks_Attribute_Parser:   global=NO  scoped=YES
HTML_To_Blocks_Transform_Registry: global=NO  scoped=YES
html_to_blocks_raw_handler:        global=NO  scoped=YES
```

Every h2bc class lives ONLY under `BlockFormatBridge\Vendor\`. The collision class is structurally unreachable — adding a third or fourth BFB-consuming plugin to the same site cannot trip the `Cannot declare class` warnings because the global names are no longer being claimed by anyone.

Also confirmed the polyfill-php80 stubs (which DO need to expose `Attribute`, `Stringable`, etc. globally — that's the polyfill's purpose) are unaffected. Their `class_alias` calls are source-authored in symfony's polyfill package, not scoper-generated, so the config change leaves them alone.

## What this does not do

- **Does NOT change BFB's public API.** The `BFB_*` adapter classes (`BFB_HTML_Adapter`, `BFB_Markdown_Adapter`, `BFB_Adapter_Registry`, `BFB_Format_Adapter` interface) are declared in BFB's own `includes/`, not in h2bc. They are not affected by scoping at all.
- **Does NOT touch h2bc upstream.** This is a one-line scoper config change in BFB; h2bc's source is correct (post-chubes4/html-to-blocks-converter#11) regardless of which side of the alias decision BFB makes.
- **Does NOT remove the global fallback paths in BFB source.** They remain useful for the development-install scenario (BFB without a `vendor_prefixed/` build, h2bc plugin active) and for the migration window before all consumers ship their own `vendor_prefixed/`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed the class_alias coupling between bundled BFB copies and the global symbol surface; identified `expose-global-classes` as the relevant scoper toggle; caught and fixed the over-aggressive first draft (which flipped all three toggles and broke `defined('ABSPATH')`); authored the scoper.inc.php config change, rebuilt vendor_prefixed/, and live-verified end-to-end with two BFB-consuming plugins active. Chris reviewed the architectural framing and the PR scope.
