### PR TITLE
fix: clean production lint findings

### DIFF
--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -39,8 +39,7 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 
 		// Already block markup — parse and return.
 		if ( false !== strpos( $content, '<!-- wp:' ) ) {
-			$parsed = parse_blocks( $content );
-			return is_array( $parsed ) ? $parsed : array();
+			return parse_blocks( $content );
 		}
 
 		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
@@ -56,7 +55,12 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 		// Should only happen in a broken build: BFB requires
 		// chubes4/html-to-blocks-converter and built distributions ship
 		// the prefixed function above.
-		error_log( '[Block Format Bridge] html-to-blocks-converter is unavailable; falling back to a freeform block.' );
+		do_action(
+			'bfb_diagnostic',
+			'html_to_blocks_unavailable',
+			'html-to-blocks-converter is unavailable; falling back to a freeform block.',
+			array( 'adapter' => 'html' )
+		);
 		return array(
 			array(
 				'blockName'    => 'core/freeform',

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -103,13 +103,13 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 		// Mirrors the approach in roots/post-content-to-markdown.
 		$html = (string) preg_replace_callback(
 			'#<pre\b[^>]*>(.*?)</pre>#is',
-			static function ( array $match ): string {
+			static function ( array $pre_match ): string {
 				$language_class = '';
-				if ( preg_match( '/\blanguage-([A-Za-z0-9_-]+)/', $match[0], $language_match ) ) {
+				if ( preg_match( '/\blanguage-([A-Za-z0-9_-]+)/', $pre_match[0], $language_match ) ) {
 					$language_class = ' class="language-' . esc_attr( $language_match[1] ) . '"';
 				}
 
-				$inner = html_entity_decode( strip_tags( $match[1] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				$inner = html_entity_decode( wp_strip_all_tags( $pre_match[1] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 				return '<pre><code' . $language_class . '>' . htmlspecialchars( $inner, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) . '</code></pre>';
 			},
 			$html
@@ -167,7 +167,12 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 		}
 
 		if ( null === $class ) {
-			error_log( '[Block Format Bridge] league/commonmark is not loaded; markdown conversion unavailable.' );
+			do_action(
+				'bfb_diagnostic',
+				'commonmark_unavailable',
+				'league/commonmark is not loaded; markdown conversion unavailable.',
+				array( 'adapter' => 'markdown' )
+			);
 			return '';
 		}
 
@@ -176,7 +181,12 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 			$result    = $converter->convert( $markdown );
 			return (string) $result;
 		} catch ( \Throwable $e ) {
-			error_log( sprintf( '[Block Format Bridge] CommonMark conversion failed: %s', $e->getMessage() ) );
+			do_action(
+				'bfb_diagnostic',
+				'commonmark_conversion_failed',
+				'CommonMark conversion failed.',
+				array( 'error' => $e->getMessage() )
+			);
 			return '';
 		}
 	}
@@ -210,7 +220,12 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 		}
 
 		if ( null === $class ) {
-			error_log( '[Block Format Bridge] league/html-to-markdown is not loaded; HTML→markdown conversion unavailable.' );
+			do_action(
+				'bfb_diagnostic',
+				'html_to_markdown_unavailable',
+				'league/html-to-markdown is not loaded; HTML to markdown conversion unavailable.',
+				array( 'adapter' => 'markdown' )
+			);
 			return '';
 		}
 
@@ -261,7 +276,12 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 
 			return (string) $converter->convert( $html );
 		} catch ( \Throwable $e ) {
-			error_log( sprintf( '[Block Format Bridge] HTML→markdown conversion failed: %s', $e->getMessage() ) );
+			do_action(
+				'bfb_diagnostic',
+				'html_to_markdown_conversion_failed',
+				'HTML to markdown conversion failed.',
+				array( 'error' => $e->getMessage() )
+			);
 			return '';
 		}
 	}
@@ -291,11 +311,20 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 			return;
 		}
 
+		if ( ! method_exists( $converter, 'getEnvironment' ) ) {
+			return;
+		}
+
 		try {
 			$env = $converter->getEnvironment();
 			$env->addConverter( new $class() );
 		} catch ( \Throwable $e ) {
-			error_log( sprintf( '[Block Format Bridge] TableConverter registration failed: %s', $e->getMessage() ) );
+			do_action(
+				'bfb_diagnostic',
+				'table_converter_registration_failed',
+				'TableConverter registration failed.',
+				array( 'error' => $e->getMessage() )
+			);
 		}
 	}
 }

--- a/includes/class-bfb-versions.php
+++ b/includes/class-bfb-versions.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 				return;
 			}
 
