### PR TITLE
fix: make duplicate BFB versions visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Package mode loads the full bridge service: adapters, `bfb_convert()`, `bfb_rend
 `wp_insert_post_data` integration, and the REST `?content_format=` integration. If multiple plugins bundle BFB while
 the standalone plugin is also active, the registry initializes the highest loaded version once.
 
+Released copies with distinct semantic versions are the safe multi-bundle path. If two different sources register the
+same semantic version, BFB keeps both registrations, emits a diagnostic with both source paths, and deterministically
+initializes the later registration. That same-version tie-break is a fallback for visibility, not a release strategy:
+different `dev-main` commits that report the same `$bfb_library_version` can expose different APIs, so consumers should
+not deploy mixed unreleased commits unless they intentionally control the load order.
+
 HTML → Blocks support is bundled via [`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter)
 as a Composer package. You do **not** need the standalone html-to-blocks-converter plugin active for BFB to convert
 HTML/Markdown into block markup.

--- a/includes/class-bfb-versions.php
+++ b/includes/class-bfb-versions.php
@@ -29,11 +29,18 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 		private static $instance = null;
 
 		/**
-		 * Version => initializer callback.
+		 * Registered bridge copies.
 		 *
-		 * @var array<string, callable>
+		 * @var array<int, array{version: string, initializer: callable, source: string, order: int}>
 		 */
 		private $versions = array();
+
+		/**
+		 * Monotonic registration counter for deterministic same-version ties.
+		 *
+		 * @var int
+		 */
+		private $registration_order = 0;
 
 		/**
 		 * Whether the winning version has initialized.
@@ -79,16 +86,31 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 		/**
 		 * Register one copy of the bridge.
 		 *
-		 * @param string   $version     Semantic version string.
-		 * @param callable $initializer Initializer that loads this copy's files.
+		 * @param string      $version     Semantic version string.
+		 * @param callable    $initializer Initializer that loads this copy's files.
+		 * @param string|null $source      Optional source path or label for diagnostics.
 		 * @return void
 		 */
-		public function register( string $version, callable $initializer ): void {
+		public function register( string $version, callable $initializer, ?string $source = null ): void {
 			if ( $this->initialized ) {
 				return;
 			}
 
-			$this->versions[ $version ] = $initializer;
+			$source = $source ?: $this->describe_initializer( $initializer );
+
+			foreach ( $this->versions as $entry ) {
+				if ( $version === $entry['version'] && $source !== $entry['source'] ) {
+					$this->warn_duplicate_version( $version, $entry['source'], $source );
+					break;
+				}
+			}
+
+			$this->versions[] = array(
+				'version'     => $version,
+				'initializer' => $initializer,
+				'source'      => $source,
+				'order'       => ++$this->registration_order,
+			);
 		}
 
 		/**
@@ -110,9 +132,22 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 				return;
 			}
 
-			uksort( $this->versions, 'version_compare' );
-			$version     = array_key_last( $this->versions );
-			$initializer = $this->versions[ $version ];
+			$versions = $this->versions;
+			usort(
+				$versions,
+				static function ( array $left, array $right ): int {
+					$version_compare = version_compare( $left['version'], $right['version'] );
+					if ( 0 !== $version_compare ) {
+						return $version_compare;
+					}
+
+					return $left['order'] <=> $right['order'];
+				}
+			);
+
+			$winner      = $versions[ array_key_last( $versions ) ];
+			$version     = $winner['version'];
+			$initializer = $winner['initializer'];
 
 			$this->initialized = true;
 			$initializer();
@@ -123,6 +158,58 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 			 * @param string $version Loaded version.
 			 */
 			do_action( 'bfb_loaded', $version );
+		}
+
+		/**
+		 * Create a useful source label when the caller does not provide one.
+		 *
+		 * @param callable $initializer Initializer callback.
+		 * @return string
+		 */
+		private function describe_initializer( callable $initializer ): string {
+			if ( $initializer instanceof Closure ) {
+				$reflection = new ReflectionFunction( $initializer );
+				return $reflection->getFileName() ?: 'closure:' . spl_object_id( $initializer );
+			}
+
+			if ( is_string( $initializer ) ) {
+				return $initializer;
+			}
+
+			if ( is_array( $initializer ) && 2 === count( $initializer ) ) {
+				$class = is_object( $initializer[0] ) ? get_class( $initializer[0] ) : (string) $initializer[0];
+				return $class . '::' . (string) $initializer[1];
+			}
+
+			if ( is_object( $initializer ) ) {
+				return get_class( $initializer ) . ':' . spl_object_id( $initializer );
+			}
+
+			return 'callable:' . md5( gettype( $initializer ) );
+		}
+
+		/**
+		 * Warn when two different sources claim the same semantic version.
+		 *
+		 * @param string $version         Duplicate semantic version.
+		 * @param string $existing_source First registered source.
+		 * @param string $new_source      Later registered source.
+		 * @return void
+		 */
+		private function warn_duplicate_version( string $version, string $existing_source, string $new_source ): void {
+			$message = sprintf(
+				'Block Format Bridge version %1$s was registered by multiple sources. Same-version ties are deterministic but unsafe for different dev-main commits; the last registration wins. Existing source: %2$s. New source: %3$s.',
+				$version,
+				$existing_source,
+				$new_source
+			);
+
+			if ( function_exists( '_doing_it_wrong' ) ) {
+				_doing_it_wrong( __METHOD__, $message, $version );
+				return;
+			}
+
+			trigger_error( $message, E_USER_WARNING );
 		}
 	}
 }

