### PR TITLE
docs(readme): drop personal-wiki design pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,6 @@ homeboy test block-format-bridge
 The suite runs inside WordPress Playground and covers every documented `bfb_convert()` direction: HTML → Blocks,
 Blocks → HTML, Markdown → HTML, Markdown → Blocks, Blocks → Markdown, and HTML → Markdown.
 
-## Design
-
-The full architectural rationale lives on the author's personal wiki at
-`projects/block-format-bridge-bidirectional-content-format-plugin-design`.
-
 ## License
 
 GPL-2.0-or-later.


### PR DESCRIPTION
## Summary

The trailing `## Design` section in `README.md` was a two-line pointer to a private-wiki path:

> The full architectural rationale lives on the author's personal wiki at
> `projects/block-format-bridge-bidirectional-content-format-plugin-design`.

That path has no public URL, so README readers couldn't follow it anywhere. README noise without README value. Drops the section entirely.

If the architectural rationale is worth publishing, it belongs in a public `docs/` page or a blog post — separate work, out of scope for this PR.

## Changes

`README.md` — removed the 5-line `## Design` block immediately above `## License`. No other changes.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the private-wiki pointer, drafted the removal commit and this PR. This was originally amended onto #17 in the same session, but #17 was squash-merged before the force-push reached GitHub, so the wiki removal lands as its own follow-up PR. Chris asked for the cleanup.
