### PR TITLE
feat: add content normalization API

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -2,10 +2,11 @@
 /**
  * Public API.
  *
- * Two functions form the entire Phase 1 surface:
+ * These functions form the public Phase 1 surface:
  *
- *   bfb_convert( $content, $from, $to )  — universal conversion
- *   bfb_get_adapter( $slug )             — registry lookup
+ *   bfb_convert( $content, $from, $to )     — universal conversion
+ *   bfb_normalize( $content, $format )      — declared-format validation
+ *   bfb_get_adapter( $slug )                — registry lookup
  *
  * Both route through the block pivot via the adapter registry. There
  * is no parsing logic in this file; everything is delegation.

--- a/includes/normalization.php
+++ b/includes/normalization.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Content normalization and validation helpers.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'bfb_normalize' ) ) {
+	/**
+	 * Normalize and validate content for a declared format.
+	 *
+	 * This is the explicit same-format safety boundary. `bfb_convert()`
+	 * remains a conversion API; callers that need to verify declared input
+	 * before storage should call this function first.
+	 *
+	 * Supported options:
+	 *   - mode: 'strict' (default) or 'lenient'. The initial contract is
+	 *     strict-first; lenient currently accepts the same recoverable cases
+	 *     as strict and reserves room for future diagnostics.
+	 *
+	 * @param string $content Source content.
+	 * @param string $format  Declared format slug.
+	 * @param array  $options Normalization options.
+	 * @return string|WP_Error Normalized content, or WP_Error on malformed input.
+	 */
+	function bfb_normalize( string $content, string $format, array $options = array() ) {
+		$mode = isset( $options['mode'] ) ? (string) $options['mode'] : 'strict';
+		if ( ! in_array( $mode, array( 'strict', 'lenient' ), true ) ) {
+			return new WP_Error(
+				'bfb_invalid_normalize_mode',
+				sprintf( 'Unsupported BFB normalization mode "%s".', $mode ),
+				array( 'mode' => $mode )
+			);
+		}
+
+		switch ( $format ) {
+			case 'blocks':
+				return bfb_normalize_blocks( $content );
+			case 'markdown':
+				return bfb_normalize_markdown( $content );
+			case 'html':
+				return bfb_normalize_html( $content );
+			default:
+				if ( ! bfb_get_adapter( $format ) ) {
+					return new WP_Error(
+						'bfb_unknown_format',
+						sprintf( 'No BFB adapter is registered for format "%s".', $format ),
+						array( 'format' => $format )
+					);
+				}
+
+				return $content;
+		}
+	}
+}
+
+if ( ! function_exists( 'bfb_normalize_blocks' ) ) {
+	/**
+	 * Validate serialized block markup without falling back to freeform.
+	 *
+	 * @param string $content Declared block content.
+	 * @return string|WP_Error
+	 */
+	function bfb_normalize_blocks( string $content ) {
+		if ( '' === trim( $content ) ) {
+			return '';
+		}
+
+		$tokens = bfb_extract_block_tokens( $content );
+		if ( bfb_is_wp_error( $tokens ) ) {
+			return $tokens;
+		}
+
+		if ( empty( $tokens ) ) {
+			return new WP_Error(
+				'bfb_blocks_missing_comments',
+				'Declared blocks content does not contain serialized block comments.',
+				array( 'format' => 'blocks' )
+			);
+		}
+
+		$stack  = array();
+		$cursor = 0;
+		foreach ( $tokens as $token ) {
+			$between = substr( $content, $cursor, $token['offset'] - $cursor );
+			if ( empty( $stack ) && '' !== trim( $between ) ) {
+				return new WP_Error(
+					'bfb_blocks_mixed_content',
+					'Declared blocks content contains raw content outside serialized block comments.',
+					array(
+						'format'  => 'blocks',
+						'excerpt' => bfb_excerpt( $between ),
+					)
+				);
+			}
+
+			if ( 'open' === $token['type'] ) {
+				$stack[] = $token['name'];
+			} elseif ( 'close' === $token['type'] ) {
+				$expected = array_pop( $stack );
+				if ( $expected !== $token['name'] ) {
+					return new WP_Error(
+						'bfb_blocks_mismatched_comment',
+						'Mismatched serialized block closing comment.',
+						array(
+							'expected' => $expected,
+							'actual'   => $token['name'],
+						)
+					);
+				}
+			}
+
+			$cursor = $token['offset'] + strlen( $token['raw'] );
+		}
+
+		$trailing = substr( $content, $cursor );
+		if ( empty( $stack ) && '' !== trim( $trailing ) ) {
+			return new WP_Error(
+				'bfb_blocks_mixed_content',
+				'Declared blocks content contains raw content outside serialized block comments.',
+				array(
+					'format'  => 'blocks',
+					'excerpt' => bfb_excerpt( $trailing ),
+				)
+			);
+		}
+
+		if ( ! empty( $stack ) ) {
+			return new WP_Error(
+				'bfb_blocks_unclosed_comment',
+				'Serialized block markup contains an unclosed block comment.',
+				array( 'open_blocks' => array_values( $stack ) )
+			);
+		}
+
+		return $content;
+	}
+}
+
+if ( ! function_exists( 'bfb_normalize_markdown' ) ) {
+	/**
+	 * Validate markdown content for mixed serialized blocks.
+	 *
+	 * @param string $content Declared markdown content.
+	 * @return string|WP_Error
+	 */
+	function bfb_normalize_markdown( string $content ) {
+		if ( bfb_contains_block_comment( $content ) ) {
+			return new WP_Error(
+				'bfb_markdown_contains_blocks',
+				'Declared markdown content contains serialized block comments.',
+				array( 'format' => 'markdown' )
+			);
+		}
+
+		return str_replace( array( "\r\n", "\r" ), "\n", $content );
+	}
+}
+
+if ( ! function_exists( 'bfb_normalize_html' ) ) {
+	/**
+	 * Validate HTML content for mixed markdown or serialized blocks.
+	 *
+	 * @param string $content Declared HTML content.
+	 * @return string|WP_Error
+	 */
+	function bfb_normalize_html( string $content ) {
+		if ( bfb_contains_block_comment( $content ) ) {
+			return new WP_Error(
+				'bfb_html_contains_blocks',
+				'Declared HTML content contains serialized block comments.',
+				array( 'format' => 'html' )
+			);
+		}
+
+		if ( bfb_html_contains_markdown_markers( $content ) ) {
+			return new WP_Error(
+				'bfb_html_contains_markdown',
+				'Declared HTML content contains markdown markers.',
+				array( 'format' => 'html' )
+			);
+		}
+
+		return $content;
+	}
+}
+
+if ( ! function_exists( 'bfb_extract_block_tokens' ) ) {
+	/**
+	 * Extract and validate serialized block comment tokens.
+	 *
+	 * @param string $content Declared block content.
+	 * @return array<int, array<string, mixed>>|WP_Error
+	 */
+	function bfb_extract_block_tokens( string $content ) {
+		if ( ! preg_match_all( '/<!--\s*(\/?wp:[^>]*)-->/', $content, $matches, PREG_OFFSET_CAPTURE ) ) {
+			return array();
+		}
+
+		$tokens = array();
+		foreach ( $matches[0] as $index => $match ) {
+			$raw   = $match[0];
+			$inner = trim( $matches[1][ $index ][0] );
+
+			if ( preg_match( '/^wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)(?:\s+\{.*\})?\s*(\/)?$/s', $inner, $open ) ) {
+				$tokens[] = array(
+					'raw'    => $raw,
+					'offset' => $match[1],
+					'type'   => isset( $open[2] ) && '/' === $open[2] ? 'self' : 'open',
+					'name'   => $open[1],
+				);
+				continue;
+			}
+
+			if ( preg_match( '/^\/wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)$/', $inner, $close ) ) {
+				$tokens[] = array(
+					'raw'    => $raw,
+					'offset' => $match[1],
+					'type'   => 'close',
+					'name'   => $close[1],
+				);
+				continue;
+			}
+
+			return new WP_Error(
+				'bfb_blocks_malformed_comment',
+				'Malformed serialized block comment.',
+				array(
+					'format'  => 'blocks',
+					'comment' => $raw,
+				)
+			);
+		}
+
+		return $tokens;
+	}
+}
+
+if ( ! function_exists( 'bfb_contains_block_comment' ) ) {
+	/**
+	 * Check for serialized block comments.
+	 *
+	 * @param string $content Content to scan.
+	 * @return bool
+	 */
+	function bfb_contains_block_comment( string $content ): bool {
+		return (bool) preg_match( '/<!--\s*\/?wp:/', $content );
+	}
+}
+
+if ( ! function_exists( 'bfb_html_contains_markdown_markers' ) ) {
+	/**
+	 * Detect common markdown markers in content declared as HTML.
+	 *
+	 * @param string $content Content to scan.
+	 * @return bool
+	 */
+	function bfb_html_contains_markdown_markers( string $content ): bool {
+		return (bool) preg_match( '/(^|\n)\s*(```|#{1,6}\s+|[-*+]\s+\S|>\s+\S)/', $content );
+	}
+}
+
+if ( ! function_exists( 'bfb_excerpt' ) ) {
+	/**
+	 * Return a compact diagnostic excerpt.
+	 *
+	 * @param string $content Content to excerpt.
+	 * @return string
+	 */
+	function bfb_excerpt( string $content ): string {
+		$excerpt = trim( preg_replace( '/\s+/', ' ', $content ) ?? $content );
+		return substr( $excerpt, 0, 120 );
+	}
+}
+
+if ( ! function_exists( 'bfb_is_wp_error' ) ) {
+	/**
+	 * Local wrapper for tests that load the API with a minimal WP_Error stub.
+	 *
+	 * @param mixed $value Value to test.
+	 * @return bool
+	 */
+	function bfb_is_wp_error( $value ): bool {
+		return function_exists( 'is_wp_error' ) ? is_wp_error( $value ) : $value instanceof WP_Error;
+	}
+}

