### PR TITLE
Add compiler conversion helpers and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ become available by registering a new adapter; the bridge core never grows.
 BFB exposes two related but separate public surfaces:
 
 - **`bfb_convert()`** converts content between two different formats. It uses WordPress block arrays as the pivot.
+- **`bfb_to_blocks()`** converts a supported source format directly into parsed WordPress block arrays for compilers.
 - **`bfb_normalize()`** validates and normalizes content that already claims to be in one format.
 
 | Conversion direction | Underlying tool                        |
@@ -50,7 +51,7 @@ BFB includes two adapters:
 Every cross-format conversion routes through the block-array pivot:
 
 ```
-$blocks = $from_adapter->to_blocks( $content );
+$blocks = bfb_to_blocks( $content, $from );
 return    $to_adapter->from_blocks( $blocks );
 ```
 
@@ -175,6 +176,38 @@ $md = bfb_convert( '<h1>X</h1>', 'html', 'markdown' );
 $html = bfb_convert( '# X', 'markdown', 'html' );
 ```
 
+### `bfb_to_blocks( $content, $from ): array`
+
+Compiler-facing conversion helper. Use this when you need parsed block arrays for inspection, splitting, policy checks,
+or template/pattern assembly instead of serialized block markup.
+
+```php
+$blocks = bfb_to_blocks( '<h1>Hello</h1><p>World</p>', 'html' );
+
+foreach ( $blocks as $block ) {
+    // parse_blocks()-compatible arrays.
+}
+```
+
+Contract:
+
+- `from === 'blocks'` parses serialized block markup with `parse_blocks()`.
+- Other formats resolve through `bfb_get_adapter( $from )` and call the adapter's `to_blocks()` method.
+- Unsupported source formats return an empty array and log the same style of error as `bfb_convert()`.
+
+### WP-CLI: `wp bfb convert`
+
+Non-PHP callers can route conversion through the same public BFB APIs:
+
+```bash
+wp bfb convert --from=html --to=blocks < input.html
+wp bfb convert --from=blocks --to=markdown --input=post.html --output=post.md
+wp bfb convert --from=html --to=blocks --as=json < input.html
+```
+
+The command reads STDIN when `--input` is omitted and writes STDOUT when `--output` is omitted. Default output is serialized
+content; use `--as=json` with `--to=blocks` when a block-array JSON document is needed.
+
 ### `bfb_normalize( $content, $format, $options = array() ): string|WP_Error`
 
 Validate and normalize content already declared as one format. Use this for imported or generated content before storage.
@@ -240,12 +273,12 @@ when active. The bridge surface is the simpler, programmatic query-param form.
 
 ### `bfb_get_adapter( $slug ): ?BFB_Format_Adapter`
 
-Resolve a registered adapter directly. Useful when callers need block arrays instead of serialized content.
+Resolve a registered adapter directly. Prefer `bfb_to_blocks()` when callers need block arrays instead of adapter internals.
 
 ### Block Theme Compiler Consumers
 
 Static HTML/CSS to block-theme compilers should treat BFB as the format-conversion substrate, not the layer that infers
-block-theme or Site Editor intent. Proposed compiler-facing helpers and CLI shape are documented in
+block-theme or Site Editor intent. The compiler-facing helper and CLI shape are documented in
 [`docs/block-theme-compiler-surface.md`](docs/block-theme-compiler-surface.md). The public mechanical conversion scope
 matrix is documented in [`docs/mechanical-block-theme-conversion.md`](docs/mechanical-block-theme-conversion.md).
 

--- a/docs/block-theme-compiler-surface.md
+++ b/docs/block-theme-compiler-surface.md
@@ -51,11 +51,11 @@ add a parallel pre-parser around h2bc for these markers.
 
 ### 1. First-class block-array helper
 
-BFB should expose a small helper like `bfb_to_blocks( string $content, string $from ): array`.
+BFB exposes `bfb_to_blocks( string $content, string $from ): array`.
 
 Today callers can already get block arrays with `bfb_get_adapter( $from )->to_blocks( $content )`, but that reaches through the public registry into the adapter contract. Compiler code should not need to know whether `'blocks'` is a special source, whether an adapter exists, or whether the input should be parsed with `parse_blocks()`.
 
-Recommended contract:
+Contract:
 
 ```php
 /**
@@ -73,11 +73,11 @@ Behavior:
 - Unsupported formats return an empty array and log the same style of error as `bfb_convert()`.
 - The helper should be the internal source of truth for `bfb_convert()` once implemented, avoiding two conversion paths.
 
-This is a small API addition, but it is not required before compiler exploration can begin.
+Use this helper instead of reaching into adapters directly.
 
 ### 2. WP-CLI conversion command
 
-BFB should eventually expose a CLI command for non-PHP callers, but not as part of this issue.
+BFB exposes a CLI command for non-PHP callers.
 
 Node-based tools such as Studio can already call WordPress through WP-CLI. A command like this would let those tools use the server-side converter without embedding PHP glue:
 
@@ -85,7 +85,7 @@ Node-based tools such as Studio can already call WordPress through WP-CLI. A com
 wp bfb convert --from=html --to=blocks < input.html
 ```
 
-Recommended initial command shape:
+Command shape:
 
 - `wp bfb convert --from=<format> --to=<format> [--input=<file>] [--output=<file>]`
 - Read STDIN when `--input` is omitted.
@@ -93,7 +93,7 @@ Recommended initial command shape:
 - Return serialized content for normal format targets.
 - Use a separate flag for structured block arrays, for example `--as=json`, rather than overloading the default output.
 
-This should land after the PHP helper surface is stable, because the CLI should be a thin wrapper around the public API rather than a parallel conversion path.
+The CLI is a thin wrapper around `bfb_convert()` for serialized output and `bfb_to_blocks()` for `--as=json` structured block output.
 
 ### 3. Arrays plus serialized markup in one call
 
@@ -145,6 +145,6 @@ That gives compiler consumers a stable integration target without moving transfo
 ## Recommended Sequence
 
 1. Document this surface now.
-2. Add `bfb_to_blocks()` when the first compiler consumer needs block arrays directly.
+2. Use `bfb_to_blocks()` when a compiler consumer needs block arrays directly.
 3. Add `bfb_to_block_document()` if callers repeatedly need arrays plus serialized markup from the same source.
-4. Add `wp bfb convert` after the PHP helpers settle, using the helpers internally.
+4. Use `wp bfb convert` for non-PHP callers that need server-side conversion.

--- a/includes/api.php
+++ b/includes/api.php
@@ -5,6 +5,7 @@
  * These functions form the public Phase 1 surface:
  *
  *   bfb_convert( $content, $from, $to )     — universal conversion
+ *   bfb_to_blocks( $content, $from )        — block-array conversion
  *   bfb_normalize( $content, $format )      — declared-format validation
  *   bfb_get_adapter( $slug )                — registry lookup
  *
@@ -31,13 +32,40 @@ if ( ! function_exists( 'bfb_get_adapter' ) ) {
 	}
 }
 
+if ( ! function_exists( 'bfb_to_blocks' ) ) {
+	/**
+	 * Convert content into parse_blocks()-compatible block arrays.
+	 *
+	 * This is the compiler-facing helper for callers that need the block-array
+	 * pivot directly instead of serialized block markup.
+	 *
+	 * @param string $content Source content.
+	 * @param string $from    Source format slug.
+	 * @return array<int, array<string, mixed>> Block array. Empty array on unsupported source.
+	 */
+	function bfb_to_blocks( string $content, string $from ): array {
+		if ( 'blocks' === $from ) {
+			return parse_blocks( $content );
+		}
+
+		$from_adapter = bfb_get_adapter( $from );
+		if ( ! $from_adapter ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Matches existing public conversion failure diagnostics.
+			error_log( sprintf( '[Block Format Bridge] No adapter registered for source format "%s".', $from ) );
+			return array();
+		}
+
+		return $from_adapter->to_blocks( $content );
+	}
+}
+
 if ( ! function_exists( 'bfb_convert' ) ) {
 	/**
 	 * Convert content from one format to another.
 	 *
 	 * Routing always passes through the block pivot:
 	 *
-	 *   $blocks = $from_adapter->to_blocks( $content );
+	 *   $blocks = bfb_to_blocks( $content, $from );
 	 *   return    $to_adapter->from_blocks( $blocks );
 	 *
 	 * Special cases:
@@ -57,19 +85,9 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 			return $content;
 		}
 
-		// Resolve the block-array intermediate.
-		if ( 'blocks' === $from ) {
-			$blocks = parse_blocks( $content );
-			if ( ! is_array( $blocks ) ) {
-				$blocks = array();
-			}
-		} else {
-			$from_adapter = bfb_get_adapter( $from );
-			if ( ! $from_adapter ) {
-				error_log( sprintf( '[Block Format Bridge] No adapter registered for source format "%s".', $from ) );
-				return '';
-			}
-			$blocks = $from_adapter->to_blocks( $content );
+		$blocks = bfb_to_blocks( $content, $from );
+		if ( array() === $blocks && 'blocks' !== $from ) {
+			return '';
 		}
 
 		// Render the intermediate into the target format.
@@ -79,6 +97,7 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 
 		$to_adapter = bfb_get_adapter( $to );
 		if ( ! $to_adapter ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Matches existing public conversion failure diagnostics.
 			error_log( sprintf( '[Block Format Bridge] No adapter registered for target format "%s".', $to ) );
 			return '';
 		}

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * WP-CLI integration.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+if ( ! class_exists( 'BFB_CLI_Command' ) ) {
+	/**
+	 * Block Format Bridge WP-CLI commands.
+	 */
+	class BFB_CLI_Command {
+
+		/**
+		 * Convert content between formats.
+		 *
+		 * ## OPTIONS
+		 *
+		 * --from=<format>
+		 * : Source format slug.
+		 *
+		 * --to=<format>
+		 * : Target format slug.
+		 *
+		 * [--input=<file>]
+		 * : Read input from a file instead of STDIN.
+		 *
+		 * [--output=<file>]
+		 * : Write output to a file instead of STDOUT.
+		 *
+		 * [--as=<format>]
+		 * : Output representation. Use `json` with `--to=blocks` for parsed block arrays.
+		 *
+		 * @param array<int, string>   $args       Positional arguments.
+		 * @param array<string, mixed> $assoc_args Associative arguments.
+		 * @return void
+		 */
+		public function convert( array $args, array $assoc_args ): void {
+			unset( $args );
+
+			$from = isset( $assoc_args['from'] ) ? (string) $assoc_args['from'] : '';
+			$to   = isset( $assoc_args['to'] ) ? (string) $assoc_args['to'] : '';
+			$as   = isset( $assoc_args['as'] ) ? (string) $assoc_args['as'] : 'content';
+
+			if ( '' === $from ) {
+				WP_CLI::error( 'Missing required --from=<format> argument.' );
+			}
+
+			if ( '' === $to ) {
+				WP_CLI::error( 'Missing required --to=<format> argument.' );
+			}
+
+			if ( ! in_array( $as, array( 'content', 'json' ), true ) ) {
+				WP_CLI::error( 'Unsupported --as value. Use "content" or "json".' );
+			}
+
+			if ( 'json' === $as && 'blocks' !== $to ) {
+				WP_CLI::error( '--as=json is only supported with --to=blocks.' );
+			}
+
+			if ( 'blocks' !== $from && ! bfb_get_adapter( $from ) ) {
+				WP_CLI::error( sprintf( 'No BFB adapter registered for source format: %s', $from ) );
+			}
+
+			if ( 'blocks' !== $to && ! bfb_get_adapter( $to ) ) {
+				WP_CLI::error( sprintf( 'No BFB adapter registered for target format: %s', $to ) );
+			}
+
+			$content = $this->read_input( isset( $assoc_args['input'] ) ? (string) $assoc_args['input'] : '' );
+			if ( 'json' === $as ) {
+				$output = wp_json_encode( bfb_to_blocks( $content, $from ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+				if ( false === $output ) {
+					WP_CLI::error( 'Failed to encode block output as JSON.' );
+				}
+			} else {
+				$output = bfb_convert( $content, $from, $to );
+			}
+
+			if ( false === $output || '' === $output ) {
+				WP_CLI::error( sprintf( 'BFB conversion failed for %s -> %s.', $from, $to ) );
+			}
+
+			$this->write_output( $output, isset( $assoc_args['output'] ) ? (string) $assoc_args['output'] : '' );
+		}
+
+		/**
+		 * Read command input.
+		 *
+		 * @param string $path Optional input file path.
+		 * @return string Input content.
+		 */
+		private function read_input( string $path ): string {
+			if ( '' === $path ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- php://stdin is the WP-CLI input stream.
+				$content = file_get_contents( 'php://stdin' );
+				return false === $content ? '' : $content;
+			}
+
+			if ( ! is_readable( $path ) ) {
+				WP_CLI::error( sprintf( 'Input file is not readable: %s', $path ) );
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file input is the command contract.
+			$content = file_get_contents( $path );
+			if ( false === $content ) {
+				WP_CLI::error( sprintf( 'Failed to read input file: %s', $path ) );
+			}
+
+			return (string) $content;
+		}
+
+		/**
+		 * Write command output.
+		 *
+		 * @param string $content Output content.
+		 * @param string $path    Optional output file path.
+		 * @return void
+		 */
+		private function write_output( string $content, string $path ): void {
+			if ( '' === $path ) {
+				WP_CLI::line( $content );
+				return;
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Local file output is the command contract.
+			$result = file_put_contents( $path, $content );
+			if ( false === $result ) {
+				WP_CLI::error( sprintf( 'Failed to write output file: %s', $path ) );
+			}
+		}
+	}
+}
+
+WP_CLI::add_command( 'bfb', 'BFB_CLI_Command' );

--- a/library.php
+++ b/library.php
@@ -72,6 +72,7 @@ $bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_vers
 	require_once $bfb_library_path . '/includes/normalization.php';
 	require_once $bfb_library_path . '/includes/hooks.php';
 	require_once $bfb_library_path . '/includes/rest.php';
+	require_once $bfb_library_path . '/includes/cli.php';
 	require_once $bfb_library_path . '/includes/bootstrap.php';
 };
 

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -269,6 +269,33 @@ MARKDOWN;
 	}
 
 	/**
+	 * Compiler consumers should get block arrays without reaching into adapters.
+	 */
+	public function test_bfb_to_blocks_exposes_compiler_facing_block_array_helper(): void {
+		$block_markup = '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">Array Heading</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Array paragraph.</p><!-- /wp:paragraph -->';
+
+		$parsed = bfb_to_blocks( $block_markup, 'blocks' );
+		$this->assertSame( 'core/heading', $parsed[0]['blockName'] ?? null );
+		$this->assertSame( 2, $parsed[0]['attrs']['level'] ?? null );
+		$this->assertSame( 'core/paragraph', $parsed[1]['blockName'] ?? null );
+
+		$html = bfb_to_blocks( '<h3>HTML Array</h3><p>HTML copy.</p>', 'html' );
+		$this->assertSame( 'core/heading', $html[0]['blockName'] ?? null );
+		$this->assertSame( 3, $html[0]['attrs']['level'] ?? null );
+		$this->assertSame( 'core/paragraph', $html[1]['blockName'] ?? null );
+
+		$markdown = bfb_to_blocks( "# Markdown Array\n\n- One\n- Two", 'markdown' );
+		$flat     = $this->flatten_blocks( $markdown );
+		$this->assertContains( 'core/heading', $flat );
+		$this->assertContains( 'core/list', $flat );
+		$this->assertContains( 'core/list-item', $flat );
+
+		$this->assertSame( array(), bfb_to_blocks( 'content', 'asciidoc' ) );
+		$this->assertSame( '', bfb_convert( 'content', 'asciidoc', 'blocks' ) );
+	}
+
+	/**
 	 * Blocks should render to HTML through WordPress' real render_block() path.
 	 */
 	public function test_blocks_to_html_renders_static_and_dynamic_blocks(): void {

--- a/tests/smoke-cli-command.php
+++ b/tests/smoke-cli-command.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Static smoke coverage for the WP-CLI wrapper contract.
+ *
+ * @package BlockFormatBridge
+ */
+
+declare(strict_types=1);
+
+function bfb_cli_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+$cli_source = file_get_contents( __DIR__ . '/../includes/cli.php' );
+$library    = file_get_contents( __DIR__ . '/../library.php' );
+
+bfb_cli_smoke_assert( is_string( $cli_source ), 'CLI source should be readable.' );
+bfb_cli_smoke_assert( is_string( $library ), 'Library source should be readable.' );
+
+$cli_source = (string) $cli_source;
+$library    = (string) $library;
+
+bfb_cli_smoke_assert( strpos( $library, "includes/cli.php" ) !== false, 'library.php should load the CLI integration.' );
+bfb_cli_smoke_assert( strpos( $cli_source, "WP_CLI::add_command( 'bfb', 'BFB_CLI_Command' )" ) !== false, 'CLI should register the bfb command namespace.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'public function convert' ) !== false, 'CLI should expose a convert subcommand.' );
+bfb_cli_smoke_assert( strpos( $cli_source, "file_get_contents( 'php://stdin' )" ) !== false, 'CLI should read STDIN when --input is omitted.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'file_get_contents( $path )' ) !== false, 'CLI should read file input when --input is present.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'file_put_contents( $path, $content )' ) !== false, 'CLI should write file output when --output is present.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'WP_CLI::line( $content )' ) !== false, 'CLI should write STDOUT when --output is omitted.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'bfb_convert( $content, $from, $to )' ) !== false, 'Content output should wrap bfb_convert().' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'bfb_to_blocks( $content, $from )' ) !== false, 'JSON block output should wrap bfb_to_blocks().' );
+bfb_cli_smoke_assert( strpos( $cli_source, '--as=json is only supported with --to=blocks.' ) !== false, 'Structured output should be explicit instead of overloading content output.' );
+bfb_cli_smoke_assert( substr_count( $cli_source, 'bfb_get_adapter(' ) >= 2, 'CLI should fail fast for unsupported source and target formats.' );
+
+echo "PASS: CLI command wrapper contract\n";


### PR DESCRIPTION
## Summary
- Adds `bfb_to_blocks()` as the compiler-facing block-array helper and routes `bfb_convert()` through it.
- Adds a thin `wp bfb convert` WP-CLI wrapper over `bfb_convert()` and `bfb_to_blocks()`.
- Updates compiler/docs coverage and tests the helper, unsupported formats, and CLI wrapper contract.

## Changes
- `bfb_to_blocks( string $content, string $from ): array` parses block markup directly or delegates source formats to registered adapters.
- `wp bfb convert --from=<format> --to=<format>` supports STDIN/STDOUT fallback, `--input`, `--output`, and `--as=json` for block-array output.
- Docs now point compiler consumers at the helper instead of adapter internals.

## Tests
- `php -l includes/api.php`
- `php -l includes/cli.php`
- `php tests/smoke-cli-command.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-compiler-helpers-cli`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-compiler-helpers-cli --changed-only`
- `git diff --check`

Closes #65.
Closes #66.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and drafting this scoped change; Chris directed the work.