### PR TITLE
docs(readme): document the actual install path + drop personal-wiki design pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ return    $to_adapter->from_blocks( $blocks );
 
 Install it as a standalone plugin, or bundle it as a Composer package.
 
-The package is distributed via [wp-packages.org](https://wp-packages.org). Add it to a Composer-managed WordPress site:
+The package is not yet published to a Composer mirror, so today the install path is a VCS repository pointing at
+GitHub:
 
 ```bash
-composer config repositories.wp-packages composer https://wp-packages.org
-composer require chubes4/block-format-bridge
+composer config repositories.bfb vcs https://github.com/chubes4/block-format-bridge
+composer require chubes4/block-format-bridge:dev-main
 ```
 
 Composer autoloads `library.php`, which registers the bridge through an Action-Scheduler-style version registry.


### PR DESCRIPTION
## Summary

Two README cleanups in one commit.

### 1. Install snippet now reflects ground truth

The README's "Install" section advertised:

```bash
composer config repositories.wp-packages composer https://wp-packages.org
composer require chubes4/block-format-bridge
```

That snippet doesn't actually install anything today:

- **wp-packages.org** is a [Roots-run mirror](https://wp-packages.org/docs) that exclusively exposes packages from the WordPress.org plugin/theme directory, under `wp-plugin/{slug}` and `wp-theme/{slug}`. Their root manifest declares `"available-package-patterns":["wp-plugin/*","wp-theme/*"]`. The `chubes4/*` namespace is not served.
- **Packagist** doesn't have BFB either.
- **GitHub** has no tagged releases (`gh release list` is empty), so even via a `vcs` repo only `dev-main` resolves.

Replaced with the install path that actually works today: a VCS repository pointing at the GitHub repo, requiring `dev-main`.

```bash
composer config repositories.bfb vcs https://github.com/chubes4/block-format-bridge
composer require chubes4/block-format-bridge:dev-main
```

### 2. Dropped the trailing "Design" section

The section was a two-line pointer to a private-wiki path:

> The full architectural rationale lives on the author's personal wiki at
> `projects/block-format-bridge-bidirectional-content-format-plugin-design`.

That path has no public URL, so it was useless to README readers — README noise without README value. If the architectural rationale is worth publishing, it belongs in a public `docs/` page or a blog post; until then, the README doesn't need to gesture at it.

## What this does not do

- **Does not publish BFB to a Composer mirror.** Tracked separately in #16. wp-packages.org publishing requires submitting the plugin to WordPress.org first; alternatively (or in parallel) we could publish to Packagist directly. When BFB ships on a real Composer mirror, the README install snippet gets a follow-up update to point at the canonical install path.
- **Does not tag a release.** Also tracked in #16; tagging is a prerequisite for any Composer mirror submission.
- **Does not add public design docs.** Out of scope; if there's appetite to publish them, that's a separate `docs/` PR.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Verified the wp-packages.org claim against their `packages.json` manifest and docs, confirmed BFB has no Packagist listing and no GitHub releases, drafted the corrected README snippet and the publishing-path tracking issue (#16). Chris reviewed and asked for the README to reflect ground truth only (with the publishing aspiration tracked separately) and to drop the personal-wiki pointer that didn't help README readers.