--- a/library.php
+++ b/library.php
@@ -69,6 +69,7 @@ $bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_vers
 	require_once $bfb_library_path . '/includes/class-bfb-html-adapter.php';
 	require_once $bfb_library_path . '/includes/class-bfb-markdown-adapter.php';
 	require_once $bfb_library_path . '/includes/api.php';
+	require_once $bfb_library_path . '/includes/normalization.php';
 	require_once $bfb_library_path . '/includes/hooks.php';
 	require_once $bfb_library_path . '/includes/rest.php';
 	require_once $bfb_library_path . '/includes/bootstrap.php';

--- a/tests/smoke-content-normalization.php
+++ b/tests/smoke-content-normalization.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Smoke coverage for malformed and mixed content normalization.
+ *
+ * @package BlockFormatBridge
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+class WP_Error {
+	/**
+	 * @var string
+	 */
+	private $code;
+
+	/**
+	 * @var string
+	 */
+	private $message;
+
+	/**
+	 * @var mixed
+	 */
+	private $data;
+
+	public function __construct( string $code = '', string $message = '', $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data() {
+		return $this->data;
+	}
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function bfb_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function bfb_smoke_assert_error( $value, string $code, string $message ): void {
+	bfb_smoke_assert( is_wp_error( $value ), $message . ' should return WP_Error.' );
+	bfb_smoke_assert( $code === $value->get_error_code(), $message . " should use {$code}." );
+	bfb_smoke_assert( '' !== $value->get_error_message(), $message . ' should include a repairable message.' );
+}
+
+function bfb_get_adapter( string $format ) {
+	return in_array( $format, array( 'html', 'markdown' ), true ) ? new stdClass() : null;
+}
+
+require_once __DIR__ . '/../includes/normalization.php';
+
+$valid_blocks = '<!-- wp:heading {"level":2} --><h2>Title</h2><!-- /wp:heading -->'
+	. '<!-- wp:paragraph --><p>Copy.</p><!-- /wp:paragraph -->'
+	. '<!-- wp:latest-posts /-->';
+
+$normalized = bfb_normalize( $valid_blocks, 'blocks' );
+bfb_smoke_assert( $valid_blocks === $normalized, 'Valid block markup should normalize stably.' );
+bfb_smoke_assert( $normalized === bfb_normalize( $normalized, 'blocks' ), 'Valid block normalization should be idempotent.' );
+
+bfb_smoke_assert_error(
+	bfb_normalize( '<!-- wp:paragraph --><p>Unclosed</p>', 'blocks' ),
+	'bfb_blocks_unclosed_comment',
+	'Unclosed block comment'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( '<!-- wp:quote --><blockquote><!-- wp:paragraph --><p>Copy</p><!-- /wp:quote --></blockquote><!-- /wp:paragraph -->', 'blocks' ),
+	'bfb_blocks_mismatched_comment',
+	'Mismatched block comment'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( '<!-- wp:heading --><h2>Title</h2><!-- /wp:heading -->\n# Markdown outside\n<!-- wp:paragraph --><p>Copy</p><!-- /wp:paragraph -->', 'blocks' ),
+	'bfb_blocks_mixed_content',
+	'Raw markdown between serialized blocks'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( '<!-- wp:heading --><h2>Title</h2><!-- /wp:heading --><div>Raw HTML</div><!-- wp:paragraph --><p>Copy</p><!-- /wp:paragraph -->', 'blocks' ),
+	'bfb_blocks_mixed_content',
+	'Raw HTML between serialized blocks'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( '<!-- wp:paragraph --><p>Bad</p><!-- /wp:paragraph', 'blocks' ),
+	'bfb_blocks_unclosed_comment',
+	'Malformed trailing block comment should not pass as valid blocks'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( '# Declared markdown\n\n<!-- wp:paragraph --><p>Block</p><!-- /wp:paragraph -->', 'markdown' ),
+	'bfb_markdown_contains_blocks',
+	'Markdown containing serialized block comments'
+);
+
+$markdown = "# Heading\r\n\r\nParagraph.";
+bfb_smoke_assert( "# Heading\n\nParagraph." === bfb_normalize( $markdown, 'markdown' ), 'Markdown normalization should normalize line endings.' );
+
+bfb_smoke_assert_error(
+	bfb_normalize( "<h1>Declared HTML</h1>\n```php\necho \"hi\";\n```", 'html' ),
+	'bfb_html_contains_markdown',
+	'HTML containing markdown fences'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( "<p>Declared HTML</p>\n# Markdown heading", 'html' ),
+	'bfb_html_contains_markdown',
+	'HTML containing markdown headings'
+);
+
+bfb_smoke_assert_error(
+	bfb_normalize( '<p>Declared HTML</p><!-- wp:paragraph --><p>Block</p><!-- /wp:paragraph -->', 'html' ),
+	'bfb_html_contains_blocks',
+	'HTML containing serialized block comments'
+);
+
+$html = '<section><h2>Valid HTML</h2><p>Copy.</p></section>';
+bfb_smoke_assert( $html === bfb_normalize( $html, 'html' ), 'Valid HTML should normalize stably.' );
+bfb_smoke_assert( $html === bfb_normalize( bfb_normalize( $html, 'html' ), 'html' ), 'Valid HTML normalization should be idempotent.' );
+
+$same_format_bad = bfb_normalize( '<!-- wp:paragraph --><p>Still open</p>', 'blocks' );
+bfb_smoke_assert_error( $same_format_bad, 'bfb_blocks_unclosed_comment', 'Bad same-format block input' );
+
+echo "PASS: content normalization contract\n";


### PR DESCRIPTION
## Summary
- Add `bfb_normalize( $content, $format, $options = array() )` as the explicit declared-format validation boundary for AI-authored content.
- Validate serialized block markup without silently accepting malformed same-format `blocks -> blocks` input.
- Add smoke coverage for malformed/mixed blocks, markdown, and HTML inputs.

## Contract
- `bfb_convert()` remains the conversion API and keeps its existing same-format no-op behavior.
- `bfb_normalize()` is the validation/normalization API callers use before trusting declared source content.
- `blocks` normalization rejects missing, unclosed, mismatched, malformed, or mixed raw content outside serialized block comments with `WP_Error`.
- `markdown` normalization rejects serialized block comments and normalizes line endings.
- `html` normalization rejects serialized block comments and common markdown markers such as fences and headings.
- `mode` accepts `strict` and `lenient`; this first pass is strict-first and reserves lenient diagnostics for a follow-up rather than pretending to safely repair more cases than it can.

## Tests
- `php tests/smoke-content-normalization.php`
- `php tests/smoke-scoped-h2bc-hooks.php`
- `php tests/smoke-multi-consumer-bundled-load.php`
- `php tests/smoke-insert-conversion-measurement.php`
- `php -l includes/api.php && php -l includes/normalization.php && php -l library.php && php -l tests/smoke-content-normalization.php`
- `git diff --check`

## Follow-ups
- No h2bc-specific defect surfaced in this pass. The covered failures are declared-format validation and mixed-content contract issues that belong in BFB.
- Future work can make `lenient` mode return richer diagnostics or repair select mixed inputs once those repairs are clearly safe.

Closes #44.
Closes #45.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the normalization API, smoke coverage, and PR preparation under Chris's review direction.
