### PR TITLE
fix: preserve WordPress hook APIs in scoped h2bc

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -27,7 +27,28 @@ return [
 		'WP_REST_Response',
 	],
 	'exclude-functions' => [
+		'add_action',
+		'add_filter',
 		'do_action',
+		'has_action',
+		'has_filter',
+	],
+	'patchers' => [
+		static function ( string $file_path, string $prefix, string $contents ): string {
+			if ( ! str_contains( $file_path, 'html-to-blocks-converter' ) ) {
+				return $contents;
+			}
+
+			foreach ( array( 'add_action', 'add_filter', 'do_action', 'has_action', 'has_filter' ) as $function_name ) {
+				$contents = str_replace(
+					" && !\\function_exists('{$prefix}\\{$function_name}')",
+					'',
+					$contents
+				);
+			}
+
+			return $contents;
+		},
 	],
 	// Disable php-scoper's default class_alias emission so the build does
 	// NOT write `\class_alias('BlockFormatBridge\Vendor\HTML_To_Blocks_*',

--- a/tests/smoke-scoped-h2bc-hooks.php
+++ b/tests/smoke-scoped-h2bc-hooks.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Smoke coverage for scoped h2bc WordPress hook registration.
+ *
+ * @package BlockFormatBridge
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+$GLOBALS['bfb_smoke_filters'] = array();
+
+function bfb_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function add_filter( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+	$GLOBALS['bfb_smoke_filters'][ $hook_name ][ $priority ][] = array(
+		'callback'      => $callback,
+		'accepted_args' => $accepted_args,
+	);
+
+	return true;
+}
+
+function add_action( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+	return add_filter( $hook_name, $callback, $priority, $accepted_args );
+}
+
+function has_filter( string $hook_name, $callback = false ) {
+	if ( ! isset( $GLOBALS['bfb_smoke_filters'][ $hook_name ] ) ) {
+		return false;
+	}
+
+	if ( false === $callback ) {
+		return true;
+	}
+
+	foreach ( $GLOBALS['bfb_smoke_filters'][ $hook_name ] as $priority => $entries ) {
+		foreach ( $entries as $entry ) {
+			if ( $entry['callback'] === $callback ) {
+				return $priority;
+			}
+		}
+	}
+
+	return false;
+}
+
+function has_action( string $hook_name, $callback = false ) {
+	return has_filter( $hook_name, $callback );
+}
+
+$hooks_file    = __DIR__ . '/../vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php';
+$versions_file = __DIR__ . '/../vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php';
+$hooks_source  = file_get_contents( $hooks_file );
+
+bfb_smoke_assert( is_string( $hooks_source ), 'Scoped h2bc hooks.php should be readable.' );
+
+foreach ( array( 'add_filter', 'has_filter', 'add_action', 'has_action' ) as $function_name ) {
+	bfb_smoke_assert(
+		! str_contains( $hooks_source, "BlockFormatBridge\\Vendor\\{$function_name}" ),
+		"Scoped h2bc hooks.php should not prefix WordPress {$function_name} guards."
+	);
+}
+
+require_once $versions_file;
+\BlockFormatBridge\Vendor\HTML_To_Blocks_Versions::register_hooks();
+
+$plugins_loaded_callback = array( \BlockFormatBridge\Vendor\HTML_To_Blocks_Versions::class, 'initialize_latest_version' );
+bfb_smoke_assert(
+	1 === has_action( 'plugins_loaded', $plugins_loaded_callback ),
+	'Scoped h2bc version registry should register on global plugins_loaded.'
+);
+
+require_once $hooks_file;
+
+bfb_smoke_assert(
+	10 === has_filter( 'wp_insert_post_data', 'BlockFormatBridge\\Vendor\\html_to_blocks_convert_on_insert' ),
+	'Scoped h2bc should register wp_insert_post_data on the global hook API.'
+);
+
+bfb_smoke_assert(
+	20 === has_action( 'init', 'BlockFormatBridge\\Vendor\\html_to_blocks_register_rest_filters' ),
+	'Scoped h2bc should register init on the global hook API.'
+);
+
+echo "PASS: scoped h2bc hooks register globally\n";

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/html-to-blocks-converter.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/html-to-blocks-converter.php
@@ -24,7 +24,7 @@ if (!\defined('HTML_TO_BLOCKS_CONVERTER_MIN_WP')) {
     \define('HTML_TO_BLOCKS_CONVERTER_MIN_WP', '6.4');
 }
 if (\version_compare(get_bloginfo('version'), \HTML_TO_BLOCKS_CONVERTER_MIN_WP, '<')) {
-    add_action('admin_notices', function () {
+    \add_action('admin_notices', function () {
         echo '<div class="notice notice-error"><p>';
         \printf(
             /* translators: %s: minimum WordPress version */

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php
@@ -68,10 +68,10 @@ if (!\class_exists('BlockFormatBridge\Vendor\HTML_To_Blocks_Versions', \false)) 
          */
         public static function register_hooks(): void
         {
-            if (self::$hooked || !\function_exists('BlockFormatBridge\Vendor\add_action')) {
+            if (self::$hooked || !\function_exists('add_action')) {
                 return;
             }
-            add_action('plugins_loaded', array(__CLASS__, 'initialize_latest_version'), 1);
+            \add_action('plugins_loaded', array(__CLASS__, 'initialize_latest_version'), 1);
             self::$hooked = \true;
         }
         /**

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php
@@ -45,8 +45,8 @@ if (!\function_exists($html_to_blocks_insert_callback)) {
         return $data;
     }
 }
-if (\function_exists('BlockFormatBridge\Vendor\add_filter') && (!\function_exists('BlockFormatBridge\Vendor\has_filter') || \false === has_filter('wp_insert_post_data', $html_to_blocks_insert_callback))) {
-    add_filter('wp_insert_post_data', $html_to_blocks_insert_callback, 10, 2);
+if (\function_exists('add_filter') && (!\function_exists('has_filter') || \false === \has_filter('wp_insert_post_data', $html_to_blocks_insert_callback))) {
+    \add_filter('wp_insert_post_data', $html_to_blocks_insert_callback, 10, 2);
 }
 // ---------------------------------------------------------------------------
 // Read path: convert HTML → blocks in REST API responses for the editor.
@@ -70,8 +70,8 @@ if (!\function_exists($html_to_blocks_register_rest_callback)) {
         $default_types = \array_keys(get_post_types(array('show_in_rest' => \true, 'public' => \true)));
         $supported_types = apply_filters('html_to_blocks_supported_post_types', $default_types);
         foreach ($supported_types as $post_type) {
-            if (!\function_exists('BlockFormatBridge\Vendor\has_filter') || \false === has_filter("rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback)) {
-                add_filter("rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback, 10, 3);
+            if (!\function_exists('has_filter') || \false === \has_filter("rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback)) {
+                \add_filter("rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback, 10, 3);
             }
         }
     }
@@ -80,8 +80,8 @@ if (!\function_exists($html_to_blocks_register_rest_callback)) {
 // at the default init priority (10). Without this, CPTs registered by other
 // plugins (e.g. Intelligence's wiki post type) won't exist yet when
 // get_post_types() is called, and their REST response filter won't be added.
-if (\function_exists('BlockFormatBridge\Vendor\add_action') && (!\function_exists('BlockFormatBridge\Vendor\has_action') || \false === has_action('init', $html_to_blocks_register_rest_callback))) {
-    add_action('init', $html_to_blocks_register_rest_callback, 20);
+if (\function_exists('add_action') && (!\function_exists('has_action') || \false === \has_action('init', $html_to_blocks_register_rest_callback))) {
+    \add_action('init', $html_to_blocks_register_rest_callback, 20);
 }
 /**
  * Convert HTML to blocks in REST API responses.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/library.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/library.php
@@ -51,5 +51,5 @@ if (did_action('plugins_loaded') && !doing_action('plugins_loaded')) {
     $html_to_blocks_register();
     HTML_To_Blocks_Versions::initialize_latest_version();
 } else {
-    add_action('plugins_loaded', $html_to_blocks_register, 0);
+    \add_action('plugins_loaded', $html_to_blocks_register, 0);
 }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/RawHandlerFixturesUnitTest.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/RawHandlerFixturesUnitTest.php
@@ -22,7 +22,7 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase
             $listener = static function (string $html, array $context, array $block) use (&$fallbacks): void {
                 $fallbacks[] = array('html' => $html, 'context' => $context, 'block' => $block);
             };
-            add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
+            \add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
             try {
                 $blocks = html_to_blocks_raw_handler(array('HTML' => $fixture['html']));
             } finally {
@@ -46,7 +46,7 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase
             $listener = static function (string $html, array $context, array $block) use (&$fallbacks): void {
                 $fallbacks[] = array('html' => $html, 'context' => $context, 'block' => $block);
             };
-            add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
+            \add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
             try {
                 $blocks = html_to_blocks_raw_handler(array('HTML' => $fixture['html']));
             } finally {

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-unsupported-html-fallback-hook.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-unsupported-html-fallback-hook.php
@@ -30,7 +30,7 @@ if (!\class_exists('WP_Block_Type_Registry', \false)) {
     \class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
 }
 $html_to_blocks_smoke_actions = [];
-if (!\function_exists('do_action') && !\function_exists('BlockFormatBridge\Vendor\do_action')) {
+if (!\function_exists('do_action')) {
     function do_action($hook_name, ...$args)
     {
         global $html_to_blocks_smoke_actions;


### PR DESCRIPTION
## Summary
- Keeps WordPress hook API functions global when php-scoper rebuilds the bundled html-to-blocks-converter artifact.
- Adds a standalone smoke proving the scoped artifact registers h2bc callbacks on `wp_insert_post_data`, `plugins_loaded`, and `init` through a minimal global hook API.
- Rebuilds `vendor_prefixed/` so the shipped artifact no longer probes `BlockFormatBridge\Vendor\add_filter`, `has_filter`, `add_action`, `has_action`, or `do_action`.

Closes #36.

## Tests
- `composer build`
- `php tests/smoke-scoped-h2bc-hooks.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@refresh-expanded-h2bc`
- `grep` verification: no scoped WordPress hook API references remain under `vendor_prefixed/chubes4/html-to-blocks-converter`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the scoped hook registration failure, drafted the targeted scoper/test changes, rebuilt the scoped artifact, and ran local verification. Chris remains responsible for review and merge.