--- a/library.php
+++ b/library.php
@@ -75,8 +75,8 @@ $bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_vers
 	require_once $bfb_library_path . '/includes/bootstrap.php';
 };
 
-$bfb_register = static function () use ( $bfb_library_version, $bfb_initializer ): void {
-	BFB_Versions::instance()->register( $bfb_library_version, $bfb_initializer );
+$bfb_register = static function () use ( $bfb_library_path, $bfb_library_version, $bfb_initializer ): void {
+	BFB_Versions::instance()->register( $bfb_library_version, $bfb_initializer, $bfb_library_path );
 };
 
 BFB_Versions::register_hooks();

--- a/tests/smoke-duplicate-version-registry.php
+++ b/tests/smoke-duplicate-version-registry.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Smoke coverage for duplicate semantic-version registry behavior.
+ *
+ * @package BlockFormatBridge
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+$GLOBALS['bfb_duplicate_loaded_versions'] = array();
+
+function bfb_duplicate_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function do_action( string $hook_name, ...$args ): void {
+	if ( 'bfb_loaded' === $hook_name ) {
+		$GLOBALS['bfb_duplicate_loaded_versions'][] = $args[0] ?? null;
+	}
+}
+
+require_once __DIR__ . '/../includes/class-bfb-versions.php';
+
+function bfb_duplicate_reset_registry(): BFB_Versions {
+	$registry = BFB_Versions::instance();
+
+	foreach ( array( 'versions', 'initialized', 'registration_order' ) as $property_name ) {
+		$property = new ReflectionProperty( $registry, $property_name );
+
+		if ( 'versions' === $property_name ) {
+			$property->setValue( $registry, array() );
+		} elseif ( 'initialized' === $property_name ) {
+			$property->setValue( $registry, false );
+		} else {
+			$property->setValue( $registry, 0 );
+		}
+	}
+
+	$GLOBALS['bfb_duplicate_loaded_versions'] = array();
+
+	return $registry;
+}
+
+$registry      = bfb_duplicate_reset_registry();
+$api_surface   = array();
+$initialized   = array();
+$old_source    = __DIR__ . '/fixtures/old-bfb-copy';
+$new_source    = __DIR__ . '/fixtures/new-bfb-copy';
+$old_api_loader = static function () use ( &$api_surface, &$initialized ): void {
+	$api_surface   = array( 'bfb_convert' );
+	$initialized[] = 'old';
+};
+$new_api_loader = static function () use ( &$api_surface, &$initialized ): void {
+	$api_surface   = array( 'bfb_convert', 'bfb_normalize' );
+	$initialized[] = 'new';
+};
+
+$registry->register( '0.3.0', $old_api_loader, $old_source );
+$registry->register( '0.4.0', $new_api_loader, $new_source );
+$registry->initialize_latest();
+
+bfb_duplicate_assert( array( 'new' ) === $initialized, 'Different semantic versions should still initialize the highest version.' );
+bfb_duplicate_assert( array( '0.4.0' ) === $GLOBALS['bfb_duplicate_loaded_versions'], 'bfb_loaded should receive the highest version.' );
+
+$registry      = bfb_duplicate_reset_registry();
+$api_surface   = array();
+$initialized   = array();
+$warnings      = array();
+set_error_handler(
+	static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+		if ( E_USER_WARNING === $errno && str_contains( $errstr, 'Block Format Bridge version 0.3.0 was registered by multiple sources' ) ) {
+			$warnings[] = $errstr;
+			return true;
+		}
+
+		return false;
+	}
+);
+
+$registry->register( '0.3.0', $old_api_loader, $old_source );
+$registry->register( '0.3.0', $new_api_loader, $new_source );
+restore_error_handler();
+
+$versions = new ReflectionProperty( $registry, 'versions' );
+$registered_versions = $versions->getValue( $registry );
+
+bfb_duplicate_assert( 1 === count( $warnings ), 'Duplicate semantic versions from different sources should emit one warning.' );
+bfb_duplicate_assert( str_contains( $warnings[0], $old_source ), 'Duplicate warning should include the first source.' );
+bfb_duplicate_assert( str_contains( $warnings[0], $new_source ), 'Duplicate warning should include the later source.' );
+bfb_duplicate_assert( array( '0.3.0', '0.3.0' ) === array_column( $registered_versions, 'version' ), 'Duplicate versions should both remain registered.' );
+
+$registry->initialize_latest();
+
+bfb_duplicate_assert( array( 'new' ) === $initialized, 'Same-version duplicate ties should deterministically initialize the later registration.' );
+bfb_duplicate_assert( array( 'bfb_convert', 'bfb_normalize' ) === $api_surface, 'Same-version duplicate ties should load the later registration API surface.' );
+bfb_duplicate_assert( array( '0.3.0' ) === $GLOBALS['bfb_duplicate_loaded_versions'], 'bfb_loaded should still fire once for duplicate-version ties.' );
+
+echo "PASS: duplicate BFB version registry behavior\n";

