### PR TITLE
feat: add conversion options for format adapters

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -47,6 +47,7 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 						'content' => array( 'type' => 'string' ),
 						'from'    => array( 'type' => 'string' ),
 						'to'      => array( 'type' => 'string' ),
+						'options' => array( 'type' => 'object' ),
 					),
 					'required'   => array( 'content', 'from', 'to' ),
 				),
@@ -113,12 +114,13 @@ if ( ! function_exists( 'bfb_ability_convert' ) ) {
 		$content = isset( $input['content'] ) ? (string) $input['content'] : '';
 		$from    = isset( $input['from'] ) ? (string) $input['from'] : '';
 		$to      = isset( $input['to'] ) ? (string) $input['to'] : '';
+		$options = isset( $input['options'] ) && is_array( $input['options'] ) ? $input['options'] : array();
 
 		if ( '' === $from || '' === $to ) {
 			return bfb_ability_error( 'bfb_missing_format', 'Both from and to formats are required.' );
 		}
 
-		$result = bfb_convert( $content, $from, $to );
+		$result = bfb_convert( $content, $from, $to, $options );
 		if ( '' === $result && '' !== $content ) {
 			return bfb_ability_error( 'bfb_conversion_failed', sprintf( 'BFB conversion failed for %s -> %s.', $from, $to ) );
 		}

--- a/includes/api.php
+++ b/includes/api.php
@@ -4,8 +4,8 @@
  *
  * These functions form the public Phase 1 surface:
  *
- *   bfb_convert( $content, $from, $to )     — universal conversion
- *   bfb_to_blocks( $content, $from )        — block-array conversion
+ *   bfb_convert( $content, $from, $to, $options ) — universal conversion
+ *   bfb_to_blocks( $content, $from, $options )    — block-array conversion
  *   bfb_normalize( $content, $format )      — declared-format validation
  *   bfb_capabilities()                      — conversion substrate report
  *   bfb_get_adapter( $slug )                — registry lookup
@@ -85,6 +85,7 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 					'bfb_rest_supported_post_types',
 					'bfb_markdown_input',
 					'bfb_markdown_output',
+					'bfb_html_to_blocks_args',
 					'bfb_html_to_markdown_options',
 				),
 				'actions' => array(
@@ -171,11 +172,12 @@ if ( ! function_exists( 'bfb_to_blocks' ) ) {
 	 * This is the compiler-facing helper for callers that need the block-array
 	 * pivot directly instead of serialized block markup.
 	 *
-	 * @param string $content Source content.
-	 * @param string $from    Source format slug.
+	 * @param string               $content Source content.
+	 * @param string               $from    Source format slug.
+	 * @param array<string, mixed> $options Per-call conversion options.
 	 * @return array<int, array<string, mixed>> Block array. Empty array on unsupported source.
 	 */
-	function bfb_to_blocks( string $content, string $from ): array {
+	function bfb_to_blocks( string $content, string $from, array $options = array() ): array {
 		if ( 'blocks' === $from ) {
 			return parse_blocks( $content );
 		}
@@ -187,7 +189,7 @@ if ( ! function_exists( 'bfb_to_blocks' ) ) {
 			return array();
 		}
 
-		return $from_adapter->to_blocks( $content );
+		return $from_adapter->to_blocks( $content, $options );
 	}
 }
 
@@ -197,8 +199,8 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 	 *
 	 * Routing always passes through the block pivot:
 	 *
-	 *   $blocks = bfb_to_blocks( $content, $from );
-	 *   return    $to_adapter->from_blocks( $blocks );
+	 *   $blocks = bfb_to_blocks( $content, $from, $options );
+	 *   return    $to_adapter->from_blocks( $blocks, $options );
 	 *
 	 * Special cases:
 	 *   - $from === $to                → returns $content unchanged
@@ -207,17 +209,18 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 	 *                                    block markup, parsing it first
 	 *   - $to === 'blocks'             → returns serialized block markup
 	 *
-	 * @param string $content Source content.
-	 * @param string $from    Source format slug.
-	 * @param string $to      Target format slug.
+	 * @param string               $content Source content.
+	 * @param string               $from    Source format slug.
+	 * @param string               $to      Target format slug.
+	 * @param array<string, mixed> $options Per-call conversion options.
 	 * @return string Converted content. Empty string on failure.
 	 */
-	function bfb_convert( string $content, string $from, string $to ): string {
+	function bfb_convert( string $content, string $from, string $to, array $options = array() ): string {
 		if ( $from === $to ) {
 			return $content;
 		}
 
-		$blocks = bfb_to_blocks( $content, $from );
+		$blocks = bfb_to_blocks( $content, $from, $options );
 		if ( array() === $blocks && 'blocks' !== $from ) {
 			return '';
 		}
@@ -234,7 +237,7 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 			return '';
 		}
 
-		return $to_adapter->from_blocks( $blocks );
+		return $to_adapter->from_blocks( $blocks, $options );
 	}
 }
 
@@ -249,11 +252,12 @@ if ( ! function_exists( 'bfb_render_post' ) ) {
 	 * Returns an empty string when the post is missing, the post type
 	 * does not support content, or the requested format is unknown.
 	 *
-	 * @param int|WP_Post $post   Post ID or WP_Post.
-	 * @param string      $format Target format slug (e.g. 'html', 'markdown').
+	 * @param int|WP_Post          $post    Post ID or WP_Post.
+	 * @param string               $format  Target format slug (e.g. 'html', 'markdown').
+	 * @param array<string, mixed> $options Per-call conversion options.
 	 * @return string Rendered content. Empty string on failure.
 	 */
-	function bfb_render_post( $post, string $format ): string {
+	function bfb_render_post( $post, string $format, array $options = array() ): string {
 		$post_obj = get_post( $post );
 		if ( ! $post_obj ) {
 			return '';
@@ -267,6 +271,6 @@ if ( ! function_exists( 'bfb_render_post' ) ) {
 		// post_content is always serialised block markup (or raw HTML on
 		// pre-Gutenberg installs); route through the 'blocks' source so
 		// dynamic blocks resolve.
-		return bfb_convert( $content, 'blocks', $format );
+		return bfb_convert( $content, 'blocks', $format, $options );
 	}
 }

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -32,7 +32,7 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 	/**
 	 * @inheritDoc
 	 */
-	public function to_blocks( string $content ): array {
+	public function to_blocks( string $content, array $options = array() ): array {
 		if ( '' === $content ) {
 			return array();
 		}
@@ -42,13 +42,31 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 			return parse_blocks( $content );
 		}
 
+		$args = array_merge( $options, array( 'HTML' => $content ) );
+
+		/**
+		 * Filters the argument array passed to html-to-blocks-converter.
+		 *
+		 * BFB reserves the `HTML` key for source content. Per-call conversion
+		 * options, such as `mode`, are forwarded alongside it for h2bc to
+		 * consume when supported.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param array<string, mixed> $args    Raw handler arguments.
+		 * @param string               $content Source HTML.
+		 * @param array<string, mixed> $options Per-call conversion options.
+		 */
+		$args         = (array) apply_filters( 'bfb_html_to_blocks_args', $args, $content, $options );
+		$args['HTML'] = $content;
+
 		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
-			$blocks = \BlockFormatBridge\Vendor\html_to_blocks_raw_handler( array( 'HTML' => $content ) );
+			$blocks = \BlockFormatBridge\Vendor\html_to_blocks_raw_handler( $args );
 			return is_array( $blocks ) ? $blocks : array();
 		}
 
 		if ( function_exists( 'html_to_blocks_raw_handler' ) ) {
-			$blocks = html_to_blocks_raw_handler( array( 'HTML' => $content ) );
+			$blocks = html_to_blocks_raw_handler( $args );
 			return is_array( $blocks ) ? $blocks : array();
 		}
 
@@ -79,7 +97,9 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 	 * resolve to their server-side HTML output. Static blocks pass
 	 * through their inner HTML untouched.
 	 */
-	public function from_blocks( array $blocks ): string {
+	public function from_blocks( array $blocks, array $options = array() ): string {
+		unset( $options );
+
 		if ( empty( $blocks ) ) {
 			return '';
 		}

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -36,7 +36,7 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 	/**
 	 * @inheritDoc
 	 */
-	public function to_blocks( string $content ): array {
+	public function to_blocks( string $content, array $options = array() ): array {
 		if ( '' === $content ) {
 			return array();
 		}
@@ -64,7 +64,7 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 			return array();
 		}
 
-		return $html_adapter->to_blocks( $html );
+		return $html_adapter->to_blocks( $html, $options );
 	}
 
 	/**
@@ -82,7 +82,9 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 	 * @param array $blocks Block array (parse_blocks() shape).
 	 * @return string Markdown representation. Empty string on failure.
 	 */
-	public function from_blocks( array $blocks ): string {
+	public function from_blocks( array $blocks, array $options = array() ): string {
+		unset( $options );
+
 		if ( empty( $blocks ) ) {
 			return '';
 		}

--- a/includes/interface-bfb-format-adapter.php
+++ b/includes/interface-bfb-format-adapter.php
@@ -39,18 +39,20 @@ interface BFB_Format_Adapter {
 	 * array of arrays each with `blockName`, `attrs`, `innerBlocks`,
 	 * `innerHTML`, and `innerContent` keys.
 	 *
-	 * @param string $content Source content in this adapter's format.
+	 * @param string               $content Source content in this adapter's format.
+	 * @param array<string, mixed> $options Per-call conversion options.
 	 * @return array Block array.
 	 */
-	public function to_blocks( string $content ): array;
+	public function to_blocks( string $content, array $options = array() ): array;
 
 	/**
 	 * Convert a block array back into this adapter's format.
 	 *
-	 * @param array $blocks Block array (parse_blocks() shape).
+	 * @param array<int, array<string, mixed>> $blocks  Block array (parse_blocks() shape).
+	 * @param array<string, mixed>             $options Per-call conversion options.
 	 * @return string Content in this adapter's format.
 	 */
-	public function from_blocks( array $blocks ): string;
+	public function from_blocks( array $blocks, array $options = array() ): string;
 
 	/**
 	 * Best-effort detection of whether $content is in this format.

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -101,6 +101,80 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Conversion options should flow from the public API into adapters and h2bc args.
+	 */
+	public function test_conversion_options_flow_to_adapters_and_h2bc_args(): void {
+		$html = '<h2>Options Heading</h2><p>Options paragraph.</p>';
+
+		$default = bfb_convert( $html, 'html', 'blocks' );
+		$this->assertNotSame( '', $default, 'Default 3-argument conversion should remain supported.' );
+
+		$seen_args = null;
+		$listener  = static function ( array $args, string $content, array $options ) use ( &$seen_args ): array {
+			$seen_args = array(
+				'args'    => $args,
+				'content' => $content,
+				'options' => $options,
+			);
+			return $args;
+		};
+
+		add_filter( 'bfb_html_to_blocks_args', $listener, 10, 3 );
+		try {
+			$with_options = bfb_convert( $html, 'html', 'blocks', array( 'mode' => 'fidelity' ) );
+		} finally {
+			remove_filter( 'bfb_html_to_blocks_args', $listener, 10 );
+		}
+
+		$this->assertNotSame( '', $with_options, '4-argument conversion should produce serialized blocks.' );
+		$this->assertIsArray( $seen_args, 'HTML adapter should expose h2bc raw-handler arguments.' );
+		$this->assertSame( 'fidelity', $seen_args['args']['mode'] ?? null, 'Mode option should be forwarded to h2bc args.' );
+		$this->assertSame( $html, $seen_args['args']['HTML'] ?? null, 'BFB should preserve the reserved HTML raw-handler arg.' );
+		$this->assertSame( array( 'mode' => 'fidelity' ), $seen_args['options'] ?? null, 'HTML adapter should receive public conversion options.' );
+
+		$probe = new class() implements BFB_Format_Adapter {
+			/**
+			 * @var array<string, mixed>
+			 */
+			public $received_options = array();
+
+			public function slug(): string {
+				return 'probe-options';
+			}
+
+			public function to_blocks( string $content, array $options = array() ): array {
+				unset( $content );
+				$this->received_options = $options;
+				return parse_blocks( '<!-- wp:paragraph --><p>Probe</p><!-- /wp:paragraph -->' );
+			}
+
+			public function from_blocks( array $blocks, array $options = array() ): string {
+				unset( $blocks );
+				$this->received_options = $options;
+				return 'probe';
+			}
+
+			public function detect( string $content ): bool {
+				unset( $content );
+				return false;
+			}
+		};
+
+		$adapter_filter = static function ( $adapter, string $slug ) use ( $probe ) {
+			return 'probe-options' === $slug ? $probe : $adapter;
+		};
+
+		add_filter( 'bfb_register_format_adapter', $adapter_filter, 10, 2 );
+		try {
+			bfb_convert( 'probe source', 'probe-options', 'blocks', array( 'mode' => 'fidelity' ) );
+		} finally {
+			remove_filter( 'bfb_register_format_adapter', $adapter_filter, 10 );
+		}
+
+		$this->assertSame( array( 'mode' => 'fidelity' ), $probe->received_options, 'Generic adapters should receive public conversion options.' );
+	}
+
+	/**
 	 * BFB should expose h2bc's expanded layout transforms through bfb_convert().
 	 */
 	public function test_html_to_blocks_covers_expanded_layout_transforms(): void {

--- a/tests/smoke-capabilities-abilities.php
+++ b/tests/smoke-capabilities-abilities.php
@@ -139,6 +139,7 @@ bfb_capabilities_smoke_assert( false === $report['formats']['html']['pivot'], 'A
 bfb_capabilities_smoke_assert( isset( $report['conversions']['html_to_blocks'] ), 'Capability report should expose HTML to blocks availability.' );
 bfb_capabilities_smoke_assert( 'not_available' === $report['block_coverage']['source'], 'Capability report should include conservative block coverage placeholder.' );
 bfb_capabilities_smoke_assert( 'h2bc#56' === $report['block_coverage']['requires'], 'Capability report should point at the h2bc inventory follow-up.' );
+bfb_capabilities_smoke_assert( in_array( 'bfb_html_to_blocks_args', $report['hooks']['filters'], true ), 'Capability report should list HTML raw-handler args filter.' );
 bfb_capabilities_smoke_assert( in_array( 'bfb_diagnostic', $report['hooks']['actions'], true ), 'Capability report should list observability hooks.' );
 bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/get-capabilities', $report['abilities'], true ), 'Capability report should list the capabilities ability.' );
 bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/convert', $report['abilities'], true ), 'Capability report should list the convert ability.' );
@@ -149,6 +150,7 @@ bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/get-capabi
 bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/convert'] ), 'Convert ability should be registered.' );
 bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/normalize'] ), 'Normalize ability should be registered.' );
 bfb_capabilities_smoke_assert( true === $abilities['block-format-bridge/get-capabilities']['meta']['show_in_rest'], 'Capabilities ability should opt into REST exposure.' );
+bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/convert']['input_schema']['properties']['options'] ), 'Convert ability should accept conversion options.' );
 
 $capability_callback = $abilities['block-format-bridge/get-capabilities']['execute_callback'];
 $ability_report      = $capability_callback( array() );

--- a/tests/smoke-insert-conversion-measurement.php
+++ b/tests/smoke-insert-conversion-measurement.php
@@ -84,7 +84,8 @@ function bfb_get_adapter( string $format ) {
 	return 'markdown' === $format ? new stdClass() : null;
 }
 
-function bfb_convert( string $content, string $from, string $to ): string {
+function bfb_convert( string $content, string $from, string $to, array $options = array() ): string {
+	unset( $options );
 	return (string) $GLOBALS['bfb_smoke_conversion_output'];
 }
 


### PR DESCRIPTION
## Summary
- Add a fourth-argument conversion options seam to `bfb_convert()`, `bfb_to_blocks()`, and `bfb_render_post()`.
- Thread options through the adapter contract so callers can request modes like `mode=fidelity` without BFB knowing about static-site-importer.
- Forward HTML conversion options into h2bc raw-handler args while preserving `HTML` as BFB-owned source content.

## API
- `bfb_convert( $content, 'html', 'blocks', array( 'mode' => 'fidelity' ) )`
- `bfb_to_blocks( $content, 'html', array( 'mode' => 'fidelity' ) )`
- `bfb_render_post( $post, 'html', array( 'mode' => 'fidelity' ) )`
- `block-format-bridge/convert` ability now accepts an optional `options` object.

## Tests
- `php -l includes/api.php includes/interface-bfb-format-adapter.php includes/class-bfb-html-adapter.php includes/class-bfb-markdown-adapter.php includes/abilities.php tests/BFBConversionUnitTest.php tests/smoke-capabilities-abilities.php`
- `php tests/smoke-capabilities-abilities.php`
- `php tests/smoke-insert-conversion-measurement.php`
- `for f in tests/smoke-*.php; do php "$f" || exit 1; done`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --file includes/class-bfb-html-adapter.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --file includes/abilities.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --file includes/api.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --file includes/interface-bfb-format-adapter.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --file includes/class-bfb-markdown-adapter.php --summary`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --file tests/smoke-insert-conversion-measurement.php --summary`

Full `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@feat-conversion-options-mode --summary` still reports existing repo-wide PHPStan noise around PHPUnit/smoke harness context. The branch-local 4-arg `bfb_convert()` findings were resolved.

Refs #80

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and tests; Chris reviews and owns the final change.
