### PR TITLE
Expose BFB conversion abilities

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * WordPress Abilities API integration.
+ *
+ * @package BlockFormatBridge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'bfb_register_abilities' ) ) {
+	/**
+	 * Register Block Format Bridge abilities when the Abilities API is present.
+	 *
+	 * @return void
+	 */
+	function bfb_register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'block-format-bridge/get-capabilities',
+			array(
+				'label'               => __( 'Get Block Format Bridge Capabilities', 'block-format-bridge' ),
+				'description'         => __( 'Return the active content-format conversion substrate capabilities.', 'block-format-bridge' ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'bfb_ability_get_capabilities',
+				'permission_callback' => 'bfb_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		wp_register_ability(
+			'block-format-bridge/convert',
+			array(
+				'label'               => __( 'Convert Content Format', 'block-format-bridge' ),
+				'description'         => __( 'Convert content between registered BFB formats through the block pivot.', 'block-format-bridge' ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'content' => array( 'type' => 'string' ),
+						'from'    => array( 'type' => 'string' ),
+						'to'      => array( 'type' => 'string' ),
+					),
+					'required'   => array( 'content', 'from', 'to' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'bfb_ability_convert',
+				'permission_callback' => 'bfb_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		wp_register_ability(
+			'block-format-bridge/normalize',
+			array(
+				'label'               => __( 'Normalize Content Format', 'block-format-bridge' ),
+				'description'         => __( 'Normalize and validate content for a declared BFB format.', 'block-format-bridge' ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'content' => array( 'type' => 'string' ),
+						'format'  => array( 'type' => 'string' ),
+						'options' => array( 'type' => 'object' ),
+					),
+					'required'   => array( 'content', 'format' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'bfb_ability_normalize',
+				'permission_callback' => 'bfb_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_ability_permission_callback' ) ) {
+	/**
+	 * Permission callback for read-only conversion substrate abilities.
+	 *
+	 * @return bool
+	 */
+	function bfb_ability_permission_callback(): bool {
+		return ! function_exists( 'current_user_can' ) || current_user_can( 'read' );
+	}
+}
+
+if ( ! function_exists( 'bfb_ability_get_capabilities' ) ) {
+	/**
+	 * Ability callback for capability discovery.
+	 *
+	 * @return array<string, mixed>
+	 */
+	function bfb_ability_get_capabilities(): array {
+		return bfb_capabilities();
+	}
+}
+
+if ( ! function_exists( 'bfb_ability_convert' ) ) {
+	/**
+	 * Ability callback for content conversion.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function bfb_ability_convert( array $input ): array {
+		$content = isset( $input['content'] ) ? (string) $input['content'] : '';
+		$from    = isset( $input['from'] ) ? (string) $input['from'] : '';
+		$to      = isset( $input['to'] ) ? (string) $input['to'] : '';
+
+		if ( '' === $from || '' === $to ) {
+			return bfb_ability_error( 'bfb_missing_format', 'Both from and to formats are required.' );
+		}
+
+		$result = bfb_convert( $content, $from, $to );
+		if ( '' === $result && '' !== $content ) {
+			return bfb_ability_error( 'bfb_conversion_failed', sprintf( 'BFB conversion failed for %s -> %s.', $from, $to ) );
+		}
+
+		return array(
+			'success' => true,
+			'from'    => $from,
+			'to'      => $to,
+			'content' => $result,
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_ability_normalize' ) ) {
+	/**
+	 * Ability callback for declared-format normalization.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function bfb_ability_normalize( array $input ): array {
+		$content = isset( $input['content'] ) ? (string) $input['content'] : '';
+		$format  = isset( $input['format'] ) ? (string) $input['format'] : '';
+		$options = isset( $input['options'] ) && is_array( $input['options'] ) ? $input['options'] : array();
+
+		if ( '' === $format ) {
+			return bfb_ability_error( 'bfb_missing_format', 'The declared format is required.' );
+		}
+
+		$result = bfb_normalize( $content, $format, $options );
+		if ( is_wp_error( $result ) ) {
+			/** @var WP_Error $result */
+			return bfb_ability_error( $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+
+		return array(
+			'success' => true,
+			'format'  => $format,
+			'content' => $result,
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_ability_error' ) ) {
+	/**
+	 * Build a structured ability error envelope.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @param mixed  $data    Optional error data.
+	 * @return array<string, mixed>
+	 */
+	function bfb_ability_error( string $code, string $message, $data = null ): array {
+		return array(
+			'success' => false,
+			'error'   => array(
+				'code'    => $code,
+				'message' => $message,
+				'data'    => $data,
+			),
+		);
+	}
+}
+
+if ( doing_action( 'wp_abilities_api_init' ) ) {
+	bfb_register_abilities();
+} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+	add_action( 'wp_abilities_api_init', 'bfb_register_abilities' );
+}

--- a/includes/api.php
+++ b/includes/api.php
@@ -7,6 +7,7 @@
  *   bfb_convert( $content, $from, $to )     — universal conversion
  *   bfb_to_blocks( $content, $from )        — block-array conversion
  *   bfb_normalize( $content, $format )      — declared-format validation
+ *   bfb_capabilities()                      — conversion substrate report
  *   bfb_get_adapter( $slug )                — registry lookup
  *
  * `bfb_convert()` routes through the block pivot via the adapter registry.
@@ -18,6 +19,137 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+if ( ! function_exists( 'bfb_capabilities' ) ) {
+	/**
+	 * Return a machine-readable report of the active conversion substrate.
+	 *
+	 * @return array<string, mixed>
+	 */
+	function bfb_capabilities(): array {
+		$formats = array(
+			'blocks' => array(
+				'slug'        => 'blocks',
+				'label'       => 'Serialized WordPress blocks',
+				'adapter'     => null,
+				'to_blocks'   => true,
+				'from_blocks' => true,
+				'pivot'       => true,
+			),
+		);
+
+		foreach ( BFB_Adapter_Registry::slugs() as $slug ) {
+			$adapter = bfb_get_adapter( $slug );
+			if ( ! $adapter ) {
+				continue;
+			}
+
+			$formats[ $slug ] = array(
+				'slug'        => $slug,
+				'label'       => $slug,
+				'adapter'     => get_class( $adapter ),
+				'to_blocks'   => true,
+				'from_blocks' => true,
+				'pivot'       => false,
+			);
+		}
+
+		$h2bc = bfb_h2bc_capabilities();
+
+		return array(
+			'bridge'         => array(
+				'version' => defined( 'BFB_VERSION' ) ? BFB_VERSION : null,
+				'path'    => defined( 'BFB_PATH' ) ? BFB_PATH : null,
+			),
+			'formats'        => $formats,
+			'conversions'    => array(
+				'html_to_blocks' => array(
+					'available' => (bool) $h2bc['available'],
+					'provider'  => 'html-to-blocks-converter',
+				),
+			),
+			'h2bc'           => $h2bc,
+			'block_coverage' => array(
+				'source'             => 'not_available',
+				'requires'           => 'h2bc#56',
+				'supported_blocks'   => array(),
+				'unsupported_blocks' => array(),
+				'classifications'    => array(),
+			),
+			'hooks'          => array(
+				'filters' => array(
+					'bfb_register_format_adapter',
+					'bfb_default_format',
+					'bfb_skip_insert_conversion',
+					'bfb_rest_supported_post_types',
+					'bfb_markdown_input',
+					'bfb_markdown_output',
+					'bfb_html_to_markdown_options',
+				),
+				'actions' => array(
+					'bfb_loaded',
+					'bfb_adapters_registered',
+					'bfb_diagnostic',
+					'bfb_insert_conversion_measured',
+					'bfb_html_to_markdown_converter',
+				),
+			),
+			'abilities'      => array(
+				'block-format-bridge/get-capabilities',
+				'block-format-bridge/convert',
+				'block-format-bridge/normalize',
+			),
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_h2bc_capabilities' ) ) {
+	/**
+	 * Return availability metadata for the bundled or standalone h2bc substrate.
+	 *
+	 * @return array<string, mixed>
+	 */
+	function bfb_h2bc_capabilities(): array {
+		$handler = null;
+		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
+			$handler = '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler';
+		} elseif ( function_exists( 'html_to_blocks_raw_handler' ) ) {
+			$handler = 'html_to_blocks_raw_handler';
+		}
+
+		$path = null;
+		if ( defined( 'HTML_TO_BLOCKS_CONVERTER_PATH' ) ) {
+			$path = HTML_TO_BLOCKS_CONVERTER_PATH;
+		} elseif ( $handler ) {
+			$reflection = new ReflectionFunction( $handler );
+			$file       = $reflection->getFileName();
+			$path       = is_string( $file ) ? dirname( $file ) . '/' : null;
+		}
+
+		$version = null;
+		if ( $path ) {
+			$library = trailingslashit( $path ) . 'library.php';
+			if ( is_readable( $library ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local package metadata read.
+				$source = file_get_contents( $library );
+				if ( is_string( $source ) && preg_match( "/html_to_blocks_library_version\s*=\s*'([^']+)'/", $source, $match ) ) {
+					$version = $match[1];
+				}
+			}
+		}
+
+		return array(
+			'available'   => null !== $handler,
+			'version'     => $version,
+			'path'        => $path,
+			'raw_handler' => $handler,
+			'inventory'   => array(
+				'source'   => 'not_available',
+				'requires' => 'h2bc#56',
+			),
+		);
+	}
 }
 
 if ( ! function_exists( 'bfb_get_adapter' ) ) {

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -20,6 +20,47 @@ if ( ! class_exists( 'BFB_CLI_Command' ) ) {
 	class BFB_CLI_Command {
 
 		/**
+		 * Report active conversion substrate capabilities.
+		 *
+		 * ## OPTIONS
+		 *
+		 * [--format=<format>]
+		 * : Output format. Supports `json` or `summary`.
+		 * ---
+		 * default: summary
+		 * ---
+		 *
+		 * @param array<int, string>   $args       Positional arguments.
+		 * @param array<string, mixed> $assoc_args Associative arguments.
+		 * @return void
+		 */
+		public function capabilities( array $args, array $assoc_args ): void {
+			unset( $args );
+
+			$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'summary';
+			$report = bfb_capabilities();
+
+			if ( 'json' === $format ) {
+				$output = wp_json_encode( $report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+				if ( false === $output ) {
+					WP_CLI::error( 'Failed to encode capabilities as JSON.' );
+				}
+				WP_CLI::line( $output );
+				return;
+			}
+
+			if ( 'summary' !== $format ) {
+				WP_CLI::error( 'Unsupported --format value. Use "summary" or "json".' );
+			}
+
+			$bridge = isset( $report['bridge'] ) && is_array( $report['bridge'] ) ? $report['bridge'] : array();
+			$h2bc   = isset( $report['h2bc'] ) && is_array( $report['h2bc'] ) ? $report['h2bc'] : array();
+			WP_CLI::line( sprintf( 'BFB: %s', isset( $bridge['version'] ) ? (string) $bridge['version'] : 'unknown' ) );
+			WP_CLI::line( sprintf( 'Formats: %s', implode( ', ', array_keys( (array) $report['formats'] ) ) ) );
+			WP_CLI::line( sprintf( 'HTML -> blocks: %s', ! empty( $h2bc['available'] ) ? 'available' : 'unavailable' ) );
+		}
+
+		/**
 		 * Convert content between formats.
 		 *
 		 * ## OPTIONS

--- a/library.php
+++ b/library.php
@@ -70,6 +70,7 @@ $bfb_initializer = static function () use ( $bfb_library_path, $bfb_library_vers
 	require_once $bfb_library_path . '/includes/class-bfb-markdown-adapter.php';
 	require_once $bfb_library_path . '/includes/api.php';
 	require_once $bfb_library_path . '/includes/normalization.php';
+	require_once $bfb_library_path . '/includes/abilities.php';
 	require_once $bfb_library_path . '/includes/hooks.php';
 	require_once $bfb_library_path . '/includes/rest.php';
 	require_once $bfb_library_path . '/includes/cli.php';

--- a/tests/smoke-capabilities-abilities.php
+++ b/tests/smoke-capabilities-abilities.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Smoke coverage for capability report and Abilities API registration.
+ *
+ * @package BlockFormatBridge
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'BFB_VERSION' ) ) {
+	define( 'BFB_VERSION', 'test-version' );
+}
+if ( ! defined( 'BFB_PATH' ) ) {
+	define( 'BFB_PATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['bfb_smoke_abilities'] = array();
+
+function bfb_capabilities_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function __( string $text, string $domain = '' ): string {
+	unset( $domain );
+	return $text;
+}
+
+function trailingslashit( string $path ): string {
+	return rtrim( $path, '/\\' ) . '/';
+}
+
+function doing_action( string $hook_name ): bool {
+	return 'wp_abilities_api_init' === $hook_name;
+}
+
+function did_action( string $hook_name ): int {
+	unset( $hook_name );
+	return 0;
+}
+
+function add_action( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $hook_name, $callback, $priority, $accepted_args );
+}
+
+function do_action( string $hook_name, ...$args ): void {
+	unset( $hook_name, $args );
+}
+
+function apply_filters( string $hook_name, $value ) {
+	unset( $hook_name );
+	return $value;
+}
+
+function current_user_can( string $capability ): bool {
+	return 'read' === $capability;
+}
+
+function wp_register_ability( string $name, array $config ): void {
+	$GLOBALS['bfb_smoke_abilities'][ $name ] = $config;
+}
+
+function parse_blocks( string $content ): array {
+	return array(
+		array(
+			'blockName'    => 'core/paragraph',
+			'attrs'        => array(),
+			'innerBlocks'  => array(),
+			'innerHTML'    => $content,
+			'innerContent' => array( $content ),
+		),
+	);
+}
+
+function serialize_blocks( array $blocks ): string {
+	return implode( '', array_map( 'serialize_block', $blocks ) );
+}
+
+function serialize_block( array $block ): string {
+	return '<!-- wp:' . $block['blockName'] . ' -->' . $block['innerHTML'] . '<!-- /wp:' . $block['blockName'] . ' -->';
+}
+
+function render_block( array $block ): string {
+	return (string) $block['innerHTML'];
+}
+
+function wp_json_encode( $value, int $flags = 0 ) {
+	return json_encode( $value, $flags );
+}
+
+class WP_Error {
+	private string $code;
+	private string $message;
+	private $data;
+
+	public function __construct( string $code, string $message, $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data() {
+		return $this->data;
+	}
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+require_once __DIR__ . '/../includes/interface-bfb-format-adapter.php';
+require_once __DIR__ . '/../includes/class-bfb-adapter-registry.php';
+require_once __DIR__ . '/../includes/class-bfb-html-adapter.php';
+require_once __DIR__ . '/../includes/api.php';
+require_once __DIR__ . '/../includes/normalization.php';
+require_once __DIR__ . '/../includes/abilities.php';
+
+BFB_Adapter_Registry::reset();
+BFB_Adapter_Registry::register( new BFB_HTML_Adapter() );
+
+$report = bfb_capabilities();
+bfb_capabilities_smoke_assert( 'test-version' === $report['bridge']['version'], 'Capability report should include BFB version.' );
+bfb_capabilities_smoke_assert( isset( $report['formats']['blocks'] ), 'Capability report should expose the block pivot format.' );
+bfb_capabilities_smoke_assert( isset( $report['formats']['html'] ), 'Capability report should expose registered adapters.' );
+bfb_capabilities_smoke_assert( false === $report['formats']['html']['pivot'], 'Adapter formats should not be marked as pivot formats.' );
+bfb_capabilities_smoke_assert( isset( $report['conversions']['html_to_blocks'] ), 'Capability report should expose HTML to blocks availability.' );
+bfb_capabilities_smoke_assert( 'not_available' === $report['block_coverage']['source'], 'Capability report should include conservative block coverage placeholder.' );
+bfb_capabilities_smoke_assert( 'h2bc#56' === $report['block_coverage']['requires'], 'Capability report should point at the h2bc inventory follow-up.' );
+bfb_capabilities_smoke_assert( in_array( 'bfb_diagnostic', $report['hooks']['actions'], true ), 'Capability report should list observability hooks.' );
+bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/get-capabilities', $report['abilities'], true ), 'Capability report should list the capabilities ability.' );
+bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/convert', $report['abilities'], true ), 'Capability report should list the convert ability.' );
+bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/normalize', $report['abilities'], true ), 'Capability report should list the normalize ability.' );
+
+$abilities = $GLOBALS['bfb_smoke_abilities'];
+bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/get-capabilities'] ), 'Capabilities ability should be registered.' );
+bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/convert'] ), 'Convert ability should be registered.' );
+bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/normalize'] ), 'Normalize ability should be registered.' );
+bfb_capabilities_smoke_assert( true === $abilities['block-format-bridge/get-capabilities']['meta']['show_in_rest'], 'Capabilities ability should opt into REST exposure.' );
+
+$capability_callback = $abilities['block-format-bridge/get-capabilities']['execute_callback'];
+$ability_report      = $capability_callback( array() );
+bfb_capabilities_smoke_assert( isset( $ability_report['formats']['html'] ), 'Capabilities ability should call the PHP report helper.' );
+
+$convert_callback = $abilities['block-format-bridge/convert']['execute_callback'];
+$converted        = $convert_callback(
+	array(
+		'content' => 'same',
+		'from'    => 'markdown',
+		'to'      => 'markdown',
+	)
+);
+bfb_capabilities_smoke_assert( true === $converted['success'], 'Convert ability should return a success envelope.' );
+bfb_capabilities_smoke_assert( 'same' === $converted['content'], 'Convert ability should call bfb_convert().' );
+
+$normalize_callback = $abilities['block-format-bridge/normalize']['execute_callback'];
+$normalized         = $normalize_callback(
+	array(
+		'content' => "Line\r\nTwo",
+		'format'  => 'markdown',
+	)
+);
+bfb_capabilities_smoke_assert( true === $normalized['success'], 'Normalize ability should return a success envelope.' );
+bfb_capabilities_smoke_assert( "Line\nTwo" === $normalized['content'], 'Normalize ability should call bfb_normalize().' );
+
+$normalize_error = $normalize_callback(
+	array(
+		'content' => 'content',
+		'format'  => 'missing-format',
+	)
+);
+bfb_capabilities_smoke_assert( false === $normalize_error['success'], 'Normalize ability should surface WP_Error failures.' );
+bfb_capabilities_smoke_assert( 'bfb_unknown_format' === $normalize_error['error']['code'], 'Normalize ability should preserve WP_Error codes.' );
+
+echo "PASS: capability report and abilities contract\n";

--- a/tests/smoke-cli-command.php
+++ b/tests/smoke-cli-command.php
@@ -24,7 +24,11 @@ $cli_source = (string) $cli_source;
 $library    = (string) $library;
 
 bfb_cli_smoke_assert( strpos( $library, "includes/cli.php" ) !== false, 'library.php should load the CLI integration.' );
+bfb_cli_smoke_assert( strpos( $library, "includes/abilities.php" ) !== false, 'library.php should load the Abilities API integration.' );
 bfb_cli_smoke_assert( strpos( $cli_source, "WP_CLI::add_command( 'bfb', 'BFB_CLI_Command' )" ) !== false, 'CLI should register the bfb command namespace.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'public function capabilities' ) !== false, 'CLI should expose a capabilities subcommand.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'bfb_capabilities()' ) !== false, 'Capabilities CLI should wrap the PHP report helper.' );
+bfb_cli_smoke_assert( strpos( $cli_source, "'json' === \$format" ) !== false, 'Capabilities CLI should support --format=json.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'public function convert' ) !== false, 'CLI should expose a convert subcommand.' );
 bfb_cli_smoke_assert( strpos( $cli_source, "file_get_contents( 'php://stdin' )" ) !== false, 'CLI should read STDIN when --input is omitted.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'file_get_contents( $path )' ) !== false, 'CLI should read file input when --input is present.' );

--- a/tests/smoke-duplicate-version-registry.php
+++ b/tests/smoke-duplicate-version-registry.php
@@ -24,6 +24,10 @@ function do_action( string $hook_name, ...$args ): void {
 	}
 }
 
+function esc_html( string $text ): string {
+	return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+}
+
 require_once __DIR__ . '/../includes/class-bfb-versions.php';
 
 function bfb_duplicate_reset_registry(): BFB_Versions {


### PR DESCRIPTION
## Summary
- Adds `bfb_capabilities()` as the machine-readable report for the active BFB conversion substrate.
- Registers WordPress Abilities for `block-format-bridge/get-capabilities`, `block-format-bridge/convert`, and `block-format-bridge/normalize`.
- Adds `wp bfb capabilities --format=json` as a thin CLI wrapper over the PHP report helper.

## Changes
- Keeps PHP API helpers as the implementation core: abilities and CLI call the same helpers instead of creating parallel contracts.
- Reports BFB version/path, registered formats, HTML-to-blocks/h2bc availability, hook names, ability names, and a conservative `block_coverage` placeholder until h2bc#56 provides generated inventory metadata.
- Does not add a duplicate REST endpoint; the abilities opt into `show_in_rest` for installs whose WordPress Abilities API exposes REST.
- Includes `convert` and `normalize` in this PR rather than deferring them, because they naturally wrap existing `bfb_convert()` and `bfb_normalize()`.

## Tests
- `php -l includes/api.php && php -l includes/abilities.php && php -l includes/cli.php`
- `php tests/smoke-capabilities-abilities.php`
- `php tests/smoke-cli-command.php`
- `php tests/smoke-normalization-api-branches.php`
- `php tests/smoke-content-normalization.php`
- `php tests/smoke-duplicate-version-registry.php`
- `php tests/smoke-multi-consumer-bundled-load.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-capability-report-ability --file includes/api.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-capability-report-ability --file includes/abilities.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-capability-report-ability --file includes/cli.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-capability-report-ability --file tests/smoke-capabilities-abilities.php --summary`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-capability-report-ability --summary`

Closes #76

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the capability report API/ability/CLI wrapper, adding smoke coverage, and running local verification. Chris remains responsible for review and merge.