### PR TITLE
test: cover bundled h2bc transform delegation

### DIFF
--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -59,6 +59,48 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * HTML input should delegate to BFB's bundled, vendor-prefixed h2bc copy.
+	 */
+	public function test_html_to_blocks_delegates_to_bundled_h2bc_for_representative_fixtures(): void {
+		$this->assertTrue(
+			function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ),
+			'BFB package mode should expose the vendor-prefixed h2bc raw handler.'
+		);
+
+		$fixtures = array(
+			'heading paragraph baseline' => array(
+				'html'   => '<h2>Delegated Heading</h2><p>Delegated paragraph.</p>',
+				'blocks' => array( 'core/heading', 'core/paragraph' ),
+			),
+			'recursive nested transforms' => array(
+				'html'   => '<ul><li>One<ul><li>Nested</li></ul></li></ul>'
+					. '<blockquote><p>Quoted</p></blockquote>'
+					. '<table><tbody><tr><td>Cell</td></tr></tbody></table>',
+				'blocks' => array( 'core/list', 'core/list-item', 'core/quote', 'core/paragraph', 'core/table' ),
+			),
+			'image code separator transforms' => array(
+				'html'   => '<figure><img src="https://example.com/image.jpg" alt="Example"><figcaption>Caption</figcaption></figure>'
+					. '<pre><code class="language-php">echo "hi";</code></pre>'
+					. '<hr class="is-style-wide">',
+				'blocks' => array( 'core/image', 'core/code', 'core/separator' ),
+			),
+			'unsupported safe fallback' => array(
+				'html'   => '<iframe src="https://example.com/embed"></iframe>',
+				'blocks' => array( 'core/html' ),
+			),
+		);
+
+		foreach ( $fixtures as $label => $fixture ) {
+			$blocks = $this->blocks_from( $fixture['html'], 'html' );
+			$flat   = $this->flatten_blocks( $blocks );
+
+			foreach ( $fixture['blocks'] as $block_name ) {
+				$this->assertContains( $block_name, $flat, "{$label} should include {$block_name}." );
+			}
+		}
+	}
+
+	/**
 	 * Markdown input should use CommonMark/GFM, then the same HTML adapter path.
 	 */
 	public function test_markdown_to_blocks_covers_commonmark_and_gfm_paths(): void {


### PR DESCRIPTION
## Summary
- Add fixture-driven BFB integration coverage for `bfb_convert( $html, 'html', 'blocks' )` delegating to bundled h2bc.
- Pin the vendor-prefixed h2bc raw handler path so package-mode autoload/scoping regressions fail in BFB's suite.

## Changes
- Adds a representative HTML-to-blocks smoke covering baseline heading/paragraph, recursive list/quote/table transforms, image/code/separator transforms, and unsupported HTML fallback.
- Keeps transform implementation out of BFB; the test only verifies cross-package delegation and serialized block output.

## Tests
- `homeboy test block-format-bridge --path "/Users/chubes/Developer/block-format-bridge@test-h2bc-expanded-transform-integration"`
- `php -l tests/BFBConversionUnitTest.php`
- `homeboy lint block-format-bridge --path "/Users/chubes/Developer/block-format-bridge@test-h2bc-expanded-transform-integration"` currently exits before findings with `/Users/chubes/.config/homeboy/extensions/wordpress/scripts/lint/lint-runner.sh: line 114: PLUGIN_PATH: unbound variable`.

Closes #27

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and verifying the BFB integration smoke coverage; Chris remains responsible for review and merge.