-			$source = $source ?: $this->describe_initializer( $initializer );
+			$source = $source ? $source : $this->describe_initializer( $initializer );
 
 			foreach ( $this->versions as $entry ) {
 				if ( $version === $entry['version'] && $source !== $entry['source'] ) {
@@ -169,7 +169,8 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 		private function describe_initializer( callable $initializer ): string {
 			if ( $initializer instanceof Closure ) {
 				$reflection = new ReflectionFunction( $initializer );
-				return $reflection->getFileName() ?: 'closure:' . spl_object_id( $initializer );
+				$file_name  = $reflection->getFileName();
+				return $file_name ? $file_name : 'closure:' . spl_object_id( $initializer );
 			}
 
 			if ( is_string( $initializer ) ) {
@@ -205,11 +206,12 @@ if ( ! class_exists( 'BFB_Versions', false ) ) {
 			);
 
 			if ( function_exists( '_doing_it_wrong' ) ) {
-				_doing_it_wrong( __METHOD__, $message, $version );
+				_doing_it_wrong( __METHOD__, esc_html( $message ), esc_html( $version ) );
 				return;
 			}
 
-			trigger_error( $message, E_USER_WARNING );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Deliberate early-load diagnostic before BFB helpers are available.
+			trigger_error( esc_html( $message ), E_USER_WARNING );
 		}
 	}
 }

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -53,9 +53,9 @@ function bfb_resolve_format_for_insert( array $data, array $postarr ): string {
 	 * @param string $post_type Post type being inserted.
 	 * @param string $content   Raw post content (already wp_unslash'd? NO — still slashed).
 	 */
-	$format = apply_filters( 'bfb_default_format', 'html', $post_type, $content );
+	$format = (string) apply_filters( 'bfb_default_format', 'html', $post_type, $content );
 
-	return is_string( $format ) && '' !== $format ? $format : 'html';
+	return '' !== $format ? $format : 'html';
 }
 
 /**
@@ -76,12 +76,8 @@ function bfb_resolve_format_for_insert( array $data, array $postarr ): string {
  * @param array $postarr Original post-insert array.
  * @return array Modified post data.
  */
-function bfb_convert_on_insert( $data, $postarr ) {
-	if ( ! is_array( $data ) ) {
-		return $data;
-	}
-
-	if ( empty( $data['post_content'] ) ) {
+function bfb_convert_on_insert( array $data, array $postarr ): array {
+	if ( empty( $data['post_content'] ) || ! is_string( $data['post_content'] ) ) {
 		return $data;
 	}
 
@@ -125,7 +121,11 @@ function bfb_convert_on_insert( $data, $postarr ) {
 		return $data;
 	}
 
-	$content   = wp_unslash( $data['post_content'] );
+	$content = wp_unslash( $data['post_content'] );
+	if ( ! is_string( $content ) ) {
+		return $data;
+	}
+
 	$post_type = isset( $data['post_type'] ) ? (string) $data['post_type'] : '';
 
 	// Already block markup — leave it alone.
@@ -135,7 +135,15 @@ function bfb_convert_on_insert( $data, $postarr ) {
 
 	$adapter = bfb_get_adapter( $format );
 	if ( ! $adapter ) {
-		error_log( sprintf( '[Block Format Bridge] No adapter for format "%s" on insert; skipping.', $format ) );
+		do_action(
+			'bfb_diagnostic',
+			'insert_adapter_unavailable',
+			'No adapter is registered for insert conversion; skipping.',
+			array(
+				'format'    => $format,
+				'post_type' => $post_type,
+			)
+		);
 		return $data;
 	}
 
@@ -158,13 +166,13 @@ function bfb_convert_on_insert( $data, $postarr ) {
 	do_action(
 		'bfb_insert_conversion_measured',
 		array(
-			'format'      => $format,
-			'from'        => $format,
-			'to'          => 'blocks',
-			'duration_ms' => ( microtime( true ) - $started_at ) * 1000,
-			'input_bytes' => strlen( $content ),
+			'format'       => $format,
+			'from'         => $format,
+			'to'           => 'blocks',
+			'duration_ms'  => ( microtime( true ) - $started_at ) * 1000,
+			'input_bytes'  => strlen( $content ),
 			'output_bytes' => strlen( $serialized ),
-			'post_type'   => $post_type,
+			'post_type'    => $post_type,
 		)
 	);
 

--- a/includes/normalization.php
+++ b/includes/normalization.php
@@ -71,9 +71,10 @@ if ( ! function_exists( 'bfb_normalize_blocks' ) ) {
 		}
 
 		$tokens = bfb_extract_block_tokens( $content );
-		if ( bfb_is_wp_error( $tokens ) ) {
+		if ( $tokens instanceof WP_Error ) {
 			return $tokens;
 		}
+		/** @var array<int, array{raw: string, offset: int, type: string, name: string}> $tokens */
 
 		if ( empty( $tokens ) ) {
 			return new WP_Error(
@@ -133,7 +134,7 @@ if ( ! function_exists( 'bfb_normalize_blocks' ) ) {
 			return new WP_Error(
 				'bfb_blocks_unclosed_comment',
 				'Serialized block markup contains an unclosed block comment.',
-				array( 'open_blocks' => array_values( $stack ) )
+				array( 'open_blocks' => $stack )
 			);
 		}
 
@@ -210,7 +211,7 @@ if ( ! function_exists( 'bfb_extract_block_tokens' ) ) {
 				$tokens[] = array(
 					'raw'    => $raw,
 					'offset' => $match[1],
-					'type'   => isset( $open[2] ) && '/' === $open[2] ? 'self' : 'open',
+					'type'   => isset( $open[2] ) ? 'self' : 'open',
 					'name'   => $open[1],
 				);
 				continue;
@@ -274,17 +275,5 @@ if ( ! function_exists( 'bfb_excerpt' ) ) {
 	function bfb_excerpt( string $content ): string {
 		$excerpt = trim( preg_replace( '/\s+/', ' ', $content ) ?? $content );
 		return substr( $excerpt, 0, 120 );
-	}
-}
-
-if ( ! function_exists( 'bfb_is_wp_error' ) ) {
-	/**
-	 * Local wrapper for tests that load the API with a minimal WP_Error stub.
-	 *
-	 * @param mixed $value Value to test.
-	 * @return bool
-	 */
-	function bfb_is_wp_error( $value ): bool {
-		return function_exists( 'is_wp_error' ) ? is_wp_error( $value ) : $value instanceof WP_Error;
 	}
 }

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -56,10 +56,6 @@ add_action( 'init', 'bfb_register_rest_filters', 20 );
  * @return array
  */
 function bfb_rest_add_collection_param( $params ) {
-	if ( ! is_array( $params ) ) {
-		return $params;
-	}
-
 	$params['content_format'] = array(
 		'description' => __( 'Render post content in the requested format and expose it as `content.formatted` on each post.', 'block-format-bridge' ),
 		'type'        => 'string',
@@ -78,10 +74,6 @@ function bfb_rest_add_collection_param( $params ) {
  * @return WP_REST_Response
  */
 function bfb_rest_prepare_response( $response, $post, $request ) {
-	if ( ! ( $response instanceof WP_REST_Response ) || ! ( $post instanceof WP_Post ) ) {
-		return $response;
-	}
-
 	$format = $request->get_param( 'content_format' );
 	if ( ! is_string( $format ) || '' === $format ) {
 		return $response;


### PR DESCRIPTION
## Summary

- Cleans the focused production-code lint/PHPStan backlog in BFB's runtime adapters, insert hook, REST hook, normalization helper, and version registry.
- Replaces production `error_log()` diagnostics with observation-only `bfb_diagnostic` actions so consumers can opt into logging without direct runtime log writes.

## Changes

- Removes short ternaries and escapes early-load duplicate-version diagnostics.
- Simplifies always-true type guards and normalizes string handling where WordPress stubs expose `array|string` unions.
- Tightens block-normalization narrowing and removes the now-unused local `bfb_is_wp_error()` wrapper.
- Switches markdown pre-block flattening to `wp_strip_all_tags()` and avoids reserved `$match` parameter naming.
- Adds a `method_exists()` guard before using `HtmlConverter::getEnvironment()`.

## Tests

- `php -l includes/class-bfb-versions.php includes/class-bfb-html-adapter.php includes/class-bfb-markdown-adapter.php includes/hooks.php includes/normalization.php includes/rest.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-production-lint --file includes/class-bfb-versions.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-production-lint --file includes/hooks.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-production-lint --file includes/normalization.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-production-lint`

## Remaining backlog / false-positive issues filed

- Full `homeboy lint block-format-bridge` still reports the repo's existing broad backlog across `scoper.inc.php`, `tools/`, tests, and unrelated production files. This PR intentionally stays on the requested production-file slice.
- Focused single-file PHPStan still reports missing sibling declarations / prefixed vendor classes in files that depend on normal plugin bootstrap context. Filed upstream: https://github.com/Extra-Chill/homeboy-extensions/issues/333

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the production-code cleanup, running targeted verification, and filing the focused PHPStan context issue. Chris remains responsible for review and merge decisions.
