### PR TITLE
docs: update block theme compiler terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ The insert/update hook path is split by source format:
 
 Both paths are server-side and deterministic. There is no AI conversion pass in BFB or h2bc.
 
-FSE and template blocks are a higher-level concern. Raw HTML can describe markup, but it often cannot encode intent such
-as template areas, patterns, block locking, global style relationships, or theme-specific structure. When that intent is
-required, use a compiler or generation layer above BFB/h2bc, then pass the resulting block markup through the normal
-storage/rendering path.
+Block-theme structure and Site Editor behavior are higher-level concerns. Raw HTML can describe markup, but it often
+cannot encode intent such as template areas, patterns, block locking, global style relationships, or theme-specific
+structure. When that intent is required, use a compiler or generation layer above BFB/h2bc, then pass the resulting block
+markup through the normal storage/rendering path.
 
 ## Install
 
@@ -217,11 +217,11 @@ when active. The bridge surface is the simpler, programmatic query-param form.
 
 Resolve a registered adapter directly. Useful when callers need block arrays instead of serialized content.
 
-### FSE / Site Compiler Consumers
+### Block Theme Compiler Consumers
 
 Static HTML/CSS to block-theme compilers should treat BFB as the format-conversion substrate, not the layer that infers
-FSE intent. Proposed compiler-facing helpers and CLI shape are documented in
-[`docs/fse-compiler-surface.md`](docs/fse-compiler-surface.md).
+block-theme or Site Editor intent. Proposed compiler-facing helpers and CLI shape are documented in
+[`docs/block-theme-compiler-surface.md`](docs/block-theme-compiler-surface.md).
 
 ### Filters
 

--- a/docs/block-theme-compiler-surface.md
+++ b/docs/block-theme-compiler-surface.md
@@ -1,8 +1,8 @@
-# FSE Compiler Consumer Surface
+# Block Theme Compiler Consumer Surface
 
 Issue: https://github.com/chubes4/block-format-bridge/issues/29
 
-This note defines the Block Format Bridge surface a future static HTML/CSS to block-theme compiler should consume. It is intentionally limited to BFB's boundary: format conversion through the block pivot. FSE inference, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside html-to-blocks-converter.
+This note defines the Block Format Bridge surface a future static HTML/CSS to block-theme compiler should consume. It is intentionally limited to BFB's boundary: format conversion through the block pivot. Block-theme structure, Site Editor behavior, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside html-to-blocks-converter.
 
 ## Boundary
 


### PR DESCRIPTION
## Summary
- Updates BFB docs to use current WordPress terminology around block themes and the Site Editor instead of the older FSE framing.
- Renames the compiler surface note to docs/block-theme-compiler-surface.md and updates README links.

## Tests
- Grepped README and docs for remaining FSE / Full Site Editing / fse-compiler references.
- Not run: runtime tests, docs-only change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the documentation wording and opened the PR; Chris directed the terminology change.