### PR TITLE
docs: define FSE compiler consumer surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ when active. The bridge surface is the simpler, programmatic query-param form.
 Resolve a registered adapter directly. Useful when you want to skip the universal router and operate on block arrays
 without re-serialising.
 
+### FSE / Site Compiler Consumers
+
+Future static HTML/CSS to block-theme compiler work should treat BFB as the format-conversion substrate, not the layer
+that infers FSE intent. The current stable surface is `bfb_convert()` plus the adapter registry. Proposed compiler-facing
+helpers and CLI shape are documented in [`docs/fse-compiler-surface.md`](docs/fse-compiler-surface.md).
+
 ### Filters
 
 - **`bfb_default_format( $format, $post_type, $content ): string`** — declares which format a CPT writes in by default.

--- a/docs/fse-compiler-surface.md
+++ b/docs/fse-compiler-surface.md
@@ -1,0 +1,127 @@
+# FSE Compiler Consumer Surface
+
+Issue: https://github.com/chubes4/block-format-bridge/issues/29
+
+This note defines the Block Format Bridge surface a future static HTML/CSS to block-theme compiler should consume. It is intentionally limited to BFB's boundary: format conversion through the block pivot. FSE inference, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside html-to-blocks-converter.
+
+## Boundary
+
+BFB is the substrate between content formats and WordPress block data:
+
+```
+HTML / Markdown / future formats
+        |
+        v
+  BFB format adapter
+        |
+        v
+ WordPress block arrays
+        |
+        +--> serialize_blocks()  -> block markup
+        +--> render_block()      -> HTML
+        +--> markdown adapter    -> Markdown
+```
+
+A site compiler can use BFB for deterministic conversion once it has already decided what belongs in templates, template parts, patterns, posts, or global styles.
+
+## Answers
+
+### 1. First-class block-array helper
+
+BFB should expose a small helper like `bfb_to_blocks( string $content, string $from ): array`.
+
+Today callers can already get block arrays with `bfb_get_adapter( $from )->to_blocks( $content )`, but that reaches through the public registry into the adapter contract. Compiler code should not need to know whether `'blocks'` is a special source, whether an adapter exists, or whether the input should be parsed with `parse_blocks()`.
+
+Recommended contract:
+
+```php
+/**
+ * Convert content into parse_blocks()-compatible block arrays.
+ *
+ * @return array<int, array<string, mixed>> Empty array on unsupported source or conversion failure.
+ */
+function bfb_to_blocks( string $content, string $from ): array;
+```
+
+Behavior:
+
+- `from === 'blocks'` parses serialized block markup with `parse_blocks()`.
+- Other formats resolve through `bfb_get_adapter( $from )` and call `to_blocks()`.
+- Unsupported formats return an empty array and log the same style of error as `bfb_convert()`.
+- The helper should be the internal source of truth for `bfb_convert()` once implemented, avoiding two conversion paths.
+
+This is a small API addition, but it is not required before compiler exploration can begin.
+
+### 2. WP-CLI conversion command
+
+BFB should eventually expose a CLI command for non-PHP callers, but not as part of this issue.
+
+Node-based tools such as Studio can already call WordPress through WP-CLI. A command like this would let those tools use the server-side converter without embedding PHP glue:
+
+```bash
+wp bfb convert --from=html --to=blocks < input.html
+```
+
+Recommended initial command shape:
+
+- `wp bfb convert --from=<format> --to=<format> [--input=<file>] [--output=<file>]`
+- Read STDIN when `--input` is omitted.
+- Write STDOUT when `--output` is omitted.
+- Return serialized content for normal format targets.
+- Use a separate flag for structured block arrays, for example `--as=json`, rather than overloading the default output.
+
+This should land after the PHP helper surface is stable, because the CLI should be a thin wrapper around the public API rather than a parallel conversion path.
+
+### 3. Arrays plus serialized markup in one call
+
+BFB should support this as a convenience for compiler workflows, but keep it separate from `bfb_convert()`.
+
+Compiler consumers often need both representations:
+
+- Block arrays for inspection, splitting, policy checks, and template/pattern assembly.
+- Serialized block markup for writing to WordPress files or `post_content`.
+
+Recommended future helper:
+
+```php
+/**
+ * Convert content to block arrays and serialized block markup in one pass.
+ *
+ * @return array{blocks: array<int, array<string, mixed>>, markup: string}
+ */
+function bfb_to_block_document( string $content, string $from ): array;
+```
+
+Implementation should compose the first-class helper:
+
+```php
+$blocks = bfb_to_blocks( $content, $from );
+return array(
+    'blocks' => $blocks,
+    'markup' => serialize_blocks( $blocks ),
+);
+```
+
+This avoids double conversion without changing `bfb_convert()` from a string-returning universal converter.
+
+### 4. Metadata preservation contract
+
+BFB should document the metadata contract, but the transform details stay in html-to-blocks-converter.
+
+For HTML to Blocks, BFB's stable contract should be:
+
+- BFB returns WordPress block arrays compatible with `serialize_blocks()` and `parse_blocks()`.
+- Source `class` attributes that html-to-blocks-converter maps into block attributes remain in `attrs` and are serialized by WordPress core.
+- Source `style` attributes that html-to-blocks-converter maps into block attributes remain in `attrs` and are serialized by WordPress core.
+- Source anchors / IDs that html-to-blocks-converter maps into block attributes remain in `attrs` and are serialized by WordPress core.
+- BFB does not promise semantic inference beyond the attributes emitted by the active adapter.
+- Per-block mapping rules and fidelity fixes belong in html-to-blocks-converter tests and releases.
+
+That gives compiler consumers a stable integration target without moving transform ownership into BFB.
+
+## Recommended Sequence
+
+1. Document this surface now.
+2. Add `bfb_to_blocks()` when the first compiler consumer needs block arrays directly.
+3. Add `bfb_to_block_document()` if callers repeatedly need arrays plus serialized markup from the same source.
+4. Add `wp bfb convert` after the PHP helpers settle, using the helpers internally.


### PR DESCRIPTION
## Summary

- Documents the recommended BFB public surface for future FSE/site compiler consumers.
- Keeps this issue design-only: no FSE inference, no h2bc transform movement, and no dependency on Data Machine or Intelligence.

## Changes

- Adds `docs/fse-compiler-surface.md` with answers for the four compiler-surface questions in #29.
- Recommends future `bfb_to_blocks()` and `bfb_to_block_document()` helpers while keeping `bfb_convert()` string-returning.
- Defers `wp bfb convert` until the PHP helper surface is stable.
- Documents the metadata-preservation boundary: BFB preserves adapter-emitted block attributes; h2bc owns per-block transform fidelity.
- Adds a README pointer to the design note.

## Tests

- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@design-fse-compiler-surface`

Refs #29

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the compiler-surface design note, README pointer, and PR description from the existing BFB API/docs and issue requirements.
