### PR TITLE
docs: define explicit Site Editor primitive markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ cannot encode intent such as template areas, patterns, block locking, global sty
 structure. When that intent is required, use a compiler or generation layer above BFB/h2bc, then pass the resulting block
 markup through the normal storage/rendering path.
 
+### Explicit Site Editor primitive markers
+
+BFB defines the public marker vocabulary for Site Editor primitives that cannot be inferred safely from arbitrary HTML.
+Only BFB-owned attributes are part of this contract:
+
+| Primitive | Marker | Deterministic block target |
+|-----------|--------|----------------------------|
+| Pattern reference | `data-bfb-pattern="namespace/slug"` | `core/pattern` with `slug: "namespace/slug"` |
+| Template part reference | `data-bfb-template-part="area-or-slug"` | `core/template-part` with `slug` and, when applicable, `area` |
+
+Rules:
+
+- BFB and h2bc must never infer patterns or template parts from layout, tag names, classes, or visual similarity.
+- `data-wp-*` aliases are intentionally not accepted. WordPress does not currently define those source-HTML markers, and
+  BFB should not mint WordPress-looking attributes for its own API.
+- Pattern markers require a fully-qualified `namespace/slug` value.
+- Template-part markers accept the standard Site Editor areas (`header`, `footer`, `sidebar`) as shorthand values. Other
+  values are treated as explicit template-part slugs.
+- Missing or malformed marker values should fall back to the normal HTML conversion path rather than guessing.
+
+The marker contract belongs in BFB because BFB is the public conversion substrate. The runtime HTML-element transforms
+belong in h2bc because `BFB_HTML_Adapter::to_blocks()` delegates HTML → Blocks conversion to
+`html_to_blocks_raw_handler()`. BFB will inherit marker support after h2bc implements those explicit raw transforms and
+the bundled dependency is refreshed.
+
 ## Install
 
 Install it as a standalone plugin, or bundle it as a Composer package.

--- a/docs/block-theme-compiler-surface.md
+++ b/docs/block-theme-compiler-surface.md
@@ -24,6 +24,29 @@ HTML / Markdown / future formats
 
 A site compiler can use BFB for deterministic conversion once it has already decided what belongs in templates, template parts, patterns, posts, or global styles.
 
+## Explicit Site Editor Primitive Markers
+
+BFB's public marker vocabulary is intentionally narrow and explicit:
+
+- `data-bfb-pattern="namespace/slug"` declares a WordPress pattern reference.
+- `data-bfb-template-part="area-or-slug"` declares a template part reference.
+
+These markers exist for compiler output, not heuristic discovery. A compiler may emit them after it has already decided
+that a fragment should become a pattern reference or template part. BFB/h2bc must not infer the same primitives from
+ordinary wrappers such as `<header>`, `<footer>`, `<section class="hero">`, or a repeated layout shape.
+
+The deterministic targets are:
+
+- Pattern marker → `core/pattern` with the marker value as `slug`.
+- Template-part marker → `core/template-part` with the marker value as `slug`, and `area` when the value is a standard Site Editor area such as `header`, `footer`, or `sidebar`.
+
+`data-wp-*` aliases are out of scope unless WordPress itself defines them as source-HTML markers. BFB-owned attributes
+avoid implying a WordPress core contract that does not exist.
+
+Implementation note: the marker contract is documented here because BFB owns the public conversion substrate. The actual
+HTML-element transforms belong in html-to-blocks-converter, the library BFB delegates to for HTML → Blocks. BFB should not
+add a parallel pre-parser around h2bc for these markers.
+
 ## Answers
 
 ### 1. First-class block-array helper

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -160,6 +160,29 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Site Editor primitives must never be inferred from lookalike HTML.
+	 */
+	public function test_html_to_blocks_does_not_infer_site_editor_primitives(): void {
+		$fixtures = array(
+			'unmarked header'           => '<header><h1>Site title</h1><nav><a href="/">Home</a></nav></header>',
+			'unmarked footer'           => '<footer><p>Copyright</p></footer>',
+			'unmarked sidebar'          => '<aside><h2>Related</h2><p>Links</p></aside>',
+			'unmarked pattern-lookalike' => '<section class="pricing-table"><h2>Pricing</h2><p>$10</p></section>',
+		);
+
+		foreach ( $fixtures as $label => $html ) {
+			$serialized = bfb_convert( $html, 'html', 'blocks' );
+			$blocks     = parse_blocks( $serialized );
+			$flat       = $this->flatten_blocks( $blocks );
+
+			$this->assertNotContains( 'core/template-part', $flat, "{$label} must not infer a template part." );
+			$this->assertNotContains( 'core/pattern', $flat, "{$label} must not infer a pattern." );
+			$this->assertStringNotContainsString( '<!-- wp:template-part', $serialized, "{$label} must not serialize a template part." );
+			$this->assertStringNotContainsString( '<!-- wp:pattern', $serialized, "{$label} must not serialize a pattern." );
+		}
+	}
+
+	/**
 	 * Unsupported embeds should stay observable and preserve their HTML fallback.
 	 */
 	public function test_html_to_blocks_emits_unsupported_fallback_hook(): void {


### PR DESCRIPTION
## Summary
- Defines BFB-owned explicit Site Editor primitive markers for pattern and template-part intent.
- Documents why runtime marker transforms belong in html-to-blocks-converter, not a parallel BFB pre-parser.
- Adds coverage that unmarked Site Editor lookalikes never become pattern or template-part blocks by heuristic.

## Changes
- Adds `data-bfb-pattern="namespace/slug"` and `data-bfb-template-part="area-or-slug"` as the documented marker contract.
- Explicitly rejects `data-wp-*` aliases until/unless WordPress defines them as source-HTML markers.
- Keeps runtime implementation split upstream: h2bc owns HTML raw transforms; BFB inherits them through `BFB_HTML_Adapter` after dependency refresh.

## Tests
- `php -l tests/BFBConversionUnitTest.php`
- `homeboy test block-format-bridge --path .`
- `/usr/bin/grep -n "FSE" README.md docs/block-theme-compiler-surface.md`

## Closes
- Closes #61
- Refs #63
- Refs #67

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing/drafting this scoped change; Chris directed the work.