### PR TITLE
test: cover expanded h2bc transforms

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "b03b4b402805e49a28aa06fbab771d41673c49ea"
+                "reference": "a85ac513b77c7960cf3a0b922f3c8373b4cfc701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/b03b4b402805e49a28aa06fbab771d41673c49ea",
-                "reference": "b03b4b402805e49a28aa06fbab771d41673c49ea",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/a85ac513b77c7960cf3a0b922f3c8373b4cfc701",
+                "reference": "a85ac513b77c7960cf3a0b922f3c8373b4cfc701",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-04-27T15:51:50+00:00"
+            "time": "2026-04-27T18:34:23+00:00"
         },
         {
             "name": "fidry/console",

--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "a25eb44a5ab19dca714fe59e0779e378e54faad3"
+                "reference": "b03b4b402805e49a28aa06fbab771d41673c49ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/a25eb44a5ab19dca714fe59e0779e378e54faad3",
-                "reference": "a25eb44a5ab19dca714fe59e0779e378e54faad3",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/b03b4b402805e49a28aa06fbab771d41673c49ea",
+                "reference": "b03b4b402805e49a28aa06fbab771d41673c49ea",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-04-26T19:21:39+00:00"
+            "time": "2026-04-27T15:51:50+00:00"
         },
         {
             "name": "fidry/console",

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -26,6 +26,9 @@ return [
 		'WP_REST_Request',
 		'WP_REST_Response',
 	],
+	'exclude-functions' => [
+		'do_action',
+	],
 	// Disable php-scoper's default class_alias emission so the build does
 	// NOT write `\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_*',
 	// 'HTML_To_Blocks_*', false)` shims back to the bare global names.

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -147,6 +147,7 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 			'audio'     => array( '<audio><source src="clip.mp3"></audio>', array( 'core/audio' ) ),
 			'gallery'   => array( '<div class="gallery columns-2"><figure><img src="a.jpg" alt="A" class="wp-image-10"><figcaption>Caption A</figcaption></figure><figure><img src="b.jpg" alt="B"><figcaption>Caption B</figcaption></figure></div>', array( 'core/gallery' ) ),
 			'mediaText' => array( '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Copy</p></div></div>', array( 'core/media-text' ) ),
+			'file'      => array( '<a href="https://example.com/report.pdf">Download report</a>', array( 'core/file' ) ),
 			'embed'     => array( '<iframe src="https://www.youtube.com/embed/abc123"></iframe>', array( 'core/embed' ) ),
 		);
 

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -101,6 +101,103 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * BFB should expose h2bc's expanded layout transforms through bfb_convert().
+	 */
+	public function test_html_to_blocks_covers_expanded_layout_transforms(): void {
+		$fixtures = array(
+			'group'   => array( '<section id="intro" class="intro-section"><h2>Intro</h2><p>Hello</p></section>', array( 'core/group' ) ),
+			'columns' => array( '<div class="row"><div class="col-md-6"><p>Left</p></div><div class="col-md-6"><p>Right</p></div></div>', array( 'core/columns', 'core/column' ) ),
+			'cover'   => array( '<section id="hero" class="hero" style="background-image: url(/hero.jpg); background-color: #123456;"><h1>Launch</h1></section>', array( 'core/cover' ) ),
+			'spacer'  => array( '<div class="spacer" style="height: 48px"></div>', array( 'core/spacer' ) ),
+		);
+
+		foreach ( $fixtures as $label => $fixture ) {
+			$flat = $this->flatten_blocks( $this->blocks_from( $fixture[0], 'html' ) );
+			foreach ( $fixture[1] as $block_name ) {
+				$this->assertContains( $block_name, $flat, "{$label} should include {$block_name}." );
+			}
+		}
+	}
+
+	/**
+	 * BFB should expose h2bc's expanded action and text transforms through bfb_convert().
+	 */
+	public function test_html_to_blocks_covers_expanded_action_text_transforms(): void {
+		$fixtures = array(
+			'button'    => array( '<a class="wp-block-button__link" href="/signup">Sign up</a>', array( 'core/buttons', 'core/button' ) ),
+			'details'   => array( '<details><summary>More <strong>info</strong></summary><p>Nested copy</p></details>', array( 'core/details' ) ),
+			'pullquote' => array( '<blockquote class="wp-block-pullquote"><p>Big line</p><cite>Author</cite></blockquote>', array( 'core/pullquote' ) ),
+			'verse'     => array( "<pre class=\"wp-block-verse\">Line 1\nLine 2<br>Line 3</pre>", array( 'core/verse' ) ),
+		);
+
+		foreach ( $fixtures as $label => $fixture ) {
+			$flat = $this->flatten_blocks( $this->blocks_from( $fixture[0], 'html' ) );
+			foreach ( $fixture[1] as $block_name ) {
+				$this->assertContains( $block_name, $flat, "{$label} should include {$block_name}." );
+			}
+		}
+	}
+
+	/**
+	 * BFB should expose h2bc's expanded media and embed transforms through bfb_convert().
+	 */
+	public function test_html_to_blocks_covers_expanded_media_embed_transforms(): void {
+		$fixtures = array(
+			'video'     => array( '<video src="movie.mp4" poster="poster.jpg" controls></video>', array( 'core/video' ) ),
+			'audio'     => array( '<audio><source src="clip.mp3"></audio>', array( 'core/audio' ) ),
+			'gallery'   => array( '<div class="gallery columns-2"><figure><img src="a.jpg" alt="A" class="wp-image-10"><figcaption>Caption A</figcaption></figure><figure><img src="b.jpg" alt="B"><figcaption>Caption B</figcaption></figure></div>', array( 'core/gallery' ) ),
+			'mediaText' => array( '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Copy</p></div></div>', array( 'core/media-text' ) ),
+			'embed'     => array( '<iframe src="https://www.youtube.com/embed/abc123"></iframe>', array( 'core/embed' ) ),
+		);
+
+		foreach ( $fixtures as $label => $fixture ) {
+			$flat = $this->flatten_blocks( $this->blocks_from( $fixture[0], 'html' ) );
+			foreach ( $fixture[1] as $block_name ) {
+				$this->assertContains( $block_name, $flat, "{$label} should include {$block_name}." );
+			}
+		}
+	}
+
+	/**
+	 * Unsupported embeds should stay observable and preserve their HTML fallback.
+	 */
+	public function test_html_to_blocks_emits_unsupported_fallback_hook(): void {
+		$this->ensure_block_registered( 'core/html' );
+
+		$fallbacks = array();
+		$listener  = static function ( string $html, array $context, array $block ) use ( &$fallbacks ): void {
+			$fallbacks[] = array(
+				'html'    => $html,
+				'context' => $context,
+				'block'   => $block,
+			);
+		};
+
+		add_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10, 3 );
+		try {
+			$blocks = $this->blocks_from( '<iframe src="https://example.com/widget"></iframe>', 'html' );
+		} finally {
+			remove_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10 );
+		}
+
+		$this->assertSame( 'core/html', $blocks[0]['blockName'] ?? null );
+		$this->assertNotEmpty( $fallbacks, 'Unsupported fallback hook should fire.' );
+		$this->assertSame( 'core/html', $fallbacks[0]['block']['blockName'] ?? null );
+		$this->assertStringContainsString( 'https://example.com/widget', $fallbacks[0]['html'] ?? '' );
+	}
+
+	/**
+	 * The bundled artifact should include h2bc's file-link transform.
+	 */
+	public function test_bundled_h2bc_artifact_includes_file_transform(): void {
+		$registry_source = file_get_contents( BFB_PATH . 'vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php' );
+
+		$this->assertIsString( $registry_source );
+		$this->assertStringContainsString( "'blockName' => 'core/file'", $registry_source );
+		$this->assertStringContainsString( 'is_file_link', $registry_source );
+	}
+
+	/**
 	 * Markdown input should use CommonMark/GFM, then the same HTML adapter path.
 	 */
 	public function test_markdown_to_blocks_covers_commonmark_and_gfm_paths(): void {
@@ -242,5 +339,19 @@ MARKDOWN;
 		}
 
 		return $names;
+	}
+
+	/**
+	 * Ensure optional core blocks exist in the minimal Playground test registry.
+	 *
+	 * @param string $name Block name.
+	 */
+	private function ensure_block_registered( string $name ): void {
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( $name ) ) {
+			return;
+		}
+
+		register_block_type( $name, array() );
 	}
 }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
@@ -73,6 +73,13 @@ class HTML_To_Blocks_Block_Factory
             case 'core/list-item':
                 $content = $attributes['content'] ?? '';
                 return '<li>' . $content . '</li>';
+            case 'core/button':
+                return self::generate_button_html($attributes);
+            case 'core/pullquote':
+                return self::generate_pullquote_html($attributes);
+            case 'core/verse':
+                $content = $attributes['content'] ?? '';
+                return '<pre class="wp-block-verse">' . $content . '</pre>';
             case 'core/image':
                 return self::generate_image_html($attributes);
             case 'core/code':
@@ -93,9 +100,47 @@ class HTML_To_Blocks_Block_Factory
                 return '<hr class="' . esc_attr($class) . '"/>';
             case 'core/table':
                 return self::generate_table_html($attributes);
+            case 'core/video':
+                return self::generate_video_html($attributes);
+            case 'core/audio':
+                return self::generate_audio_html($attributes);
+            case 'core/file':
+                return self::generate_file_html($attributes);
+            case 'core/embed':
+                return self::generate_embed_html($attributes);
             default:
                 return '';
         }
