### PR TITLE
fix: refresh scoped html-to-blocks hooks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "94f7da210f1457221173acd8e1ab028a4bc4e42d"
+                "reference": "7f2e31ca44e628062cf58b422616bf2c9f251fb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/94f7da210f1457221173acd8e1ab028a4bc4e42d",
-                "reference": "94f7da210f1457221173acd8e1ab028a4bc4e42d",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/7f2e31ca44e628062cf58b422616bf2c9f251fb0",
+                "reference": "7f2e31ca44e628062cf58b422616bf2c9f251fb0",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-04-27T19:09:00+00:00"
+            "time": "2026-04-28T16:05:24+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
@@ -108,6 +108,8 @@ class HTML_To_Blocks_Block_Factory
                 return self::generate_file_html($attributes);
             case 'core/embed':
                 return self::generate_embed_html($attributes);
+            case 'core/shortcode':
+                return $attributes['text'] ?? '';
             default:
                 return '';
         }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php
@@ -66,12 +66,12 @@ $html_to_blocks_convert_rest_callback = __NAMESPACE__ ? __NAMESPACE__ . '\html_t
 if (!\function_exists($html_to_blocks_register_rest_callback)) {
     function html_to_blocks_register_rest_filters()
     {
-        global $html_to_blocks_convert_rest_callback;
+        $convert_rest_callback = __NAMESPACE__ ? __NAMESPACE__ . '\html_to_blocks_convert_rest_response' : 'html_to_blocks_convert_rest_response';
         $default_types = \array_keys(get_post_types(array('show_in_rest' => \true, 'public' => \true)));
         $supported_types = apply_filters('html_to_blocks_supported_post_types', $default_types);
         foreach ($supported_types as $post_type) {
-            if (!\function_exists('has_filter') || \false === \has_filter("rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback)) {
-                \add_filter("rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback, 10, 3);
+            if (!\function_exists('has_filter') || \false === \has_filter("rest_prepare_{$post_type}", $convert_rest_callback)) {
+                \add_filter("rest_prepare_{$post_type}", $convert_rest_callback, 10, 3);
             }
         }
     }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/GutenbergRawHandlerParityUnitTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Gutenberg rawHandler parity contract for deterministic static HTML.
+ *
+ * @package HtmlToBlocksConverter
+ */
+/**
+ * Exercises the supported subset h2bc intentionally keeps aligned with
+ * Gutenberg rawHandler behavior.
+ */
+class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase
+{
+    /**
+     * Static raw HTML fixtures should produce the same core block families that
+     * Gutenberg rawHandler infers from equivalent deterministic markup.
+     */
+    public function test_static_gutenberg_rawhandler_parity_fixtures(): void
+    {
+        foreach ($this->parity_fixtures() as $label => $fixture) {
+            $fallbacks = array();
+            $listener = static function (string $html, array $context, array $block) use (&$fallbacks): void {
+                $fallbacks[] = array('html' => $html, 'context' => $context, 'block' => $block);
+            };
+            \add_action('html_to_blocks_unsupported_html_fallback', $listener, 10, 3);
+            try {
+                $blocks = html_to_blocks_raw_handler(array('HTML' => $fixture['html']));
+            } finally {
+                remove_action('html_to_blocks_unsupported_html_fallback', $listener, 10);
+            }
+            $this->assertSame($fixture['expected_names'], $this->flatten_block_names($blocks), "{$label} should match Gutenberg rawHandler block family parity.");
+            $this->assertSame(array(), $fallbacks, "{$label} should not fall back to core/html.");
+            $combined = $this->combined_block_payload($blocks);
+            foreach ($fixture['snippets'] ?? array() as $snippet) {
+                $this->assertStringContainsString($snippet, $combined, "{$label} should preserve {$snippet}.");
+            }
+        }
+    }
+    /**
+     * The parity documentation should name both the covered static contract and
+     * the paste/editor behavior that remains intentionally out of scope.
+     */
+    public function test_parity_document_names_scope_boundary(): void
+    {
+        $doc = \file_get_contents(\dirname(__DIR__) . '/docs/gutenberg-rawhandler-parity.md');
+        $this->assertIsString($doc);
+        $this->assertStringContainsString('deterministic static HTML', $doc);
+        $this->assertStringContainsString('Google Docs', $doc);
+        $this->assertStringContainsString('Microsoft Word', $doc);
+        $this->assertStringContainsString('Dynamic, contextual, or FSE block inference', $doc);
+    }
+    /**
+     * Gutenberg-compatible static fixture matrix.
+     *
+     * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>
+     */
+    private function parity_fixtures(): array
+    {
+        return array('heading' => array('html' => '<h2>Fixture Heading</h2>', 'expected_names' => array('core/heading'), 'snippets' => array('Fixture Heading')), 'paragraph' => array('html' => '<p>Fixture <strong>paragraph</strong>.</p>', 'expected_names' => array('core/paragraph'), 'snippets' => array('<strong>paragraph</strong>')), 'list' => array('html' => '<ul><li>One<ul><li>Child</li></ul></li><li>Two</li></ul>', 'expected_names' => array('core/list', 'core/list-item', 'core/list', 'core/list-item', 'core/list-item'), 'snippets' => array('Child', 'Two')), 'quote' => array('html' => '<blockquote><p>Quote text</p><cite>Source</cite></blockquote>', 'expected_names' => array('core/quote', 'core/paragraph', 'core/paragraph'), 'snippets' => array('Quote text', 'Source')), 'image' => array('html' => '<figure><img src="photo.jpg" alt="Alt text"><figcaption>Caption text</figcaption></figure>', 'expected_names' => array('core/image'), 'snippets' => array('photo.jpg', 'Alt text', 'Caption text')), 'code' => array('html' => '<pre><code>const answer = 42;</code></pre>', 'expected_names' => array('core/code'), 'snippets' => array('const answer = 42;')), 'preformatted' => array('html' => '<pre>Plain preformatted text</pre>', 'expected_names' => array('core/preformatted'), 'snippets' => array('Plain preformatted text')), 'separator' => array('html' => '<hr>', 'expected_names' => array('core/separator')), 'table' => array('html' => '<table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Ada</td></tr></tbody></table>', 'expected_names' => array('core/table'), 'snippets' => array('Name', 'Ada')), 'shortcode' => array('html' => '[gallery ids="1,2"]', 'expected_names' => array('core/shortcode'), 'snippets' => array('[gallery ids="1,2"]')), 'group' => array('html' => '<div class="wp-block-group"><p>Grouped copy</p></div>', 'expected_names' => array('core/group', 'core/paragraph'), 'snippets' => array('Grouped copy')), 'columns' => array('html' => '<div class="wp-block-columns"><div class="wp-block-column"><p>Left</p></div><div class="wp-block-column"><p>Right</p></div></div>', 'expected_names' => array('core/columns', 'core/column', 'core/paragraph', 'core/column', 'core/paragraph'), 'snippets' => array('Left', 'Right')), 'cover' => array('html' => '<section class="hero cover" style="background-image: url(cover.jpg)"><p>Cover text</p></section>', 'expected_names' => array('core/cover', 'core/paragraph'), 'snippets' => array('cover.jpg', 'Cover text')), 'spacer' => array('html' => '<div class="wp-block-spacer" style="height: 48px"></div>', 'expected_names' => array('core/spacer'), 'snippets' => array('48px')), 'buttons' => array('html' => '<a class="wp-block-button__link wp-element-button" href="https://example.com">Click</a>', 'expected_names' => array('core/buttons', 'core/button'), 'snippets' => array('https://example.com', 'Click')), 'details' => array('html' => '<details><summary>Question</summary><p>Answer</p></details>', 'expected_names' => array('core/details', 'core/paragraph'), 'snippets' => array('Question', 'Answer')), 'pullquote' => array('html' => '<blockquote class="wp-block-pullquote"><p>Pull this</p><cite>Citation</cite></blockquote>', 'expected_names' => array('core/pullquote'), 'snippets' => array('Pull this', 'Citation')), 'verse' => array('html' => '<pre class="wp-block-verse">Line one\nLine two</pre>', 'expected_names' => array('core/verse'), 'snippets' => array('Line one', 'Line two')), 'video' => array('html' => '<video controls src="movie.mp4" poster="poster.jpg"></video>', 'expected_names' => array('core/video'), 'snippets' => array('movie.mp4', 'poster.jpg')), 'audio' => array('html' => '<audio controls><source src="clip.mp3" type="audio/mpeg"></audio>', 'expected_names' => array('core/audio'), 'snippets' => array('clip.mp3')), 'gallery' => array('html' => '<div class="gallery columns-2"><figure><img src="a.jpg" alt="A"><figcaption>Caption A</figcaption></figure><figure><img src="b.jpg" alt="B"><figcaption>Caption B</figcaption></figure></div>', 'expected_names' => array('core/gallery', 'core/image', 'core/image'), 'snippets' => array('Caption A', 'b.jpg')), 'media-text' => array('html' => '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Media copy</p></div></div>', 'expected_names' => array('core/media-text', 'core/image', 'core/group', 'core/paragraph'), 'snippets' => array('hero.jpg', 'Media copy')), 'file' => array('html' => '<a href="https://example.com/report.pdf">Download report</a>', 'expected_names' => array('core/file'), 'snippets' => array('report.pdf', 'Download report')), 'embed' => array('html' => '<iframe src="https://www.youtube.com/embed/abc123"></iframe>', 'expected_names' => array('core/embed'), 'snippets' => array('youtube.com/watch?v=abc123')));
+    }
+    /**
+     * Flatten block names recursively.
+     *
+     * @param array<int,array<string,mixed>> $blocks Blocks.
+     * @return string[] Block names.
+     */
+    private function flatten_block_names(array $blocks): array
+    {
+        $names = array();
+        foreach ($blocks as $block) {
+            $names[] = $block['blockName'] ?? null;
+            if (!empty($block['innerBlocks'])) {
+                $names = \array_merge($names, $this->flatten_block_names($block['innerBlocks']));
+            }
+        }
+        return $names;
+    }
+    /**
+     * Collect block HTML, attrs, and nested payloads for fixture assertions.
+     *
+     * @param array<int,array<string,mixed>> $blocks Blocks.
+     * @return string Combined payload.
+     */
+    private function combined_block_payload(array $blocks): string
+    {
+        $combined = '';
+        foreach ($blocks as $block) {
+            foreach (array('innerHTML', 'content') as $key) {
+                if (isset($block[$key]) && \is_string($block[$key])) {
+                    $combined .= "\n" . $block[$key];
+                }
+            }
+            foreach ($block['attrs'] ?? array() as $value) {
+                if (\is_string($value)) {
+                    $combined .= "\n" . $value;
+                }
+            }
+            if (!empty($block['innerBlocks'])) {
+                $combined .= $this->combined_block_payload($block['innerBlocks']);
+            }
+        }
+        return $combined;
+    }
+}

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-scoped-rest-callback.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-scoped-rest-callback.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Smoke test for namespace-safe REST filter callback registration.
+ *
+ * Run with: php tests/smoke-scoped-rest-callback.php
+ *
+ * @package HTML_To_Blocks_Converter\Tests
+ */
+namespace BlockFormatBridge\Vendor\VendorScoped;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+$registered_filters = array();
+function add_filter(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): bool
+{
+    global $registered_filters;
+    $registered_filters[] = array($hook_name, $callback, $priority, $accepted_args);
+    return \true;
+}
+function has_filter(string $hook_name, $callback = \false)
+{
+    global $registered_filters;
+    foreach ($registered_filters as $filter) {
+        if ($filter[0] === $hook_name && $filter[1] === $callback) {
+            return $filter[2];
+        }
+    }
+    return \false;
+}
+function add_action(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): bool
+{
+    return add_filter($hook_name, $callback, $priority, $accepted_args);
+}
+function has_action(string $hook_name, $callback = \false)
+{
+    return has_filter($hook_name, $callback);
+}
+function get_post_types(): array
+{
+    return array('post' => 'post', 'page' => 'page');
+}
+function apply_filters(string $hook_name, $value)
+{
+    unset($hook_name);
+    return $value;
+}
+function wp_unslash($value)
+{
+    return $value;
+}
+function wp_slash($value)
+{
+    return $value;
+}
+function html_to_blocks_is_supported_type(): bool
+{
+    return \true;
+}
+function html_to_blocks_convert_content(string $content): string
+{
+    return $content;
+}
+$source = file_get_contents(dirname(__DIR__) . '/includes/hooks.php');
+$test_namespace = __NAMESPACE__;
+$source = preg_replace('/^<\?php\s*(?:namespace\s+[^;]+;\s*)?/', "<?php\nnamespace {$test_namespace};\n", $source, 1);
+$source = str_replace(array('\add_filter(', '\has_filter(', '\add_action(', '\has_action(', '\get_post_types(', '\apply_filters('), array('add_filter(', 'has_filter(', 'add_action(', 'has_action(', 'get_post_types(', 'apply_filters('), $source);
+$tmp = tempnam(sys_get_temp_dir(), 'h2bc-scoped-hooks-');
+file_put_contents($tmp, $source);
+require $tmp;
+unlink($tmp);
+html_to_blocks_register_rest_filters();
+$callbacks = array_column($registered_filters, 1);
+if (!in_array(__NAMESPACE__ . '\html_to_blocks_convert_rest_response', $callbacks, \true)) {
+    fwrite(\STDERR, "FAIL: scoped REST callback was not registered.\n");
+    exit(1);
+}
+if (in_array(null, $callbacks, \true) || in_array('', $callbacks, \true) || in_array(array(), $callbacks, \true)) {
+    fwrite(\STDERR, "FAIL: empty REST callback was registered.\n");
+    exit(1);
+}
+echo "PASS: scoped REST callback registration\n";


### PR DESCRIPTION
## Summary
- Refresh the bundled html-to-blocks-converter copy to include the scoped REST callback fix.
- Adds the vendored smoke proving scoped REST callback registration does not create empty callbacks.

## Why
After BFB's normalization work landed, the live Studio site loaded the standalone BFB plugin and emitted WordPress `_wp_filter_build_unique_id()` warnings. The bundled h2bc REST hook was reading callback state through `global`, which breaks under php-scoper namespacing and registers empty callbacks.

## Tests
- `php tests/smoke-scoped-h2bc-hooks.php`
- `php tests/smoke-content-normalization.php`
- `php vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-scoped-rest-callback.php`
- `php -l vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php`
- `git diff --check`

## Related
- chubes4/html-to-blocks-converter#32
- chubes4/html-to-blocks-converter#33
- chubes4/html-to-blocks-converter#34
- chubes4/html-to-blocks-converter#35

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Tracing the live WordPress hook warnings to the scoped h2bc REST callback, fixing h2bc upstream, rebuilding BFB's vendored copy, and verifying the scoped smoke.
