### PR TITLE
ci: test newer PHP runtimes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Runtime support starts at PHP 8.1, but the dev/build toolchain
-        # currently includes humbug/php-scoper 0.18.19, which requires PHP 8.2.
-        php-version: ['8.2', '8.3']
+        # Runtime support starts at PHP 8.1, but the dev/build toolchain currently
+        # requires PHP 8.2. Test the supported build floor plus newer runtimes.
+        php-version: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Expand the Homeboy test matrix from PHP 8.2/8.3 to PHP 8.2 through 8.5.
- Keep PHP 8.2 as the build-toolchain floor while using CI to catch compatibility issues on newer runtimes.

## Tests
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }; puts "workflow yaml ok"'`
- `homeboy validate block-format-bridge --path /Users/chubes/Developer/block-format-bridge@expand-php-test-matrix`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@expand-php-test-matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and validated the workflow matrix update; Chris remains responsible for review and merge.
