### PR TITLE
docs: link Homeboy in test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ add_filter( 'bfb_register_format_adapter', function ( $adapter, $slug ) {
 
 ## Tests
 
-Run the conversion smoke suite through Homeboy:
+Run the conversion smoke suite through [Homeboy](https://github.com/Extra-Chill/homeboy):
 
 ```bash
 homeboy test block-format-bridge


### PR DESCRIPTION
## Summary

- Link the README Tests section's Homeboy mention to the Homeboy repository.

## Tests

- Not run; README-only link change.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the README link change, verified the diff, and drafted the PR.