+    }
+    /**
+     * Generates HTML for button block.
+     *
+     * @param array $attributes Block attributes.
+     * @return string Button HTML.
+     */
+    private static function generate_button_html($attributes)
+    {
+        $text = $attributes['text'] ?? '';
+        $url = $attributes['url'] ?? '';
+        $rel = !empty($attributes['rel']) ? ' rel="' . esc_attr($attributes['rel']) . '"' : '';
+        $target = !empty($attributes['linkTarget']) ? ' target="' . esc_attr($attributes['linkTarget']) . '"' : '';
+        $class_name = 'wp-block-button';
+        if (!empty($attributes['className'])) {
+            $class_name .= ' ' . $attributes['className'];
+        }
+        return '<div class="' . esc_attr($class_name) . '"><a class="wp-block-button__link wp-element-button" href="' . esc_url($url) . '"' . $target . $rel . '>' . $text . '</a></div>';
+    }
+    /**
+     * Generates HTML for pullquote block.
+     *
+     * @param array $attributes Block attributes.
+     * @return string Pullquote HTML.
+     */
+    private static function generate_pullquote_html($attributes)
+    {
+        $value = $attributes['value'] ?? '';
+        $citation = !empty($attributes['citation']) ? '<cite>' . $attributes['citation'] . '</cite>' : '';
+        return '<figure class="wp-block-pullquote"><blockquote>' . $value . $citation . '</blockquote></figure>';
     }
     /**
      * Generates HTML for image block
@@ -179,6 +224,104 @@ class HTML_To_Blocks_Block_Factory
         return $html;
     }
     /**
+     * Generates HTML for a video block.
+     *
+     * @param array $attributes Block attributes.
+     * @return string Block HTML.
+     */
+    private static function generate_video_html($attributes)
+    {
+        $src = $attributes['src'] ?? '';
+        if ($src === '') {
+            return '';
+        }
+        $attrs = ' controls';
+        foreach (['autoplay', 'loop', 'muted', 'playsInline'] as $flag) {
+            if (!empty($attributes[$flag])) {
+                $attrs .= ' ' . \strtolower($flag === 'playsInline' ? 'playsinline' : $flag);
+            }
+        }
+        foreach (['poster', 'preload'] as $key) {
+            if (!empty($attributes[$key])) {
+                $attrs .= ' ' . $key . '="' . esc_attr($attributes[$key]) . '"';
+            }
+        }
+        $html = '<figure class="wp-block-video"><video src="' . esc_url($src) . '"' . $attrs . '></video>';
+        if (!empty($attributes['caption'])) {
+            $html .= '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
+        }
+        $html .= '</figure>';
+        return $html;
+    }
+    /**
+     * Generates HTML for an audio block.
+     *
+     * @param array $attributes Block attributes.
+     * @return string Block HTML.
+     */
+    private static function generate_audio_html($attributes)
+    {
+        $src = $attributes['src'] ?? '';
+        if ($src === '') {
+            return '';
+        }
+        $attrs = ' controls';
+        foreach (['autoplay', 'loop'] as $flag) {
+            if (!empty($attributes[$flag])) {
+                $attrs .= ' ' . $flag;
+            }
+        }
+        if (!empty($attributes['preload'])) {
+            $attrs .= ' preload="' . esc_attr($attributes['preload']) . '"';
+        }
+        $html = '<figure class="wp-block-audio"><audio src="' . esc_url($src) . '"' . $attrs . '></audio>';
+        if (!empty($attributes['caption'])) {
+            $html .= '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
+        }
+        $html .= '</figure>';
+        return $html;
+    }
+    /**
+     * Generates HTML for a file block.
+     *
+     * @param array $attributes Block attributes.
+     * @return string Block HTML.
+     */
+    private static function generate_file_html($attributes)
+    {
+        $href = $attributes['href'] ?? $attributes['textLinkHref'] ?? '';
+        if ($href === '') {
+            return '';
+        }
+        $name = $attributes['fileName'] ?? \basename(\strtok($href, '?#'));
+        $target = !empty($attributes['textLinkTarget']) ? ' target="' . esc_attr($attributes['textLinkTarget']) . '"' : '';
+        $html = '<div class="wp-block-file"><a href="' . esc_url($href) . '"' . $target . '>' . $name . '</a>';
+        if (!isset($attributes['showDownloadButton']) || $attributes['showDownloadButton']) {
+            $html .= '<a href="' . esc_url($href) . '" class="wp-block-file__button wp-element-button" download>Download</a>';
+        }
+        $html .= '</div>';
+        return $html;
+    }
+    /**
+     * Generates HTML for an embed block.
+     *
+     * @param array $attributes Block attributes.
+     * @return string Block HTML.
+     */
+    private static function generate_embed_html($attributes)
+    {
+        $url = $attributes['url'] ?? '';
+        if ($url === '') {
+            return '';
+        }
+        $provider = $attributes['providerNameSlug'] ?? '';
+        $class = 'wp-block-embed';
+        if ($provider !== '') {
+            $class .= ' is-provider-' . sanitize_html_class($provider) . ' wp-block-embed-' . sanitize_html_class($provider);
+        }
+        return '<figure class="' . esc_attr($class) . '"><div class="wp-block-embed__wrapper">' . esc_url($url) . '</div></figure>';
+    }
+    /**
      * Generates wrapper HTML for blocks with inner blocks
      *
      * @param string $name       Block name
@@ -197,12 +340,33 @@ class HTML_To_Blocks_Block_Factory
                 return ['opening' => '<li>' . $content, 'closing' => '</li>'];
             case 'core/quote':
                 return ['opening' => '<blockquote class="wp-block-quote">', 'closing' => '</blockquote>'];
+            case 'core/buttons':
+                return ['opening' => '<div class="wp-block-buttons">', 'closing' => '</div>'];
+            case 'core/details':
+                $summary = $attributes['summary'] ?? '';
+                return ['opening' => '<details class="wp-block-details"><summary>' . $summary . '</summary>', 'closing' => '</details>'];
             case 'core/group':
                 return ['opening' => '<div class="wp-block-group">', 'closing' => '</div>'];
             case 'core/column':
                 return ['opening' => '<div class="wp-block-column">', 'closing' => '</div>'];
             case 'core/columns':
                 return ['opening' => '<div class="wp-block-columns">', 'closing' => '</div>'];
+            case 'core/gallery':
+                $class = 'wp-block-gallery has-nested-images columns-default is-cropped';
+                if (!empty($attributes['columns'])) {
+                    $class = 'wp-block-gallery has-nested-images columns-' . (int) $attributes['columns'] . ' is-cropped';
+                }
+                return ['opening' => '<figure class="' . esc_attr($class) . '">', 'closing' => '</figure>'];
+            case 'core/media-text':
+                $media_url = $attributes['mediaUrl'] ?? '';
+                $media_type = $attributes['mediaType'] ?? 'image';
+                $media_alt = esc_attr($attributes['mediaAlt'] ?? '');
+                $media_html = $media_type === 'video' ? '<video src="' . esc_url($media_url) . '" controls></video>' : '<img src="' . esc_url($media_url) . '" alt="' . $media_alt . '"/>';
+                $class = 'wp-block-media-text is-stacked-on-mobile';
+                if (($attributes['mediaPosition'] ?? 'left') === 'right') {
+                    $class .= ' has-media-on-the-right';
+                }
+                return ['opening' => '<div class="' . esc_attr($class) . '"><figure class="wp-block-media-text__media">' . $media_html . '</figure><div class="wp-block-media-text__content">', 'closing' => '</div></div>'];
             default:
                 return ['opening' => '', 'closing' => ''];
         }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php
@@ -117,7 +117,7 @@ if (!\class_exists('BlockFormatBridge\Vendor\HTML_To_Blocks_Versions', \false)) 
              *
              * @param string $version Loaded version.
              */
-            do_action('html_to_blocks_loaded', $version);
+            \do_action('html_to_blocks_loaded', $version);
         }
     }
 }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -25,11 +25,260 @@ class HTML_To_Blocks_Transform_Registry
         if (self::$transforms !== null) {
             return self::$transforms;
         }
-        self::$transforms = \array_merge(self::get_heading_transforms(), self::get_list_transforms(), self::get_image_transforms(), self::get_quote_transforms(), self::get_code_transforms(), self::get_preformatted_transforms(), self::get_separator_transforms(), self::get_table_transforms(), self::get_paragraph_transforms());
+        self::$transforms = \array_merge(self::get_heading_transforms(), self::get_list_transforms(), self::get_button_transforms(), self::get_media_transforms(), self::get_image_transforms(), self::get_details_transforms(), self::get_pullquote_transforms(), self::get_quote_transforms(), self::get_code_transforms(), self::get_verse_transforms(), self::get_preformatted_transforms(), self::get_separator_transforms(), self::get_table_transforms(), self::get_layout_transforms(), self::get_paragraph_transforms());
         \usort(self::$transforms, function ($a, $b) {
             return ($a['priority'] ?? 10) - ($b['priority'] ?? 10);
         });
         return self::$transforms;
