### PR TITLE
ci: install Node for Playground tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -35,4 +36,7 @@ jobs:
         with:
           commands: test
           php-version: ${{ matrix.php-version }}
+          # The WordPress extension's Playground backend needs Node to install
+          # @wp-playground/cli; without this, push-context runs skip Node setup.
+          node-version: '24'
           autofix: 'false'


### PR DESCRIPTION
## Summary
- Pass `node-version: '24'` to Homeboy Action so the WordPress extension can install `@wp-playground/cli` for Playground-backed tests.
- Grant `issues: write` for push-context runs because Homeboy Action attempts to file categorized issues when main-branch quality checks fail.

## Why
PR checks were green, but every `push` run on `main` failed before executing tests because Homeboy resolved `node: skip` and the WordPress extension did not have `node_modules/.bin/wp-playground-cli` installed.

## Tests
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }; puts "workflow yaml ok"'`
- `homeboy validate block-format-bridge --path /Users/chubes/Developer/block-format-bridge@fix-playground-cli-ci-setup`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@fix-playground-cli-ci-setup`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the push-context CI failure, drafted the workflow fix, and validated locally; Chris remains responsible for review and merge.
