### PR TITLE
fix: preserve code fence language hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,6 @@ add_filter( 'bfb_register_format_adapter', function ( $adapter, $slug ) {
 
 ## Known limitations
 
-- **Code-fence language hints round-trip lossily.** `\`\`\`php` becomes `\`\`\`` after Blocks → Markdown. The block
-  carries `className: language-php` but league/html-to-markdown doesn't reconstruct the fence info string. Track in
-  follow-up issue.
 - **Custom blocks without sensible HTML rendering produce garbage markdown.** Out of bridge scope; document in your
   block.
 

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -104,8 +104,13 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 		$html = (string) preg_replace_callback(
 			'#<pre\b[^>]*>(.*?)</pre>#is',
 			static function ( array $match ): string {
+				$language_class = '';
+				if ( preg_match( '/\blanguage-([A-Za-z0-9_-]+)/', $match[0], $language_match ) ) {
+					$language_class = ' class="language-' . esc_attr( $language_match[1] ) . '"';
+				}
+
 				$inner = html_entity_decode( strip_tags( $match[1] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-				return '<pre><code>' . htmlspecialchars( $inner, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) . '</code></pre>';
+				return '<pre><code' . $language_class . '>' . htmlspecialchars( $inner, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) . '</code></pre>';
 			},
 			$html
 		);

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -287,11 +287,9 @@ MARKDOWN;
 		$this->assertStringContainsString( 'Paragraph with **bold**.', $markdown );
 		$this->assertStringContainsString( '- One', $markdown );
 		$this->assertStringContainsString( '> Quote text', $markdown );
+		$this->assertStringContainsString( '```php', $markdown );
 		$this->assertStringContainsString( 'echo "hi";', $markdown );
 		$this->assertStringContainsString( '| Name | BFB |', $markdown );
-
-		// league/html-to-markdown currently preserves code content but not the language hint.
-		$this->assertStringNotContainsString( '```php', $markdown );
 	}
 
 	/**
@@ -346,7 +344,7 @@ MARKDOWN;
 			. '<!-- wp:paragraph --><p>Block paragraph with <strong>bold</strong>, <em>emphasis</em>, and <a href="https://example.com">example link</a>.</p><!-- /wp:paragraph -->'
 			. '<!-- wp:list --><ul class="wp-block-list"><!-- wp:list-item --><li>First block item</li><!-- /wp:list-item --><li>Second block item</li></ul><!-- /wp:list -->'
 			. '<!-- wp:quote --><blockquote class="wp-block-quote"><!-- wp:paragraph --><p>Quoted blocks</p><!-- /wp:paragraph --></blockquote><!-- /wp:quote -->'
-			. '<!-- wp:code --><pre class="wp-block-code"><code>echo &quot;matrix&quot;;</code></pre><!-- /wp:code -->'
+			. '<!-- wp:code --><pre class="wp-block-code language-php"><code>echo &quot;matrix&quot;;</code></pre><!-- /wp:code -->'
 			. '<!-- wp:table --><figure class="wp-block-table"><table><tbody><tr><td>Name</td><td>Value</td></tr><tr><td>BFB</td><td>Matrix</td></tr></tbody></table></figure><!-- /wp:table -->';
 
 		$matrix = array(
@@ -372,7 +370,7 @@ MARKDOWN;
 				'from'     => 'blocks',
 				'to'       => 'markdown',
 				'content'  => $blocks,
-				'contains' => array( '## Block Matrix', '**bold**', '*emphasis*', '[example link](https://example.com)', '> Quoted blocks', 'echo "matrix";', '| Name | Value |' ),
+				'contains' => array( '## Block Matrix', '**bold**', '*emphasis*', '[example link](https://example.com)', '> Quoted blocks', '```php', 'echo "matrix";', '| Name | Value |' ),
 			),
 			'html -> markdown' => array(
 				'from'     => 'html',


### PR DESCRIPTION
## Summary
- Preserve `language-*` classes while flattening rendered `<pre>` markup before Blocks → Markdown conversion.
- Update the conversion matrix so language-qualified code fences are covered, and remove the resolved limitation from the README.

## Tests
- `php -l includes/class-bfb-markdown-adapter.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@fix-code-fence-language-hints`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small implementation, updated tests/docs, and ran the focused verification. Chris remains responsible for review and merge.
