### PR TITLE
test: tighten smoke harness lint handling

### DIFF
--- a/tests/smoke-multi-consumer-bundled-load.php
+++ b/tests/smoke-multi-consumer-bundled-load.php
@@ -186,6 +186,9 @@ function bfb_smoke_copy_path( string $source, string $target ): void {
 		mkdir( $target, 0777, true );
 		$iterator = new FilesystemIterator( $source, FilesystemIterator::SKIP_DOTS );
 		foreach ( $iterator as $item ) {
+			if ( ! $item instanceof SplFileInfo ) {
+				continue;
+			}
 			bfb_smoke_copy_path( $item->getPathname(), $target . '/' . $item->getBasename() );
 		}
 		return;
@@ -200,8 +203,11 @@ function bfb_smoke_copy_package( string $source_root, string $target_root, strin
 	bfb_smoke_copy_path( $source_root . '/includes', $target_root . '/includes' );
 	bfb_smoke_copy_path( $source_root . '/vendor_prefixed', $target_root . '/vendor_prefixed' );
 
-	$library = file_get_contents( $target_root . '/library.php' );
-	bfb_smoke_assert( is_string( $library ), 'Temp library.php should be readable.' );
+	$library_raw = file_get_contents( $target_root . '/library.php' );
+	if ( ! is_string( $library_raw ) ) {
+		bfb_smoke_assert( false, 'Temp library.php should be readable.' );
+	}
+	$library = is_string( $library_raw ) ? $library_raw : '';
 	$library = preg_replace( '/\$bfb_library_version = \'[^\']+\';/', "\$bfb_library_version = '{$version}';", $library, 1, $count );
 	bfb_smoke_assert( 1 === $count && is_string( $library ), "Temp library.php version should patch to {$version}." );
 	if ( ! $with_normalization ) {
@@ -224,6 +230,9 @@ function bfb_smoke_remove_path( string $path ): void {
 
 	$iterator = new FilesystemIterator( $path, FilesystemIterator::SKIP_DOTS );
 	foreach ( $iterator as $item ) {
+		if ( ! $item instanceof SplFileInfo ) {
+			continue;
+		}
 		bfb_smoke_remove_path( $item->getPathname() );
 	}
 	rmdir( $path );
@@ -288,10 +297,16 @@ try {
 	bfb_smoke_assert( function_exists( 'bfb_convert' ), 'bfb_convert() should exist after the winning copy boots.' );
 	bfb_smoke_assert( function_exists( 'bfb_normalize' ), 'bfb_normalize() should exist after the winning copy boots, even though the stale bundled copy lacked it.' );
 	bfb_smoke_assert( defined( 'BFB_VERSION' ) && '9.9.9' === BFB_VERSION, 'The highest registered BFB version should initialize.' );
-	$winning_path = realpath( $consumer_b );
-	$losing_path  = realpath( $consumer_a );
-	bfb_smoke_assert( is_string( $winning_path ), 'Winning consumer path should resolve.' );
-	bfb_smoke_assert( is_string( $losing_path ), 'Losing consumer path should resolve.' );
+	$winning_path_raw = realpath( $consumer_b );
+	$losing_path_raw  = realpath( $consumer_a );
+	if ( ! is_string( $winning_path_raw ) ) {
+		bfb_smoke_assert( false, 'Winning consumer path should resolve.' );
+	}
+	if ( ! is_string( $losing_path_raw ) ) {
+		bfb_smoke_assert( false, 'Losing consumer path should resolve.' );
+	}
+	$winning_path = is_string( $winning_path_raw ) ? $winning_path_raw : '';
+	$losing_path  = is_string( $losing_path_raw ) ? $losing_path_raw : '';
 	bfb_smoke_assert(
 		defined( 'BFB_PATH' ) && trailingslashit( $winning_path ) === BFB_PATH,
 		'BFB_PATH should point at the winning consumer copy. Expected ' . trailingslashit( $winning_path ) . ', got ' . ( defined( 'BFB_PATH' ) ? BFB_PATH : 'undefined' ) . '. Losing copy was ' . trailingslashit( $losing_path ) . '.'

--- a/tests/smoke-scoped-h2bc-hooks.php
+++ b/tests/smoke-scoped-h2bc-hooks.php
@@ -57,9 +57,12 @@ function has_action( string $hook_name, $callback = false ) {
 
 $hooks_file    = __DIR__ . '/../vendor_prefixed/chubes4/html-to-blocks-converter/includes/hooks.php';
 $versions_file = __DIR__ . '/../vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-to-blocks-versions.php';
-$hooks_source  = file_get_contents( $hooks_file );
+$hooks_source_raw = file_get_contents( $hooks_file );
 
-bfb_smoke_assert( is_string( $hooks_source ), 'Scoped h2bc hooks.php should be readable.' );
+if ( ! is_string( $hooks_source_raw ) ) {
+	bfb_smoke_assert( false, 'Scoped h2bc hooks.php should be readable.' );
+}
+$hooks_source = is_string( $hooks_source_raw ) ? $hooks_source_raw : '';
 
 foreach ( array( 'add_filter', 'has_filter', 'add_action', 'has_action' ) as $function_name ) {
 	bfb_smoke_assert(

--- a/tools/smoke-test.php
+++ b/tools/smoke-test.php
@@ -46,9 +46,9 @@ $failures = 0;
 function assert_true( string $label, bool $ok, string $detail = '' ): void {
 	global $failures;
 	if ( $ok ) {
-		echo '  ✓ ' . $label . "\n";
+		echo '  ✓ ' . esc_html( $label ) . "\n";
 	} else {
-		echo '  ✗ ' . $label . ( '' !== $detail ? "\n      " . $detail : '' ) . "\n";
+		echo '  ✗ ' . esc_html( $label ) . ( '' !== $detail ? "\n      " . esc_html( $detail ) : '' ) . "\n";
 		++$failures;
 	}
 }
@@ -74,8 +74,8 @@ assert_true(
 );
 
 // --- Test 2: HTML → blocks parity ---
-$html         = '<h1>Hello</h1><p>World</p>';
-$html_result  = bfb_convert( $html, 'html', 'blocks' );
+$html        = '<h1>Hello</h1><p>World</p>';
+$html_result = bfb_convert( $html, 'html', 'blocks' );
 
 assert_true(
 	'HTML → blocks returns non-empty serialised markup',
@@ -104,7 +104,7 @@ $filter = function ( $format, $post_type ) use ( $test_post_type ) {
 };
 add_filter( 'bfb_default_format', $filter, 10, 2 );
 
-$post_id = wp_insert_post(
+$inserted_post_id = wp_insert_post(
 	array(
 		'post_type'    => $test_post_type,
 		'post_status'  => 'draft',
@@ -116,16 +116,17 @@ $post_id = wp_insert_post(
 
 remove_filter( 'bfb_default_format', $filter, 10 );
 
-if ( is_wp_error( $post_id ) ) {
-	assert_true( 'wp_insert_post succeeded', false, $post_id->get_error_message() );
+if ( is_wp_error( $inserted_post_id ) ) {
+	assert_true( 'wp_insert_post succeeded', false, $inserted_post_id->get_error_message() );
 } else {
-	$saved = get_post_field( 'post_content', $post_id );
+	$saved = get_post_field( 'post_content', $inserted_post_id );
+	$saved = is_string( $saved ) ? $saved : '';
 	assert_true(
 		'wp_insert_post stored block markup (filter-driven markdown route)',
 		false !== strpos( $saved, '<!-- wp:' ),
 		'stored: ' . substr( $saved, 0, 200 )
 	);
-	wp_delete_post( $post_id, true );
+	wp_delete_post( $inserted_post_id, true );
 }
 
 // --- Test 3b: bfb_skip_insert_conversion vetoes the conversion ---
@@ -162,6 +163,7 @@ if ( is_wp_error( $skip_post_id ) ) {
 	assert_true( 'wp_insert_post (skip path) succeeded', false, $skip_post_id->get_error_message() );
 } else {
 	$skipped_saved = get_post_field( 'post_content', $skip_post_id );
+	$skipped_saved = is_string( $skipped_saved ) ? $skipped_saved : '';
 	assert_true(
 		'bfb_skip_insert_conversion=true leaves post_content untouched',
 		false === strpos( $skipped_saved, '<!-- wp:' )
@@ -171,7 +173,7 @@ if ( is_wp_error( $skip_post_id ) ) {
 	assert_true(
 		'bfb_skip_insert_conversion receives the resolved format slug',
 		'markdown' === $skip_seen_format,
-		'got: ' . var_export( $skip_seen_format, true )
+		'got: ' . wp_json_encode( $skip_seen_format )
 	);
 	wp_delete_post( $skip_post_id, true );
 }
@@ -242,8 +244,8 @@ if ( is_wp_error( $render_post_id ) ) {
 }
 
 // --- Test 7a: TableConverter round-trips GFM tables ---
-$table_md       = "| col1 | col2 |\n| --- | --- |\n| a | b |\n";
-$table_round    = bfb_convert( bfb_convert( $table_md, 'markdown', 'blocks' ), 'blocks', 'markdown' );
+$table_md    = "| col1 | col2 |\n| --- | --- |\n| a | b |\n";
+$table_round = bfb_convert( bfb_convert( $table_md, 'markdown', 'blocks' ), 'blocks', 'markdown' );
 assert_true(
 	'Tables round-trip through markdown→blocks→markdown',
 	false !== strpos( $table_round, '| col1 | col2 |' ),
@@ -314,5 +316,5 @@ if ( 0 === $failures ) {
 	echo "All checks passed.\n";
 	exit( 0 );
 }
-echo $failures . " failure(s).\n";
+echo esc_html( (string) $failures ) . " failure(s).\n";
 exit( 1 );


### PR DESCRIPTION
## Summary

- Tightens BFB smoke-test harnesses so simple lint/static-analysis checks catch real brittle file/type handling instead of test-only noise.
- Keeps scoper/build-tooling/PHPUnit false positives out of the repo via an upstream Homeboy extension issue instead of local broad suppressions.

## Changes

- Escapes CLI smoke-test output, avoids the `$post_id` WordPress global-name warning, and normalizes `get_post_field()` values before string assertions.
- Adds explicit file-read/path checks in the multi-consumer and scoped-h2bc smoke harnesses before using paths, iterators, and generated source text.
- Leaves `scoper.inc.php`, `tools/build-autoloader.php`, PHPUnit tests, and generated/runtime-loaded symbol false positives for the lint runner profile to handle upstream.

## Tests

- `php -l tools/smoke-test.php && php -l tests/smoke-multi-consumer-bundled-load.php && php -l tests/smoke-scoped-h2bc-hooks.php`
- `php tests/smoke-multi-consumer-bundled-load.php`
- `php tests/smoke-scoped-h2bc-hooks.php`
- `php tests/smoke-content-normalization.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-test-tooling-lint`
- Targeted `homeboy lint ... --file` reruns pass PHPCS for touched files; remaining PHPStan findings are runtime-loaded/generated-symbol false positives tracked upstream.

## Remaining false positives / upstream issues filed

- Extra-Chill/homeboy-extensions#331 tracks the lint-profile mismatch for php-scoper config, build scripts, standalone smoke harnesses, generated/vendor-prefixed symbols, and WordPress PHPUnit tests.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Triage, smoke-harness cleanup, verification, upstream false-positive issue drafting, and PR description drafting. Chris remains responsible for review and merge.