--- a/tests/smoke-multi-consumer-bundled-load.php
+++ b/tests/smoke-multi-consumer-bundled-load.php
@@ -269,7 +269,14 @@ try {
 	$registered_versions = $versions->getValue( $registry );
 
 	bfb_smoke_assert( is_array( $registered_versions ), 'Registered versions should be inspectable.' );
-	bfb_smoke_assert( array( '0.3.0', '9.9.9' ) === array_keys( $registered_versions ), 'Both consumer copies should register their BFB versions.' );
+	bfb_smoke_assert(
+		array( '0.3.0', '9.9.9' ) === array_column( $registered_versions, 'version' ),
+		'Both consumer copies should register their BFB versions.'
+	);
+	bfb_smoke_assert(
+		array( realpath( $consumer_a ), realpath( $consumer_b ) ) === array_column( $registered_versions, 'source' ),
+		'Both consumer copies should retain source paths for duplicate-version diagnostics.'
+	);
 
 	bfb_smoke_do_action_range( 'plugins_loaded', 1, 1 );
 


### PR DESCRIPTION
## Summary
- Preserve all BFB version registrations instead of keying by semantic version and silently overwriting duplicates.
- Keep the existing highest-version behavior for released copies while adding deterministic same-version tie handling.
- Document the `dev-main` duplicate-version risk and add smoke coverage for the duplicate API-surface case.

## Behaviour for duplicate semantic versions
- Different semantic versions still sort with `version_compare()`, and the highest version initializes.
- Same semantic-version ties are sorted by registration order, so the later registration wins deterministically.
- When two different sources register the same version, BFB emits a diagnostic containing both source paths. This makes duplicate `dev-main` skew visible instead of silently choosing one initializer.

## Tests
- `php tests/smoke-multi-consumer-bundled-load.php`
- `php tests/smoke-duplicate-version-registry.php`
- `php tests/smoke-content-normalization.php`
- `git diff --check`

Closes #48

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the registry behavior change, smoke coverage, documentation, and local verification. Chris remains responsible for review and merge.