+    }
+    /**
+     * Media and embed transforms for high-confidence static HTML patterns.
+     *
+     * @return array Transform definitions
+     */
+    private static function get_media_transforms()
+    {
+        return [['blockName' => 'core/gallery', 'priority' => 8, 'isMatch' => function ($element) {
+            return self::is_gallery_element($element);
+        }, 'transform' => function ($element) {
+            return self::create_gallery_block($element);
+        }], ['blockName' => 'core/media-text', 'priority' => 8, 'isMatch' => function ($element) {
+            $class = $element->has_attribute('class') ? $element->get_attribute('class') : '';
+            return \preg_match('/(?:^|\s)(?:wp-block-media-text|media-text)(?:$|\s)/i', $class) === 1 && ($element->query_selector('img') || $element->query_selector('video'));
+        }, 'transform' => function ($element, $handler) {
+            return self::create_media_text_block($element, $handler);
+        }], ['blockName' => 'core/video', 'priority' => 9, 'isMatch' => function ($element) {
+            $video = $element->get_tag_name() === 'VIDEO' ? $element : $element->query_selector('video');
+            return $video && self::get_media_src($video) !== '';
+        }, 'transform' => function ($element) {
+            $video = $element->get_tag_name() === 'VIDEO' ? $element : $element->query_selector('video');
+            $attributes = self::get_media_attributes($video, ['src', 'poster', 'preload', 'autoplay', 'controls', 'loop', 'muted', 'playsInline']);
+            if ($element->get_tag_name() === 'FIGURE') {
+                $caption = $element->query_selector('figcaption');
+                if ($caption) {
+                    $attributes['caption'] = $caption->get_inner_html();
+                }
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/video', $attributes);
+        }], ['blockName' => 'core/audio', 'priority' => 9, 'isMatch' => function ($element) {
+            $audio = $element->get_tag_name() === 'AUDIO' ? $element : $element->query_selector('audio');
+            return $audio && self::get_media_src($audio) !== '';
+        }, 'transform' => function ($element) {
+            $audio = $element->get_tag_name() === 'AUDIO' ? $element : $element->query_selector('audio');
+            $attributes = self::get_media_attributes($audio, ['src', 'preload', 'autoplay', 'loop']);
+            if ($element->get_tag_name() === 'FIGURE') {
+                $caption = $element->query_selector('figcaption');
+                if ($caption) {
+                    $attributes['caption'] = $caption->get_inner_html();
+                }
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/audio', $attributes);
+        }], ['blockName' => 'core/file', 'priority' => 9, 'isMatch' => function ($element) {
+            return $element->get_tag_name() === 'A' && $element->has_attribute('href') && self::is_file_link($element);
+        }, 'transform' => function ($element) {
+            $attributes = ['href' => $element->get_attribute('href'), 'textLinkHref' => $element->get_attribute('href'), 'fileName' => $element->get_inner_html(), 'showDownloadButton' => \true];
+            if ($element->has_attribute('target')) {
+                $attributes['textLinkTarget'] = $element->get_attribute('target');
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/file', $attributes);
+        }], ['blockName' => 'core/embed', 'priority' => 9, 'isMatch' => function ($element) {
+            return $element->get_tag_name() === 'IFRAME' && $element->has_attribute('src') && self::get_embed_provider_slug($element->get_attribute('src')) !== '';
+        }, 'transform' => function ($element) {
+            $src = $element->get_attribute('src');
+            $attributes = ['url' => self::normalise_embed_url($src), 'type' => 'rich', 'providerNameSlug' => self::get_embed_provider_slug($src), 'responsive' => \true];
+            return HTML_To_Blocks_Block_Factory::create_block('core/embed', $attributes);
+        }]];
+    }
+    /**
+     * Checks whether an element is a high-confidence gallery wrapper.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+     * @return bool
+     */
+    private static function is_gallery_element($element): bool
+    {
+        $class = $element->has_attribute('class') ? $element->get_attribute('class') : '';
+        if (\preg_match('/(?:^|\s)(?:wp-block-gallery|blocks-gallery-grid|gallery|image-grid)(?:$|\s)/i', $class) !== 1) {
+            return \false;
+        }
+        return \count($element->query_selector_all('img')) > 1;
+    }
+    /**
+     * Creates a gallery block containing image inner blocks.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Gallery wrapper.
+     * @return array Block array.
+     */
+    private static function create_gallery_block($element): array
+    {
+        $images = $element->query_selector_all('img');
+        $captions = $element->query_selector_all('figcaption');
+        $inner_blocks = [];
+        $ids = [];
+        foreach ($images as $index => $img) {
+            $caption = isset($captions[$index]) ? $captions[$index]->get_inner_html() : '';
+            $image_block = self::create_image_block_from_img($img, $caption);
+            $inner_blocks[] = $image_block;
+            if (isset($image_block['attrs']['id'])) {
+                $ids[] = $image_block['attrs']['id'];
+            }
+        }
+        $attributes = [];
+        if (!empty($ids)) {
+            $attributes['ids'] = $ids;
+        }
+        if (\preg_match('/(?:^|\s)columns-(\d+)(?:$|\s)/', $element->get_attribute('class') ?? '', $matches)) {
+            $attributes['columns'] = \min(8, \max(1, (int) $matches[1]));
+        }
+        return HTML_To_Blocks_Block_Factory::create_block('core/gallery', $attributes, $inner_blocks);
+    }
+    /**
+     * Creates an image block from an img element.
+     *
+     * @param HTML_To_Blocks_HTML_Element $img     Image element.
+     * @param string                      $caption Optional caption HTML.
+     * @return array Block array.
+     */
+    private static function create_image_block_from_img($img, string $caption = ''): array
+    {
+        $attributes = ['url' => $img->get_attribute('src') ?? ''];
+        if ($img->has_attribute('alt')) {
+            $attributes['alt'] = $img->get_attribute('alt');
+        }
+        if ($caption !== '') {
+            $attributes['caption'] = $caption;
+        }
+        if ($img->has_attribute('class') && \preg_match('/(?:^|\s)wp-image-(\d+)(?:$|\s)/', $img->get_attribute('class'), $matches)) {
+            $attributes['id'] = (int) $matches[1];
+        }
+        return HTML_To_Blocks_Block_Factory::create_block('core/image', $attributes);
+    }
+    /**
+     * Creates a media-text block from a recognized two-column wrapper.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Media-text wrapper.
+     * @param callable                    $handler Recursive raw handler.
+     * @return array Block array.
+     */
+    private static function create_media_text_block($element, $handler): array
+    {
+        $media = $element->query_selector('img') ?: $element->query_selector('video');
+        $content = $element->query_selector('.wp-block-media-text__content');
+        $media_type = $media && $media->get_tag_name() === 'VIDEO' ? 'video' : 'image';
+        $attributes = ['mediaUrl' => self::get_media_src($media), 'mediaType' => $media_type, 'mediaPosition' => 'left', 'mediaWidth' => 50, 'isStackedOnMobile' => \true];
+        if ($media && $media->has_attribute('alt')) {
+            $attributes['mediaAlt'] = $media->get_attribute('alt');
+        }
+        if ($media && $media->has_attribute('class') && \preg_match('/(?:^|\s)wp-image-(\d+)(?:$|\s)/', $media->get_attribute('class'), $matches)) {
+            $attributes['mediaId'] = (int) $matches[1];
+        }
+        if (\preg_match('/(?:^|\s)has-media-on-the-right(?:$|\s)/', $element->get_attribute('class') ?? '')) {
+            $attributes['mediaPosition'] = 'right';
+        }
+        if (!$content) {
+            $children = $element->get_child_elements();
+            foreach ($children as $child) {
+                if (!$child->query_selector('img') && !$child->query_selector('video')) {
+                    $content = $child;
+                    break;
+                }
+            }
+        }
+        $inner_blocks = $content ? $handler(['HTML' => $content->get_inner_html()]) : [];
+        return HTML_To_Blocks_Block_Factory::create_block('core/media-text', $attributes, $inner_blocks);
+    }
+    /**
+     * Extracts the best media source from src or nested source tags.
+     *
+     * @param HTML_To_Blocks_HTML_Element|null $element Media element.
+     * @return string
+     */
+    private static function get_media_src($element): string
+    {
+        if (!$element) {
+            return '';
+        }
+        if ($element->has_attribute('src') && $element->get_attribute('src') !== '') {
+            return $element->get_attribute('src');
+        }
+        $source = $element->query_selector('source');
+        if ($source && $source->has_attribute('src')) {
+            return $source->get_attribute('src');
+        }
+        return '';
+    }
+    /**
+     * Extracts media attributes from a video/audio element.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Media element.
+     * @param array                       $keys    Allowed attributes.
+     * @return array
+     */
+    private static function get_media_attributes($element, array $keys): array
+    {
+        $attributes = ['src' => self::get_media_src($element)];
+        foreach ($keys as $key) {
+            $html_key = $key === 'playsInline' ? 'playsinline' : $key;
+            if ($key === 'src' || !$element->has_attribute($html_key)) {
+                continue;
+            }
+            $value = $element->get_attribute($html_key);
+            if (\in_array($key, ['autoplay', 'controls', 'loop', 'muted', 'playsInline'], \true)) {
+                $attributes[$key] = \true;
+            } else {
+                $attributes[$key] = $value;
+            }
+        }
+        return $attributes;
+    }
+    /**
+     * Checks whether a link points to a document/archive download.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Link element.
+     * @return bool
+     */
+    private static function is_file_link($element): bool
+    {
+        $href = \strtolower(\strtok($element->get_attribute('href'), '?#'));
+        if (\preg_match('/\.(?:pdf|docx?|pptx?|xlsx?|zip|rar|7z|txt|csv|ics|epub)$/', $href)) {
+            return \true;
+        }
+        $class = $element->has_attribute('class') ? $element->get_attribute('class') : '';
+        return $element->has_attribute('download') && \preg_match('/(?:^|\s)(?:download|file)(?:$|\s)/i', $class) === 1;
+    }
+    /**
+     * Infers a conservative core/embed provider slug from a URL.
+     *
+     * @param string $url Embed URL.
+     * @return string
+     */
+    private static function get_embed_provider_slug(string $url): string
+    {
+        $host = \parse_url($url, \PHP_URL_HOST);
+        $host = $host ? \strtolower(\preg_replace('/^www\./', '', $host)) : '';
+        $providers = ['youtube.com' => 'youtube', 'youtu.be' => 'youtube', 'vimeo.com' => 'vimeo', 'soundcloud.com' => 'soundcloud', 'spotify.com' => 'spotify', 'twitter.com' => 'twitter', 'x.com' => 'twitter', 'instagram.com' => 'instagram', 'tiktok.com' => 'tiktok'];
+        foreach ($providers as $needle => $slug) {
+            if ($host === $needle || \substr($host, -\strlen('.' . $needle)) === '.' . $needle) {
+                return $slug;
+            }
+        }
+        return '';
+    }
+    /**
+     * Converts common iframe embed URLs back to their public oEmbed URL.
+     *
+     * @param string $url Iframe URL.
+     * @return string
+     */
+    private static function normalise_embed_url(string $url): string
+    {
+        if (\preg_match('#youtube\.com/embed/([^?&/]+)#i', $url, $matches)) {
+            return 'https://www.youtube.com/watch?v=' . $matches[1];
+        }
+        if (\preg_match('#player\.vimeo\.com/video/(\d+)#i', $url, $matches)) {
+            return 'https://vimeo.com/' . $matches[1];
+        }
+        return $url;
     }
     /**
      * core/heading transforms - h1-h6 elements
@@ -196,6 +445,108 @@ class HTML_To_Blocks_Transform_Registry
         return null;
     }
     /**
+     * core/buttons and core/button transforms - explicit button-like anchors.
+     *
+     * @return array Transform definitions
+     */
+    private static function get_button_transforms()
+    {
+        return [['blockName' => 'core/buttons', 'priority' => 9, 'selector' => 'a', 'isMatch' => function ($element) {
+            return $element->get_tag_name() === 'A' && self::is_button_like_anchor($element);
+        }, 'transform' => function ($element) {
+            return self::create_buttons_block_from_anchor($element);
+        }], ['blockName' => 'core/buttons', 'priority' => 9, 'selector' => 'p', 'isMatch' => function ($element) {
+            $anchor = self::get_single_anchor_from_html($element->get_inner_html());
+            return $element->get_tag_name() === 'P' && $anchor && self::is_button_like_anchor($anchor);
+        }, 'transform' => function ($element) {
+            $anchor = self::get_single_anchor_from_html($element->get_inner_html());
+            return self::create_buttons_block_from_anchor($anchor);
+        }]];
+    }
+    /**
+     * Gets a single anchor element when the HTML is only one anchor.
+     *
+     * @param string $html Inner HTML to inspect.
+     * @return HTML_To_Blocks_HTML_Element|null Anchor element or null.
+     */
+    private static function get_single_anchor_from_html(string $html): ?HTML_To_Blocks_HTML_Element
+    {
+        $html = \trim($html);
+        if (!\preg_match('/^<a\s([^>]*)>(.*)<\/a>$/is', $html, $matches)) {
+            return null;
+        }
+        $attributes = self::parse_attribute_string($matches[1]);
+        return new HTML_To_Blocks_HTML_Element('a', $attributes, $html, \trim($matches[2]));
+    }
+    /**
+     * Parses an HTML attribute string into an associative array.
+     *
+     * @param string $attribute_string Raw attribute string.
+     * @return array Parsed attributes.
+     */
+    private static function parse_attribute_string(string $attribute_string): array
+    {
+        $attributes = [];
+        if (\preg_match_all('/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/', $attribute_string, $matches, \PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $attributes[\strtolower($match[1])] = \html_entity_decode($match[3] !== '' ? $match[3] : ($match[4] !== '' ? $match[4] : $match[5]), \ENT_QUOTES, 'UTF-8');
+            }
+        }
+        return $attributes;
+    }
+    /**
+     * Checks if an anchor explicitly carries button intent.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Anchor element.
+     * @return bool True when the anchor is button-like.
+     */
+    private static function is_button_like_anchor($element): bool
+    {
+        if (!$element || $element->get_tag_name() !== 'A') {
+            return \false;
+        }
+        $class_name = $element->get_attribute('class') ?? '';
+        return \preg_match('/(?:^|\s)(?:button|btn|wp-block-button__link|wp-element-button)(?:$|\s|-)/i', $class_name) === 1;
+    }
+    /**
+     * Creates a buttons wrapper with one button child from an anchor.
+     *
+     * @param HTML_To_Blocks_HTML_Element $anchor Anchor element.
+     * @return array Block array.
+     */
+    private static function create_buttons_block_from_anchor($anchor): array
+    {
+        $attributes = ['text' => $anchor->get_inner_html()];
+        if ($anchor->has_attribute('href')) {
+            $attributes['url'] = $anchor->get_attribute('href');
+        }
+        if ($anchor->has_attribute('target')) {
+            $attributes['linkTarget'] = $anchor->get_attribute('target');
+        }
+        if ($anchor->has_attribute('rel')) {
+            $attributes['rel'] = $anchor->get_attribute('rel');
+        }
+        if ($anchor->has_attribute('class')) {
+            $attributes['className'] = self::button_block_class_name($anchor->get_attribute('class'));
+        }
+        $button = HTML_To_Blocks_Block_Factory::create_block('core/button', $attributes);
+        return HTML_To_Blocks_Block_Factory::create_block('core/buttons', [], [$button]);
+    }
+    /**
+     * Converts anchor classes to button block classes.
+     *
+     * @param string $class_name Anchor class attribute.
+     * @return string Button block class name.
+     */
+    private static function button_block_class_name(string $class_name): string
+    {
+        $classes = \preg_split('/\s+/', \trim($class_name));
+        $classes = \array_filter($classes, function ($class) {
+            return !\in_array($class, ['wp-block-button__link', 'wp-element-button'], \true);
+        });
+        return \trim(\implode(' ', $classes));
+    }
+    /**
      * core/image transforms - figure with img
      *
      * @return array Transform definitions
@@ -271,6 +622,52 @@ class HTML_To_Blocks_Transform_Registry
         }]];
     }
     /**
+     * core/details transforms - details elements with a summary.
+     *
+     * @return array Transform definitions
+     */
+    private static function get_details_transforms()
+    {
+        return [['blockName' => 'core/details', 'priority' => 10, 'selector' => 'details', 'isMatch' => function ($element) {
+            return $element->get_tag_name() === 'DETAILS' && \preg_match('/<summary(?:\s[^>]*)?>.*?<\/summary>/is', $element->get_inner_html()) === 1;
+        }, 'transform' => function ($element, $handler) {
+            $inner_html = $element->get_inner_html();
+            \preg_match('/<summary(?:\s[^>]*)?>(.*?)<\/summary>/is', $inner_html, $summary_matches);
+            $summary = \trim($summary_matches[1] ?? '');
+            $content_html = \trim(\preg_replace('/<summary(?:\s[^>]*)?>.*?<\/summary>/is', '', $inner_html, 1));
+            $inner_blocks = $content_html !== '' ? $handler(['HTML' => $content_html]) : [];
+            $attributes = ['summary' => $summary];
+            return HTML_To_Blocks_Block_Factory::create_block('core/details', $attributes, $inner_blocks);
+        }]];
+    }
+    /**
+     * core/pullquote transforms - explicit pullquote blockquotes.
+     *
+     * @return array Transform definitions
+     */
+    private static function get_pullquote_transforms()
+    {
+        return [['blockName' => 'core/pullquote', 'priority' => 9, 'selector' => 'blockquote', 'isMatch' => function ($element) {
+            if ($element->get_tag_name() !== 'BLOCKQUOTE' || !$element->has_attribute('class')) {
+                return \false;
+            }
+            $class_name = $element->get_attribute('class');
+            return \preg_match('/(?:^|\s)(?:wp-block-pullquote|pullquote|is-style-pullquote)(?:$|\s)/i', $class_name) === 1;
+        }, 'transform' => function ($element) {
+            $value = \trim($element->get_inner_html());
+            $citation = '';
+            if (\preg_match('/<cite(?:\s[^>]*)?>(.*?)<\/cite>/is', $value, $matches)) {
+                $citation = \trim($matches[1]);
+                $value = \trim(\preg_replace('/<cite(?:\s[^>]*)?>.*?<\/cite>/is', '', $value, 1));
+            }
+            $attributes = ['value' => $value];
+            if ($citation !== '') {
+                $attributes['citation'] = $citation;
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/pullquote', $attributes);
+        }]];
+    }
+    /**
      * core/quote transforms - blockquote elements
      *
      * @return array Transform definitions
@@ -320,6 +717,23 @@ class HTML_To_Blocks_Transform_Registry
                 }
             }
             return HTML_To_Blocks_Block_Factory::create_block('core/code', $attributes);
+        }]];
+    }
+    /**
+     * core/verse transforms - explicit verse/preformatted poetry classes.
+     *
+     * @return array Transform definitions
+     */
+    private static function get_verse_transforms()
+    {
+        return [['blockName' => 'core/verse', 'priority' => 10, 'selector' => 'pre', 'isMatch' => function ($element) {
+            if ($element->get_tag_name() !== 'PRE' || !$element->has_attribute('class')) {
+                return \false;
+            }
+            $class_name = $element->get_attribute('class');
+            return \preg_match('/(?:^|\s)(?:wp-block-verse|verse)(?:$|\s)/i', $class_name) === 1;
+        }, 'transform' => function ($element) {
+            return HTML_To_Blocks_Block_Factory::create_block('core/verse', ['content' => $element->get_inner_html()]);
         }]];
     }
     /**
@@ -476,6 +890,207 @@ class HTML_To_Blocks_Transform_Registry
             $inner_html = \substr($content, 0, $close_pos);
             $offset += $matches[0][1] + \strlen($matches[0][0]) - \strlen($content) + $close_pos + \strlen($close_tag);
             return \trim($inner_html);
+        }
+        return '';
+    }
+    /**
+     * Layout transforms - conservative wrappers only.
+     *
+     * @return array Transform definitions
+     */
+    private static function get_layout_transforms()
+    {
+        return [['blockName' => 'core/spacer', 'priority' => 11, 'isMatch' => function ($element) {
+            return self::is_spacer_element($element);
+        }, 'transform' => function ($element) {
+            $attributes = [];
+            $height = self::extract_height_value($element);
+            if ($height !== '') {
+                $attributes['height'] = $height;
+            }
+            if ($element->has_attribute('id') && $element->get_attribute('id') !== '') {
+                $attributes['anchor'] = $element->get_attribute('id');
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/spacer', $attributes);
+        }], ['blockName' => 'core/cover', 'priority' => 12, 'isMatch' => function ($element) {
+            return self::is_cover_element($element);
+        }, 'transform' => function ($element, $handler) {
+            $attributes = self::get_common_layout_attributes($element);
+            $style = $element->has_attribute('style') ? $element->get_attribute('style') : '';
+            $inner_blocks = $handler(['HTML' => $element->get_inner_html()]);
+            if (\preg_match('/background-image:\s*url\((["\']?)([^)"\']+)\1\)/i', $style, $matches)) {
+                $attributes['url'] = \trim($matches[2]);
+            }
+            $background_color = self::extract_background_color($style);
+            if ($background_color !== '') {
+                $attributes['customOverlayColor'] = $background_color;
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/cover', $attributes, $inner_blocks);
+        }], ['blockName' => 'core/columns', 'priority' => 13, 'isMatch' => function ($element) {
+            return self::is_columns_element($element);
+        }, 'transform' => function ($element, $handler) {
+            $inner_blocks = [];
+            foreach ($element->get_child_elements() as $child) {
+                if (!self::is_column_element($child)) {
+                    continue;
+                }
+                $column_attributes = self::get_common_layout_attributes($child);
+                $column_blocks = $handler(['HTML' => $child->get_inner_html()]);
+                $inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/column', $column_attributes, $column_blocks);
+            }
+            return HTML_To_Blocks_Block_Factory::create_block('core/columns', self::get_common_layout_attributes($element), $inner_blocks);
+        }], ['blockName' => 'core/column', 'priority' => 14, 'isMatch' => function ($element) {
+            return self::is_column_element($element);
+        }, 'transform' => function ($element, $handler) {
+            return HTML_To_Blocks_Block_Factory::create_block('core/column', self::get_common_layout_attributes($element), $handler(['HTML' => $element->get_inner_html()]));
+        }], ['blockName' => 'core/group', 'priority' => 15, 'isMatch' => function ($element) {
+            return self::is_group_element($element);
+        }, 'transform' => function ($element, $handler) {
+            return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), $handler(['HTML' => $element->get_inner_html()]));
+        }]];
+    }
+    /**
+     * Gets attributes shared by layout blocks.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return array Block attributes.
+     */
+    private static function get_common_layout_attributes($element): array
+    {
+        $attributes = [];
+        if ($element->has_attribute('id') && $element->get_attribute('id') !== '') {
+            $attributes['anchor'] = $element->get_attribute('id');
+        }
+        if ($element->has_attribute('class') && $element->get_attribute('class') !== '') {
+            $attributes['className'] = $element->get_attribute('class');
+        }
+        return $attributes;
+    }
+    /**
+     * Checks whether an element is a safe group wrapper.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return bool True when the element should become core/group.
+     */
+    private static function is_group_element($element): bool
+    {
+        $tag = $element->get_tag_name();
+        if ($tag === 'SECTION') {
+            return \true;
+        }
+        if (!\in_array($tag, ['DIV', 'MAIN', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER'], \true)) {
+            return \false;
+        }
+        return self::class_matches($element, '/(?:^|[-_\s])(group|section|container|wrapper|content|main|article|aside|header|footer)(?:$|[-_\s])/i');
+    }
+    /**
+     * Checks whether an element is a cover/hero wrapper.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return bool True when the element should become core/cover.
+     */
+    private static function is_cover_element($element): bool
+    {
+        $style = $element->has_attribute('style') ? $element->get_attribute('style') : '';
+        if ($style === '') {
+            return \false;
+        }
+        $has_background_image = \preg_match('/background-image:\s*url\(/i', $style) === 1;
+        $has_background_color = self::extract_background_color($style) !== '';
+        $is_hero_like = self::class_matches($element, '/(?:^|[-_\s])(hero|cover|banner|masthead)(?:$|[-_\s])/i');
+        if (!$has_background_image && !$has_background_color) {
+            return \false;
+        }
+        return $is_hero_like || $has_background_image && $element->get_tag_name() === 'SECTION';
+    }
+    /**
+     * Checks whether an element is a columns wrapper.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return bool True when the element should become core/columns.
+     */
+    private static function is_columns_element($element): bool
+    {
+        if (!\in_array($element->get_tag_name(), ['DIV', 'SECTION'], \true)) {
+            return \false;
+        }
+        if (!self::class_matches($element, '/(?:^|[-_\s])(columns|row|grid|flex)(?:$|[-_\s])/i')) {
+            return \false;
+        }
+        $column_count = 0;
+        foreach ($element->get_child_elements() as $child) {
+            if (!self::is_column_element($child)) {
+                return \false;
+            }
+            $column_count++;
+        }
+        return $column_count >= 2;
+    }
+    /**
+     * Checks whether an element is an individual column.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return bool True when the element should become core/column.
+     */
+    private static function is_column_element($element): bool
+    {
+        if (!\in_array($element->get_tag_name(), ['DIV', 'SECTION', 'ARTICLE', 'ASIDE'], \true)) {
+            return \false;
+        }
+        return self::class_matches($element, '/(?:^|[-_\s])(column|col|cell)(?:$|[-_\s]|\d)/i');
+    }
+    /**
+     * Checks whether an element is an empty explicit spacer.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return bool True when the element should become core/spacer.
+     */
+    private static function is_spacer_element($element): bool
+    {
+        if (!\in_array($element->get_tag_name(), ['DIV', 'SPAN'], \true)) {
+            return \false;
+        }
+        if (\trim(wp_strip_all_tags($element->get_inner_html())) !== '') {
+            return \false;
+        }
+        return self::class_matches($element, '/(?:^|[-_\s])(spacer|gap|separator-space)(?:$|[-_\s])/i') && self::extract_height_value($element) !== '';
+    }
+    /**
+     * Checks a source element class attribute against a pattern.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @param string                      $pattern Regex pattern.
+     * @return bool True when the class matches.
+     */
+    private static function class_matches($element, string $pattern): bool
+    {
+        $class_name = $element->has_attribute('class') ? $element->get_attribute('class') : '';
+        return $class_name !== '' && \preg_match($pattern, $class_name) === 1;
+    }
+    /**
+     * Extracts an explicit height CSS value.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The source element.
+     * @return string CSS height value or empty string.
+     */
+    private static function extract_height_value($element): string
+    {
+        $style = $element->has_attribute('style') ? $element->get_attribute('style') : '';
+        if (\preg_match('/(?:^|;)\s*height:\s*([^;]+)/i', $style, $matches)) {
+            return \trim($matches[1]);
+        }
+        return '';
+    }
+    /**
+     * Extracts a background-color CSS value.
+     *
+     * @param string $style CSS style attribute.
+     * @return string CSS color value or empty string.
+     */
+    private static function extract_background_color(string $style): string
+    {
+        if (\preg_match('/(?:^|;)\s*background(?:-color)?:\s*(?![^;]*url\()([^;]+)/i', $style, $matches)) {
+            return \trim($matches[1]);
         }
         return '';
     }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -76,11 +76,12 @@ class HTML_To_Blocks_Transform_Registry
         }], ['blockName' => 'core/file', 'priority' => 9, 'isMatch' => function ($element) {
             return $element->get_tag_name() === 'A' && $element->has_attribute('href') && self::is_file_link($element);
         }, 'transform' => function ($element) {
-            $attributes = ['href' => $element->get_attribute('href'), 'textLinkHref' => $element->get_attribute('href'), 'fileName' => $element->get_inner_html(), 'showDownloadButton' => \true];
-            if ($element->has_attribute('target')) {
-                $attributes['textLinkTarget'] = $element->get_attribute('target');
-            }
-            return HTML_To_Blocks_Block_Factory::create_block('core/file', $attributes);
+            return self::create_file_block_from_anchor($element);
+        }], ['blockName' => 'core/file', 'priority' => 9, 'isMatch' => function ($element) {
+            $anchor = $element->get_tag_name() === 'P' ? $element->query_selector('a') : null;
+            return $anchor && self::is_file_link($anchor) && \trim($element->get_inner_html()) === \trim($anchor->get_outer_html());
+        }, 'transform' => function ($element) {
+            return self::create_file_block_from_anchor($element->query_selector('a'));
         }], ['blockName' => 'core/embed', 'priority' => 9, 'isMatch' => function ($element) {
             return $element->get_tag_name() === 'IFRAME' && $element->has_attribute('src') && self::get_embed_provider_slug($element->get_attribute('src')) !== '';
         }, 'transform' => function ($element) {
@@ -245,6 +246,20 @@ class HTML_To_Blocks_Transform_Registry
         }
         $class = $element->has_attribute('class') ? $element->get_attribute('class') : '';
         return $element->has_attribute('download') && \preg_match('/(?:^|\s)(?:download|file)(?:$|\s)/i', $class) === 1;
+    }
+    /**
+     * Creates a file block from a downloadable anchor.
+     *
+     * @param HTML_To_Blocks_HTML_Element $anchor Link element.
+     * @return array Block array.
+     */
+    private static function create_file_block_from_anchor($anchor): array
+    {
+        $attributes = ['href' => $anchor->get_attribute('href'), 'textLinkHref' => $anchor->get_attribute('href'), 'fileName' => $anchor->get_inner_html(), 'showDownloadButton' => \true];
+        if ($anchor->has_attribute('target')) {
+            $attributes['textLinkTarget'] = $anchor->get_attribute('target');
+        }
+        return HTML_To_Blocks_Block_Factory::create_block('core/file', $attributes);
     }
     /**
      * Infers a conservative core/embed provider slug from a URL.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
@@ -98,12 +98,12 @@ function html_to_blocks_convert($html)
         }
         $element = HTML_To_Blocks_HTML_Element::from_html($element_html);
         if (!$element) {
-            $blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/html', ['content' => $element_html]);
+            $blocks[] = html_to_blocks_create_unsupported_html_fallback_block($element_html, ['reason' => 'element_parse_failed', 'tag_name' => $tag_name, 'occurrence' => $occurrence]);
             continue;
         }
         $raw_transform = html_to_blocks_find_transform($element, $transforms);
         if (!$raw_transform) {
-            $blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/html', ['content' => $element_html]);
+            $blocks[] = html_to_blocks_create_unsupported_html_fallback_block($element_html, ['reason' => 'no_transform', 'tag_name' => $element->get_tag_name(), 'occurrence' => $occurrence]);
         } else {
             $transform_fn = $raw_transform['transform'] ?? null;
             if ($transform_fn && \is_callable($transform_fn)) {
@@ -138,6 +138,28 @@ function html_to_blocks_convert($html)
         \error_log(\sprintf('[HTML to Blocks] Significant content loss detected | Input: %d chars | Output: %d chars | Blocks: %d | Processor error: %s | Preview: %s', $original_html_length, $output_content_length, \count($blocks), $last_error ?? 'none', \substr($html, 0, 500)));
     }
     return $blocks;
+}
+/**
+ * Creates the core/html fallback block and emits an observability hook.
+ *
+ * @param string $element_html Unsupported HTML fragment.
+ * @param array  $context      Fallback context such as reason, tag_name, and occurrence.
+ * @return array Block array.
+ */
+function html_to_blocks_create_unsupported_html_fallback_block(string $element_html, array $context = []): array
+{
+    $block = HTML_To_Blocks_Block_Factory::create_block('core/html', ['content' => $element_html]);
+    if (\function_exists('do_action')) {
+        /**
+         * Fires when h2bc falls back to core/html because no supported transform exists.
+         *
+         * @param string $element_html Unsupported HTML fragment.
+         * @param array  $context      Context including reason, tag_name, and occurrence when available.
+         * @param array  $block        The generated core/html fallback block.
+         */
+        \do_action('html_to_blocks_unsupported_html_fallback', $element_html, $context, $block);
+    }
+    return $block;
 }
 /**
  * Finds all positions of a tag's opening tags in HTML

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/RawHandlerFixturesUnitTest.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/RawHandlerFixturesUnitTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Production-shape raw-handler fixture coverage.
+ *
+ * @package HtmlToBlocksConverter
+ */
+/**
+ * Exercises literal HTML fragments through the plugin's raw handler.
+ */
+class RawHandlerFixturesUnitTest extends WP_UnitTestCase
+{
+    /**
+     * Supported static HTML fixtures should become their native core blocks.
+     */
+    public function test_supported_fixtures_convert_to_expected_blocks(): void
+    {
+        foreach ($this->supported_fixtures() as $label => $fixture) {
+            $fallbacks = array();
+            $listener = static function (string $html, array $context, array $block) use (&$fallbacks): void {
+                $fallbacks[] = array('html' => $html, 'context' => $context, 'block' => $block);
+            };
+            add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
+            try {
+                $blocks = html_to_blocks_raw_handler(array('HTML' => $fixture['html']));
+            } finally {
+                remove_action('html_to_blocks_unsupported_html_fallback', $listener, 10);
+            }
+            $this->assertSame($fixture['expected_names'], $this->flatten_block_names($blocks), "{$label} should produce expected block names.");
+            $this->assertSame(array(), $fallbacks, "{$label} should not emit unsupported HTML fallbacks.");
+            $combined_html = $this->combined_block_html($blocks);
+            foreach ($fixture['snippets'] ?? array() as $snippet) {
+                $this->assertStringContainsString($snippet, $combined_html, "{$label} should preserve {$snippet}.");
+            }
+        }
+    }
+    /**
+     * Unsupported HTML should remain observable and preserve the original fragment.
+     */
+    public function test_unsupported_fixtures_emit_fallback_context(): void
+    {
+        foreach ($this->unsupported_fixtures() as $label => $fixture) {
+            $fallbacks = array();
+            $listener = static function (string $html, array $context, array $block) use (&$fallbacks): void {
+                $fallbacks[] = array('html' => $html, 'context' => $context, 'block' => $block);
+            };
+            add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
+            try {
+                $blocks = html_to_blocks_raw_handler(array('HTML' => $fixture['html']));
+            } finally {
+                remove_action('html_to_blocks_unsupported_html_fallback', $listener, 10);
+            }
+            $this->assertSame($fixture['expected_names'], $this->flatten_block_names($blocks), "{$label} should preserve unsupported HTML as core/html.");
+            $this->assertCount(1, $fallbacks, "{$label} should emit one fallback action.");
+            $this->assertSame('no_transform', $fallbacks[0]['context']['reason'] ?? null, "{$label} should expose fallback reason.");
+            $this->assertSame($fixture['fallback_tag'], $fallbacks[0]['context']['tag_name'] ?? null, "{$label} should expose fallback tag.");
+            $this->assertSame('core/html', $fallbacks[0]['block']['blockName'] ?? null, "{$label} fallback should be core/html.");
+            $this->assertStringContainsString($fixture['snippet'], $fallbacks[0]['html'] ?? '', "{$label} fallback should include source HTML.");
+        }
+    }
+    /**
+     * Supported fixture matrix.
+     *
+     * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>
+     */
+    private function supported_fixtures(): array
+    {
+        return array('heading' => array('html' => '<h2>Fixture Heading</h2>', 'expected_names' => array('core/heading'), 'snippets' => array('Fixture Heading')), 'paragraph' => array('html' => '<p>Fixture <strong>paragraph</strong>.</p>', 'expected_names' => array('core/paragraph'), 'snippets' => array('<strong>paragraph</strong>')), 'nested-list' => array('html' => '<ul><li>One<ul><li>Child</li></ul></li><li>Two</li></ul>', 'expected_names' => array('core/list', 'core/list-item', 'core/list', 'core/list-item', 'core/list-item'), 'snippets' => array('Child')), 'quote' => array('html' => '<blockquote><p>Quote text</p><cite>Source</cite></blockquote>', 'expected_names' => array('core/quote', 'core/paragraph', 'core/paragraph'), 'snippets' => array('Source')), 'code' => array('html' => '<pre><code>const answer = 42;</code></pre>', 'expected_names' => array('core/code'), 'snippets' => array('const answer = 42;')), 'preformatted' => array('html' => '<pre>Plain preformatted text</pre>', 'expected_names' => array('core/preformatted'), 'snippets' => array('Plain preformatted text')), 'separator' => array('html' => '<hr class="is-style-wide">', 'expected_names' => array('core/separator'), 'snippets' => array('wp-block-separator')), 'table' => array('html' => '<table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Ada</td></tr></tbody></table>', 'expected_names' => array('core/table')), 'group' => array('html' => '<div class="wp-block-group"><p>Grouped copy</p></div>', 'expected_names' => array('core/group', 'core/paragraph'), 'snippets' => array('Grouped copy')), 'columns' => array('html' => '<div class="wp-block-columns"><div class="wp-block-column"><p>Left</p></div><div class="wp-block-column"><p>Right</p></div></div>', 'expected_names' => array('core/columns', 'core/column', 'core/paragraph', 'core/column', 'core/paragraph'), 'snippets' => array('Left', 'Right')), 'cover' => array('html' => '<section class="hero cover" style="background-image: url(cover.jpg)"><p>Cover text</p></section>', 'expected_names' => array('core/cover', 'core/paragraph'), 'snippets' => array('Cover text')), 'spacer' => array('html' => '<div style="height: 48px" aria-hidden="true" class="wp-block-spacer"></div>', 'expected_names' => array('core/spacer')), 'buttons' => array('html' => '<a class="wp-block-button__link wp-element-button" href="https://example.com">Click</a>', 'expected_names' => array('core/buttons', 'core/button'), 'snippets' => array('https://example.com', 'Click')), 'details' => array('html' => '<details><summary>Question</summary><p>Answer</p></details>', 'expected_names' => array('core/details', 'core/paragraph'), 'snippets' => array('Question', 'Answer')), 'pullquote' => array('html' => '<blockquote class="wp-block-pullquote"><p>Pull this</p><cite>Citation</cite></blockquote>', 'expected_names' => array('core/pullquote'), 'snippets' => array('Pull this', 'Citation')), 'verse' => array('html' => '<pre class="wp-block-verse">Line one\nLine two</pre>', 'expected_names' => array('core/verse'), 'snippets' => array('Line one', 'Line two')), 'video' => array('html' => '<video controls src="movie.mp4" poster="poster.jpg"></video>', 'expected_names' => array('core/video'), 'snippets' => array('movie.mp4', 'poster.jpg')), 'audio' => array('html' => '<audio controls><source src="clip.mp3" type="audio/mpeg"></audio>', 'expected_names' => array('core/audio'), 'snippets' => array('clip.mp3')), 'gallery' => array('html' => '<div class="gallery columns-2"><figure><img src="a.jpg" alt="A" class="wp-image-10"><figcaption>Caption A</figcaption></figure><figure><img src="b.jpg" alt="B"><figcaption>Caption B</figcaption></figure></div>', 'expected_names' => array('core/gallery', 'core/image', 'core/image'), 'snippets' => array('Caption A', 'b.jpg')), 'media-text' => array('html' => '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Media copy</p></div></div>', 'expected_names' => array('core/media-text', 'core/image', 'core/group', 'core/paragraph'), 'snippets' => array('hero.jpg', 'Media copy')), 'file' => array('html' => '<a href="https://example.com/report.pdf">Download report</a>', 'expected_names' => array('core/file'), 'snippets' => array('report.pdf', 'Download report')), 'recognized-embed' => array('html' => '<iframe src="https://www.youtube.com/embed/abc123"></iframe>', 'expected_names' => array('core/embed'), 'snippets' => array('youtube.com/watch?v=abc123')));
+    }
+    /**
+     * Unsupported fixture matrix.
+     *
+     * @return array<string,array{html:string,expected_names:string[],fallback_tag:string,snippet:string}>
+     */
+    private function unsupported_fixtures(): array
+    {
+        return array('unknown-iframe-provider' => array('html' => '<iframe src="https://example.com/widget"></iframe>', 'expected_names' => array('core/html'), 'fallback_tag' => 'IFRAME', 'snippet' => 'example.com/widget'), 'custom-element' => array('html' => '<x-card data-kind="promo">Custom payload</x-card>', 'expected_names' => array('core/html'), 'fallback_tag' => 'X-CARD', 'snippet' => 'Custom payload'), 'app-widget' => array('html' => '<div data-widget="stock-ticker"><span>AAPL</span></div>', 'expected_names' => array('core/html'), 'fallback_tag' => 'DIV', 'snippet' => 'stock-ticker'));
+    }
+    /**
+     * Flatten block names recursively.
+     *
+     * @param array<int,array<string,mixed>> $blocks Blocks.
+     * @return string[] Block names.
+     */
+    private function flatten_block_names(array $blocks): array
+    {
+        $names = array();
+        foreach ($blocks as $block) {
+            $names[] = $block['blockName'] ?? null;
+            if (!empty($block['innerBlocks'])) {
+                $names = \array_merge($names, $this->flatten_block_names($block['innerBlocks']));
+            }
+        }
+        return $names;
+    }
+    /**
+     * Collect block HTML/content recursively for fixture assertions.
+     *
+     * @param array<int,array<string,mixed>> $blocks Blocks.
+     * @return string Combined HTML/content.
+     */
+    private function combined_block_html(array $blocks): string
+    {
+        $combined = '';
+        foreach ($blocks as $block) {
+            foreach (array('innerHTML', 'content') as $key) {
+                if (isset($block[$key]) && \is_string($block[$key])) {
+                    $combined .= "\n" . $block[$key];
+                }
+            }
+            foreach ($block['attrs'] ?? array() as $value) {
+                if (\is_string($value)) {
+                    $combined .= "\n" . $value;
+                }
+            }
+            if (!empty($block['innerBlocks'])) {
+                $combined .= $this->combined_block_html($block['innerBlocks']);
+            }
+        }
+        return $combined;
+    }
+}

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-action-text-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-action-text-transforms.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Smoke test: action/text raw transforms.
+ *
+ * Run: php tests/smoke-action-text-transforms.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ */
+// phpcs:disable
+\define('ABSPATH', __DIR__);
+if (!\function_exists('BlockFormatBridge\Vendor\esc_attr')) {
+    function esc_attr($value)
+    {
+        return \htmlspecialchars((string) $value, \ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\esc_url')) {
+    function esc_url($value)
+    {
+        return \htmlspecialchars((string) $value, \ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
+    function wp_strip_all_tags($value)
+    {
+        return \strip_tags((string) $value);
+    }
+}
+class WP_Block_Type_Registry
+{
+    private static $instance;
+    public static function get_instance()
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+    public function is_registered($name)
+    {
+        return \true;
+    }
+    public function get_registered($name)
+    {
+        $attributes = \array_fill_keys(['anchor', 'citation', 'className', 'content', 'level', 'linkTarget', 'rel', 'summary', 'text', 'url', 'value'], ['type' => 'string']);
+        return (object) ['attributes' => $attributes];
+    }
+}
+\class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
+require_once \dirname(__DIR__) . '/includes/class-html-element.php';
+require_once \dirname(__DIR__) . '/includes/class-block-factory.php';
+require_once \dirname(__DIR__) . '/includes/class-transform-registry.php';
+$failures = [];
+$assertions = 0;
+$smoke_assert = function ($condition, $label, $detail = '') use (&$failures, &$assertions) {
+    $assertions++;
+    if (!$condition) {
+        $failures[] = 'FAIL [' . $label . ']' . ($detail !== '' ? ': ' . $detail : '');
+    }
+};
+$find_transform = function ($element) {
+    foreach (HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform) {
+        try {
+            $is_match = \call_user_func($transform['isMatch'], $element);
+        } catch (\Throwable $e) {
+            $is_match = \false;
+        }
+        if ($is_match) {
+            return $transform;
+        }
+    }
+    return null;
+};
+$handler = function ($args) {
+    return [HTML_To_Blocks_Block_Factory::create_block('core/paragraph', ['content' => \trim($args['HTML'] ?? '')])];
+};
+// -------------------------------------------------------------------------
+// Buttons: explicit button-like anchors become core/buttons > core/button.
+// -------------------------------------------------------------------------
+$button_paragraph = new HTML_To_Blocks_HTML_Element('p', [], '<p><a href="/buy" target="_blank" rel="nofollow" class="btn btn-primary wp-block-button__link">Buy <strong>Now</strong></a></p>', '<a href="/buy" target="_blank" rel="nofollow" class="btn btn-primary wp-block-button__link">Buy <strong>Now</strong></a>');
+$button_transform = $find_transform($button_paragraph);
+$button_block = \call_user_func($button_transform['transform'], $button_paragraph, $handler);
+$smoke_assert($button_transform['blockName'] === 'core/buttons', 'button-transform-selected');
+$smoke_assert($button_block['blockName'] === 'core/buttons', 'button-wrapper-block-name');
+$smoke_assert(\count($button_block['innerBlocks']) === 1, 'button-wrapper-has-one-child');
+$smoke_assert($button_block['innerBlocks'][0]['blockName'] === 'core/button', 'button-child-block-name');
+$smoke_assert($button_block['innerBlocks'][0]['attrs']['url'] === '/buy', 'button-url-preserved');
+$smoke_assert($button_block['innerBlocks'][0]['attrs']['linkTarget'] === '_blank', 'button-target-preserved');
+$smoke_assert($button_block['innerBlocks'][0]['attrs']['rel'] === 'nofollow', 'button-rel-preserved');
+$smoke_assert(\strpos($button_block['innerBlocks'][0]['attrs']['className'], 'btn-primary') !== \false, 'button-class-preserved');
+$smoke_assert(\strpos($button_block['innerBlocks'][0]['innerHTML'], 'Buy <strong>Now</strong>') !== \false, 'button-rich-text-preserved');
+$ordinary_link = new HTML_To_Blocks_HTML_Element('p', [], '<p>Read <a href="/more">more</a>.</p>', 'Read <a href="/more">more</a>.');
+$ordinary_link_transform = $find_transform($ordinary_link);
+$smoke_assert($ordinary_link_transform['blockName'] === 'core/paragraph', 'ordinary-link-stays-paragraph');
+// -------------------------------------------------------------------------
+// Details: summary becomes an attribute and nested content becomes blocks.
+// -------------------------------------------------------------------------
+$details = new HTML_To_Blocks_HTML_Element('details', [], '<details><summary>More <strong>info</strong></summary><p>Nested copy</p><ul><li>One</li></ul></details>', '<summary>More <strong>info</strong></summary><p>Nested copy</p><ul><li>One</li></ul>');
+$details_transform = $find_transform($details);
+$details_block = \call_user_func($details_transform['transform'], $details, $handler);
+$smoke_assert($details_transform['blockName'] === 'core/details', 'details-transform-selected');
+$smoke_assert($details_block['attrs']['summary'] === 'More <strong>info</strong>', 'details-summary-preserved');
+$smoke_assert(\count($details_block['innerBlocks']) === 1, 'details-content-routed-through-handler');
+$smoke_assert(\strpos($details_block['innerBlocks'][0]['attrs']['content'], '<p>Nested copy</p>') !== \false, 'details-nested-content-preserved');
+// -------------------------------------------------------------------------
+// Pullquote: explicit pullquote class wins, ordinary blockquote stays quote.
+// -------------------------------------------------------------------------
+$pullquote = new HTML_To_Blocks_HTML_Element('blockquote', ['class' => 'wp-block-pullquote'], '<blockquote class="wp-block-pullquote"><p>Big line</p><cite>Author</cite></blockquote>', '<p>Big line</p><cite>Author</cite>');
+$pullquote_transform = $find_transform($pullquote);
+$pullquote_block = \call_user_func($pullquote_transform['transform'], $pullquote, $handler);
+$smoke_assert($pullquote_transform['blockName'] === 'core/pullquote', 'pullquote-transform-selected');
+$smoke_assert($pullquote_block['attrs']['value'] === '<p>Big line</p>', 'pullquote-value-preserved');
+$smoke_assert($pullquote_block['attrs']['citation'] === 'Author', 'pullquote-citation-preserved');
+$quote = new HTML_To_Blocks_HTML_Element('blockquote', [], '<blockquote><p>Regular quote</p></blockquote>', '<p>Regular quote</p>');
+$quote_transform = $find_transform($quote);
+$smoke_assert($quote_transform['blockName'] === 'core/quote', 'ordinary-blockquote-stays-quote');
+// -------------------------------------------------------------------------
+// Verse: explicit verse pre blocks preserve line breaks.
+// -------------------------------------------------------------------------
+$verse = new HTML_To_Blocks_HTML_Element('pre', ['class' => 'wp-block-verse'], "<pre class=\"wp-block-verse\">Line 1\nLine 2<br>Line 3</pre>", "Line 1\nLine 2<br>Line 3");
+$verse_transform = $find_transform($verse);
+$verse_block = \call_user_func($verse_transform['transform'], $verse, $handler);
+$smoke_assert($verse_transform['blockName'] === 'core/verse', 'verse-transform-selected');
+$smoke_assert($verse_block['attrs']['content'] === "Line 1\nLine 2<br>Line 3", 'verse-content-preserves-line-breaks');
+$smoke_assert(\strpos($verse_block['innerHTML'], "Line 1\nLine 2<br>Line 3") !== \false, 'verse-inner-html-preserves-line-breaks');
+echo 'Assertions: ' . $assertions . \PHP_EOL;
+if (empty($failures)) {
+    echo 'ALL PASS' . \PHP_EOL;
+    exit(0);
+}
+echo 'FAILURES (' . \count($failures) . '):' . \PHP_EOL;
+foreach ($failures as $failure) {
+    echo '  - ' . $failure . \PHP_EOL;
+}
+exit(1);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-layout-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-layout-transforms.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Smoke test: high-confidence layout raw transforms.
+ *
+ * Run: php tests/smoke-layout-transforms.php
+ *
+ * Exits 0 on pass, 1 on failure. Uses small WordPress stubs so it can run
+ * deterministically outside a site that may already have another h2bc copy
+ * loaded by a drop-in or composer autoloader.
+ */
+// phpcs:disable
+if (!\defined('ABSPATH')) {
+    \define('ABSPATH', __DIR__);
+}
+if (!\class_exists('WP_Block_Type_Registry', \false)) {
+    class WP_Block_Type_Registry
+    {
+        public static function get_instance()
+        {
+            return new self();
+        }
+        public function is_registered($name)
+        {
+            return \in_array($name, ['core/group', 'core/columns', 'core/column', 'core/cover', 'core/spacer', 'core/heading', 'core/paragraph', 'core/html'], \true);
+        }
+        public function get_registered($name)
+        {
+            return (object) ['attributes' => []];
+        }
+    }
+    \class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
+}
+foreach (['esc_attr', 'esc_html', 'esc_url'] as $function_name) {
+    if (!\function_exists($function_name)) {
+        eval('function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
+    function wp_strip_all_tags($text)
+    {
+        return \strip_tags($text);
+    }
+}
+$repo_root = \dirname(__DIR__);
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+class Layout_Smoke_Element
+{
+    private string $tag_name;
+    private array $attributes;
+    private string $inner_html;
+    private array $children;
+    public function __construct(string $tag_name, array $attributes = [], string $inner_html = '', array $children = [])
+    {
+        $this->tag_name = \strtoupper($tag_name);
+        $this->attributes = \array_change_key_case($attributes, \CASE_LOWER);
+        $this->inner_html = $inner_html;
+        $this->children = $children;
+    }
+    public function get_tag_name(): string
+    {
+        return $this->tag_name;
+    }
+    public function has_attribute(string $name): bool
+    {
+        return \array_key_exists(\strtolower($name), $this->attributes);
+    }
+    public function get_attribute(string $name): ?string
+    {
+        return $this->attributes[\strtolower($name)] ?? null;
+    }
+    public function get_inner_html(): string
+    {
+        return $this->inner_html;
+    }
+    public function get_child_elements(): array
+    {
+        return $this->children;
+    }
+    public function query_selector(string $selector)
+    {
+        return null;
+    }
+    public function get_text_content(): string
+    {
+        return \trim(\strip_tags($this->inner_html));
+    }
+}
+$failures = [];
+$assertions = 0;
+$smoke_assert = static function ($condition, $label, $detail = '') use (&$failures, &$assertions) {
+    $assertions++;
+    if (!$condition) {
+        $failures[] = 'FAIL [' . $label . ']' . ($detail !== '' ? ': ' . $detail : '');
+    }
+};
+$find_transform = static function ($element, string $block_name) {
+    foreach (HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform) {
+        if (($transform['blockName'] ?? '') !== $block_name) {
+            continue;
+        }
+        if (\is_callable($transform['isMatch'] ?? null) && \call_user_func($transform['isMatch'], $element)) {
+            return $transform;
+        }
+    }
+    return null;
+};
+$handler = static function ($args) {
+    $html = $args['HTML'] ?? '';
+    if (\strpos($html, '<h1') !== \false || \strpos($html, '<h2') !== \false) {
+        return [HTML_To_Blocks_Block_Factory::create_block('core/heading', ['level' => 2, 'content' => 'Heading'])];
+    }
+    return [HTML_To_Blocks_Block_Factory::create_block('core/paragraph', ['content' => 'Paragraph'])];
+};
+// --------------------------------------------------------------------------
+// Group: section is a high-confidence semantic wrapper, and inner content must
+// recurse through the normal raw handler.
+// --------------------------------------------------------------------------
+$section = new Layout_Smoke_Element('section', ['id' => 'intro', 'class' => 'intro-section'], '<h2>Intro</h2><p>Hello</p>');
+$group_transform = $find_transform($section, 'core/group');
+$group = $group_transform ? \call_user_func($group_transform['transform'], $section, $handler) : null;
+$smoke_assert($group && $group['blockName'] === 'core/group', 'section-to-group');
+$smoke_assert(($group['attrs']['anchor'] ?? '') === 'intro', 'group-preserves-anchor');
+$smoke_assert(\strpos($group['attrs']['className'] ?? '', 'intro-section') !== \false, 'group-preserves-class');
+$smoke_assert(\count($group['innerBlocks'] ?? []) === 1, 'group-preserves-inner-blocks');
+$smoke_assert(($group['innerBlocks'][0]['blockName'] ?? '') === 'core/heading', 'group-inner-heading');
+// --------------------------------------------------------------------------
+// Columns: require an explicit row/grid signal plus direct column-like children.
+// --------------------------------------------------------------------------
+$left = new Layout_Smoke_Element('div', ['class' => 'col-md-6'], '<p>Left</p>');
+$right = new Layout_Smoke_Element('div', ['class' => 'col-md-6'], '<p>Right</p>');
+$row = new Layout_Smoke_Element('div', ['class' => 'row'], '', [$left, $right]);
+$columns_transform = $find_transform($row, 'core/columns');
+$columns = $columns_transform ? \call_user_func($columns_transform['transform'], $row, $handler) : null;
+$smoke_assert($columns && $columns['blockName'] === 'core/columns', 'row-to-columns');
+$smoke_assert(\count($columns['innerBlocks'] ?? []) === 2, 'columns-has-two-columns');
+$smoke_assert(($columns['innerBlocks'][0]['blockName'] ?? '') === 'core/column', 'first-child-column');
+$smoke_assert(($columns['innerBlocks'][1]['blockName'] ?? '') === 'core/column', 'second-child-column');
+$smoke_assert(\strpos($columns['innerBlocks'][0]['attrs']['className'] ?? '', 'col-md-6') !== \false, 'column-preserves-class');
+$smoke_assert(($columns['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? '') === 'core/paragraph', 'column-preserves-inner-paragraph');
+// --------------------------------------------------------------------------
+// Cover: require a hero/cover signal with an explicit background style.
+// --------------------------------------------------------------------------
+$hero = new Layout_Smoke_Element('section', ['id' => 'hero', 'class' => 'hero', 'style' => 'background-image: url(/hero.jpg); background-color: #123456;'], '<h1>Launch</h1>');
+$cover_transform = $find_transform($hero, 'core/cover');
+$cover = $cover_transform ? \call_user_func($cover_transform['transform'], $hero, $handler) : null;
+$smoke_assert($cover && $cover['blockName'] === 'core/cover', 'hero-to-cover');
+$smoke_assert(($cover['attrs']['anchor'] ?? '') === 'hero', 'cover-preserves-anchor');
+$smoke_assert(($cover['attrs']['url'] ?? '') === '/hero.jpg', 'cover-preserves-background-image');
+$smoke_assert(($cover['attrs']['customOverlayColor'] ?? '') === '#123456', 'cover-preserves-background-color');
+$smoke_assert(($cover['innerBlocks'][0]['blockName'] ?? '') === 'core/heading', 'cover-preserves-inner-heading');
+// --------------------------------------------------------------------------
+// Spacer: only empty explicit spacer elements with an explicit height qualify.
+// --------------------------------------------------------------------------
+$spacer_element = new Layout_Smoke_Element('div', ['class' => 'spacer', 'style' => 'height: 48px'], '');
+$spacer_transform = $find_transform($spacer_element, 'core/spacer');
+$spacer = $spacer_transform ? \call_user_func($spacer_transform['transform'], $spacer_element, $handler) : null;
+$smoke_assert($spacer && $spacer['blockName'] === 'core/spacer', 'explicit-spacer-to-spacer');
+$smoke_assert(($spacer['attrs']['height'] ?? '') === '48px', 'spacer-preserves-height');
+// --------------------------------------------------------------------------
+// Fallback safety: arbitrary divs must not become layout blocks.
+// --------------------------------------------------------------------------
+$ambiguous = new Layout_Smoke_Element('div', [], '<p>Ambiguous</p>');
+$smoke_assert($find_transform($ambiguous, 'core/group') === null, 'ambiguous-div-not-group');
+$smoke_assert($find_transform($ambiguous, 'core/columns') === null, 'ambiguous-div-not-columns');
+$smoke_assert($find_transform($ambiguous, 'core/cover') === null, 'ambiguous-div-not-cover');
+$smoke_assert($find_transform($ambiguous, 'core/spacer') === null, 'ambiguous-div-not-spacer');
+echo 'Assertions: ' . $assertions . \PHP_EOL;
+if (empty($failures)) {
+    echo 'ALL PASS' . \PHP_EOL;
+    exit(0);
+}
+echo 'FAILURES (' . \count($failures) . '):' . \PHP_EOL;
+foreach ($failures as $failure) {
+    echo '  - ' . $failure . \PHP_EOL;
+}
+exit(1);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-media-embed-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-media-embed-transforms.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Smoke test: media/embed raw transforms.
+ *
+ * Runs without WordPress by stubbing the tiny surface needed by the transform
+ * registry and block factory. This keeps the transform contract deterministic:
+ * high-confidence media patterns become semantic blocks, while unsafe patterns
+ * remain unmatched for the raw handler's core/html fallback.
+ *
+ * Run: php tests/smoke-media-embed-transforms.php
+ */
+// phpcs:disable
+if (!\defined('ABSPATH')) {
+    \define('ABSPATH', __DIR__);
+}
+if (!\function_exists('BlockFormatBridge\Vendor\esc_attr')) {
+    function esc_attr($value)
+    {
+        return \htmlspecialchars((string) $value, \ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\esc_url')) {
+    function esc_url($value)
+    {
+        return (string) $value;
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\sanitize_html_class')) {
+    function sanitize_html_class($value)
+    {
+        return \preg_replace('/[^A-Za-z0-9_-]/', '', (string) $value);
+    }
+}
+if (!\class_exists('WP_Block_Type_Registry', \false)) {
+    class WP_Block_Type_Registry
+    {
+        private static $instance;
+        private $blocks = [];
+        public static function get_instance()
+        {
+            if (!self::$instance) {
+                self::$instance = new self();
+            }
+            return self::$instance;
+        }
+        public function __construct()
+        {
+            $source_string = ['type' => 'string', 'source' => 'attribute'];
+            $source_rich = ['type' => 'rich-text', 'source' => 'rich-text'];
+            foreach (['core/video', 'core/audio', 'core/image'] as $name) {
+                $this->blocks[$name] = (object) ['attributes' => ['src' => $source_string, 'url' => $source_string, 'alt' => $source_string, 'caption' => $source_rich, 'poster' => $source_string, 'preload' => $source_string, 'autoplay' => ['type' => 'boolean', 'source' => 'attribute'], 'controls' => ['type' => 'boolean', 'source' => 'attribute'], 'loop' => ['type' => 'boolean', 'source' => 'attribute'], 'muted' => ['type' => 'boolean', 'source' => 'attribute'], 'id' => ['type' => 'number'], 'className' => ['type' => 'string']]];
+            }
+            $this->blocks['core/gallery'] = (object) ['attributes' => ['ids' => ['type' => 'array'], 'columns' => ['type' => 'number']]];
+            $this->blocks['core/media-text'] = (object) ['attributes' => ['mediaUrl' => ['type' => 'string'], 'mediaAlt' => $source_string, 'mediaType' => ['type' => 'string'], 'mediaPosition' => ['type' => 'string'], 'mediaWidth' => ['type' => 'number'], 'isStackedOnMobile' => ['type' => 'boolean']]];
+            $this->blocks['core/file'] = (object) ['attributes' => ['href' => ['type' => 'string'], 'textLinkHref' => $source_string, 'fileName' => $source_rich, 'showDownloadButton' => ['type' => 'boolean']]];
+            $this->blocks['core/embed'] = (object) ['attributes' => ['url' => ['type' => 'string'], 'type' => ['type' => 'string'], 'providerNameSlug' => ['type' => 'string'], 'responsive' => ['type' => 'boolean']]];
+            foreach (['core/paragraph', 'core/html'] as $name) {
+                $this->blocks[$name] = (object) ['attributes' => ['content' => ['type' => 'string']]];
+            }
+        }
+        public function is_registered($name)
+        {
+            return isset($this->blocks[$name]);
+        }
+        public function get_registered($name)
+        {
+            return $this->blocks[$name] ?? null;
+        }
+    }
+    \class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
+}
+require_once \dirname(__DIR__) . '/includes/class-block-factory.php';
+require_once \dirname(__DIR__) . '/includes/class-transform-registry.php';
+class H2BC_Fake_Element
+{
+    private $tag;
+    private $attrs;
+    private $inner;
+    private $children;
+    public function __construct($tag, $attrs = [], $inner = '', $children = [])
+    {
+        $this->tag = \strtoupper($tag);
+        $this->attrs = \array_change_key_case($attrs, \CASE_LOWER);
+        $this->inner = $inner;
+        $this->children = $children;
+    }
+    public function get_tag_name()
+    {
+        return $this->tag;
+    }
+    public function has_attribute(string $name): bool
+    {
+        return \array_key_exists(\strtolower($name), $this->attrs);
+    }
+    public function get_attribute(string $name): ?string
+    {
+        return $this->attrs[\strtolower($name)] ?? null;
+    }
+    public function get_inner_html(): string
+    {
+        return $this->inner;
+    }
+    public function get_text_content(): string
+    {
+        return \trim(\strip_tags($this->inner));
+    }
+    public function get_outer_html(): string
+    {
+        return '<' . \strtolower($this->tag) . '>' . $this->inner . '</' . \strtolower($this->tag) . '>';
+    }
+    public function get_child_elements(): array
+    {
+        return $this->children;
+    }
+    public function query_selector(string $selector)
+    {
+        $all = $this->query_selector_all($selector);
+        return $all[0] ?? null;
+    }
+    public function query_selector_all(string $selector): array
+    {
+        $results = [];
+        foreach ($this->children as $child) {
+            if ($child->matches($selector)) {
+                $results[] = $child;
+            }
+            $results = \array_merge($results, $child->query_selector_all($selector));
+        }
+        return $results;
+    }
+    private function matches(string $selector): bool
+    {
+        if ($selector[0] === '.') {
+            $class = $this->attrs['class'] ?? '';
+            return \preg_match('/(?:^|\s)' . \preg_quote(\substr($selector, 1), '/') . '(?:$|\s)/', $class) === 1;
+        }
+        return \strtoupper($selector) === $this->tag;
+    }
+}
+$failures = [];
+$assertions = 0;
+$assert = function ($condition, $label, $detail = '') use (&$failures, &$assertions) {
+    $assertions++;
+    if (!$condition) {
+        $failures[] = 'FAIL [' . $label . ']' . ($detail !== '' ? ': ' . $detail : '');
+    }
+};
+$find_transform = function ($element) {
+    foreach (HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform) {
+        if (\call_user_func($transform['isMatch'], $element)) {
+            return $transform;
+        }
+    }
+    return null;
+};
+$convert = function ($element) use ($find_transform) {
+    $transform = $find_transform($element);
+    if (!$transform) {
+        return null;
+    }
+    $handler = function () {
+        return [HTML_To_Blocks_Block_Factory::create_block('core/paragraph', ['content' => 'Nested text'])];
+    };
+    return \call_user_func($transform['transform'], $element, $handler);
+};
+$video = $convert(new H2BC_Fake_Element('video', ['src' => 'movie.mp4', 'poster' => 'poster.jpg', 'controls' => '']));
+$assert($video['blockName'] === 'core/video', 'video-direct-block');
+$assert(\strpos($video['innerHTML'], 'movie.mp4') !== \false && \strpos($video['innerHTML'], 'poster.jpg') !== \false, 'video-direct-html');
+$video_source = $convert(new H2BC_Fake_Element('video', [], '', [new H2BC_Fake_Element('source', ['src' => 'nested.mp4'])]));
+$assert($video_source['blockName'] === 'core/video', 'video-source-block');
+$assert(\strpos($video_source['innerHTML'], 'nested.mp4') !== \false, 'video-source-html');
+$audio = $convert(new H2BC_Fake_Element('audio', [], '', [new H2BC_Fake_Element('source', ['src' => 'clip.mp3'])]));
+$assert($audio['blockName'] === 'core/audio', 'audio-source-block');
+$assert(\strpos($audio['innerHTML'], 'clip.mp3') !== \false, 'audio-source-html');
+$gallery = $convert(new H2BC_Fake_Element('div', ['class' => 'gallery columns-2'], '', [new H2BC_Fake_Element('figure', [], '', [new H2BC_Fake_Element('img', ['src' => 'a.jpg', 'alt' => 'A', 'class' => 'wp-image-10']), new H2BC_Fake_Element('figcaption', [], 'Caption A')]), new H2BC_Fake_Element('figure', [], '', [new H2BC_Fake_Element('img', ['src' => 'b.jpg', 'alt' => 'B']), new H2BC_Fake_Element('figcaption', [], 'Caption B')])]));
+$assert($gallery['blockName'] === 'core/gallery', 'gallery-block');
+$assert(\count($gallery['innerBlocks']) === 2, 'gallery-inner-image-count');
+$assert(\strpos($gallery['innerHTML'], 'wp-block-gallery') !== \false, 'gallery-wrapper-html');
+$assert(\strpos($gallery['innerBlocks'][0]['innerHTML'], 'Caption A') !== \false, 'gallery-caption-preserved');
+$media_text = $convert(new H2BC_Fake_Element('div', ['class' => 'wp-block-media-text'], '', [new H2BC_Fake_Element('figure', [], '', [new H2BC_Fake_Element('img', ['src' => 'hero.jpg', 'alt' => 'Hero'])]), new H2BC_Fake_Element('div', ['class' => 'wp-block-media-text__content'], '<p>Copy</p>')]));
+$assert($media_text['blockName'] === 'core/media-text', 'media-text-block');
+$assert(($media_text['attrs']['mediaUrl'] ?? '') === 'hero.jpg', 'media-text-media-url');
+$assert(\count($media_text['innerBlocks']) === 1, 'media-text-inner-blocks');
+$file = $convert(new H2BC_Fake_Element('a', ['href' => 'https://example.com/report.pdf'], 'Download report'));
+$assert($file['blockName'] === 'core/file', 'file-link-block');
+$assert(($file['attrs']['href'] ?? '') === 'https://example.com/report.pdf', 'file-link-href');
+$cta = $find_transform(new H2BC_Fake_Element('a', ['href' => 'https://example.com/signup'], 'Sign up'));
+$assert($cta === null, 'normal-cta-link-not-file');
+$embed = $convert(new H2BC_Fake_Element('iframe', ['src' => 'https://www.youtube.com/embed/abc123']));
+$assert($embed['blockName'] === 'core/embed', 'youtube-iframe-block');
+$assert(($embed['attrs']['providerNameSlug'] ?? '') === 'youtube', 'youtube-provider');
+$assert(($embed['attrs']['url'] ?? '') === 'https://www.youtube.com/watch?v=abc123', 'youtube-url-normalised');
+$unknown_iframe = $find_transform(new H2BC_Fake_Element('iframe', ['src' => 'https://example.com/widget']));
+$assert($unknown_iframe === null, 'unknown-iframe-safe-fallback');
+echo 'Assertions: ' . $assertions . \PHP_EOL;
+if (empty($failures)) {
+    echo 'ALL PASS' . \PHP_EOL;
+    exit(0);
+}
+echo 'FAILURES (' . \count($failures) . '):' . \PHP_EOL;
+foreach ($failures as $failure) {
+    echo '  - ' . $failure . \PHP_EOL;
+}
+exit(1);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-unsupported-html-fallback-hook.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-unsupported-html-fallback-hook.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Smoke test: unsupported HTML fallback observability hook.
+ *
+ * Run: php tests/smoke-unsupported-html-fallback-hook.php
+ */
+// phpcs:disable
+if (!\defined('ABSPATH')) {
+    \define('ABSPATH', __DIR__);
+}
+if (!\class_exists('WP_Block_Type_Registry', \false)) {
+    class WP_Block_Type_Registry
+    {
+        public static function get_instance()
+        {
+            return new self();
+        }
+        public function is_registered($name)
+        {
+            return $name === 'core/html';
+        }
+        public function get_registered($name)
+        {
+            return (object) ['attributes' => ['content' => ['type' => 'string']]];
+        }
+    }
+    \class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
+}
+$html_to_blocks_smoke_actions = [];
+if (!\function_exists('do_action') && !\function_exists('BlockFormatBridge\Vendor\do_action')) {
+    function do_action($hook_name, ...$args)
+    {
+        global $html_to_blocks_smoke_actions;
+        $html_to_blocks_smoke_actions[] = [$hook_name, $args];
+    }
+}
+require_once \dirname(__DIR__) . '/includes/class-block-factory.php';
+require_once \dirname(__DIR__) . '/raw-handler.php';
+$failures = [];
+$assertions = 0;
+$assert = static function ($condition, $label, $detail = '') use (&$failures, &$assertions) {
+    $assertions++;
+    if (!$condition) {
+        $failures[] = 'FAIL [' . $label . ']' . ($detail !== '' ? ': ' . $detail : '');
+    }
+};
+$fallback_html = '<iframe src="https://example.com/widget"></iframe>';
+$context = ['reason' => 'no_transform', 'tag_name' => 'IFRAME', 'occurrence' => 0];
+$block = html_to_blocks_create_unsupported_html_fallback_block($fallback_html, $context);
+$assert($block['blockName'] === 'core/html', 'fallback-block-name');
+$assert(($block['attrs']['content'] ?? '') === $fallback_html, 'fallback-preserves-html');
+$assert(\count($html_to_blocks_smoke_actions) === 1, 'fallback-emits-one-action');
+$action = $html_to_blocks_smoke_actions[0] ?? null;
+$assert($action && $action[0] === 'html_to_blocks_unsupported_html_fallback', 'fallback-action-name');
+$assert(($action[1][0] ?? '') === $fallback_html, 'fallback-action-html-arg');
+$assert(($action[1][1]['reason'] ?? '') === 'no_transform', 'fallback-action-reason');
+$assert(($action[1][1]['tag_name'] ?? '') === 'IFRAME', 'fallback-action-tag-name');
+$assert(($action[1][2]['blockName'] ?? '') === 'core/html', 'fallback-action-block-arg');
+$raw_handler_source = \file_get_contents(\dirname(__DIR__) . '/raw-handler.php');
+$assert(\substr_count($raw_handler_source, 'html_to_blocks_create_unsupported_html_fallback_block(') >= 3, 'raw-handler-routes-fallbacks-through-helper');
+echo 'Assertions: ' . $assertions . \PHP_EOL;
+if (empty($failures)) {
+    echo 'ALL PASS' . \PHP_EOL;
+    exit(0);
+}
+echo 'FAILURES (' . \count($failures) . '):' . \PHP_EOL;
+foreach ($failures as $failure) {
+    echo '  - ' . $failure . \PHP_EOL;
+}
+exit(1);


### PR DESCRIPTION
## Summary
- Refreshes BFB's bundled html-to-blocks-converter artifact to include the merged expanded transform wave.
- Adds BFB-level package tests proving the new transform families route through `bfb_convert( $html, 'html', 'blocks' )`.
- Keeps unsupported fallback observability working after php-scoper prefixing by excluding WordPress' `do_action` from function-prefix rewriting.

## Changes
- Updates `composer.lock` from h2bc `a25eb44` to `b03b4b4` and rebuilds `vendor_prefixed/`.
- Covers layout, action/text, media/embed, unsupported fallback, and bundled file-transform presence in `tests/BFBConversionUnitTest.php`.
- Includes h2bc's generated smoke fixtures in the refreshed prefixed artifact.

## Tests
- `php -l tests/BFBConversionUnitTest.php && php -l scoper.inc.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@refresh-expanded-h2bc`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@refresh-expanded-h2bc` currently blocked by Extra-Chill/homeboy-extensions#296 (`PLUGIN_PATH: unbound variable`).

Closes #33

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updating the bundled h2bc artifact, drafting BFB integration tests, running verification, and preparing the PR. Chris remains responsible for review and merge.