### PR TITLE
docs: document custom block markdown contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,31 @@ block-theme or Site Editor intent. The compiler-facing helper and CLI shape are 
 [`docs/block-theme-compiler-surface.md`](docs/block-theme-compiler-surface.md). The public mechanical conversion scope
 matrix is documented in [`docs/mechanical-block-theme-conversion.md`](docs/mechanical-block-theme-conversion.md).
 
+### Custom block Markdown rendering contract
+
+BFB's Blocks → Markdown path is render-output based:
+
+```text
+parse_blocks() -> render_block() -> league/html-to-markdown
+```
+
+That means BFB converts the front-end HTML a block renders. It does not infer Markdown semantics from block comments,
+attributes, editor-only scaffolding, JSON blobs, placeholders, or empty render output. Custom blocks that want useful
+Markdown output should treat their front-end render contract as the source of truth.
+
+Custom block expectations:
+
+- Render semantic front-end HTML for the content you want represented in Markdown, such as headings, paragraphs, lists,
+  tables, links, images, blockquotes, and code blocks.
+- Keep editor-only scaffolding, inspector state, placeholders, and machine JSON out of saved or rendered output unless
+  that material should appear in the Markdown.
+- If semantic HTML is not enough for the block's content model, register a block-specific converter through
+  `bfb_html_to_markdown_converter` and let league/html-to-markdown handle that rendered HTML explicitly.
+
+For example, a dynamic block that renders `<h2>Release notes</h2><ul><li>Item</li></ul>` can produce meaningful
+Markdown. A block that only renders `<div data-state="{...}"></div>` or an empty placeholder cannot; BFB has no safe
+way to reconstruct the missing author-facing Markdown from the block comment alone.
+
 ### Filters
 
 - **`bfb_default_format( $format, $post_type, $content ): string`** — declares which format a CPT writes in by default.
@@ -356,11 +381,6 @@ add_filter( 'bfb_register_format_adapter', function ( $adapter, $slug ) {
     return $adapter;
 }, 10, 2 );
 ```
-
-## Known limitations
-
-- **Custom blocks without sensible HTML rendering produce garbage markdown.** Out of bridge scope; document in your
-  block.
 
 ## Tests
 

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -343,6 +343,45 @@ MARKDOWN;
 	}
 
 	/**
+	 * Custom blocks convert to markdown from rendered front-end HTML, not from hidden attrs.
+	 */
+	public function test_custom_blocks_to_markdown_uses_rendered_html_contract(): void {
+		$semantic_block = 'bfb/semantic-markdown-fixture';
+		$empty_block    = 'bfb/empty-markdown-fixture';
+
+		register_block_type(
+			$semantic_block,
+			array(
+				'render_callback' => static function (): string {
+					return '<article><h2>Custom block heading</h2><p>Front-end copy.</p><ul><li>Rendered item</li></ul></article>';
+				},
+			)
+		);
+		register_block_type(
+			$empty_block,
+			array(
+				'render_callback' => static function (): string {
+					return '';
+				},
+			)
+		);
+
+		try {
+			$semantic_markdown = bfb_convert( '<!-- wp:bfb/semantic-markdown-fixture /-->', 'blocks', 'markdown' );
+			$this->assertStringContainsString( '## Custom block heading', $semantic_markdown );
+			$this->assertStringContainsString( 'Front-end copy.', $semantic_markdown );
+			$this->assertStringContainsString( '- Rendered item', $semantic_markdown );
+
+			$empty_markdown = bfb_convert( '<!-- wp:bfb/empty-markdown-fixture {"title":"Hidden attr title"} /-->', 'blocks', 'markdown' );
+			$this->assertSame( '', $empty_markdown );
+			$this->assertStringNotContainsString( 'Hidden attr title', $empty_markdown );
+		} finally {
+			unregister_block_type( $semantic_block );
+			unregister_block_type( $empty_block );
+		}
+	}
+
+	/**
 	 * Non-block formats should compose through the block pivot in both directions.
 	 */
 	public function test_composition_paths_route_through_blocks_pivot(): void {


### PR DESCRIPTION
## Summary
- Document that Blocks -> Markdown conversion is based on `parse_blocks()` -> `render_block()` -> league/html-to-markdown.
- Define the custom-block contract for useful Markdown output and remove the terse known-limitation bullet it supersedes.
- Add a unit fixture proving custom blocks convert from rendered front-end HTML, not hidden attrs in block comments.

## Tests
- `php -l tests/BFBConversionUnitTest.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@docs-custom-block-markdown-contract`

Closes #59

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the README contract section, added the focused test fixture, and ran verification. Chris remains responsible for review and merge.
