### PR TITLE
fix: register BFB ability category

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -9,6 +9,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! defined( 'BFB_ABILITY_CATEGORY' ) ) {
+	define( 'BFB_ABILITY_CATEGORY', 'block-format-bridge' );
+}
+
+if ( ! function_exists( 'bfb_register_ability_category' ) ) {
+	/**
+	 * Register the Block Format Bridge ability category.
+	 *
+	 * @return void
+	 */
+	function bfb_register_ability_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			BFB_ABILITY_CATEGORY,
+			array(
+				'label'       => __( 'Block Format Bridge', 'block-format-bridge' ),
+				'description' => __( 'Content format conversion and normalization capabilities.', 'block-format-bridge' ),
+			)
+		);
+	}
+}
+
 if ( ! function_exists( 'bfb_register_abilities' ) ) {
 	/**
 	 * Register Block Format Bridge abilities when the Abilities API is present.
@@ -25,6 +50,7 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 			array(
 				'label'               => __( 'Get Block Format Bridge Capabilities', 'block-format-bridge' ),
 				'description'         => __( 'Return the active content-format conversion substrate capabilities.', 'block-format-bridge' ),
+				'category'            => BFB_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(),
@@ -41,6 +67,7 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 			array(
 				'label'               => __( 'Convert Content Format', 'block-format-bridge' ),
 				'description'         => __( 'Convert content between registered BFB formats through the block pivot.', 'block-format-bridge' ),
+				'category'            => BFB_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -63,6 +90,7 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 			array(
 				'label'               => __( 'Normalize Content Format', 'block-format-bridge' ),
 				'description'         => __( 'Normalize and validate content for a declared BFB format.', 'block-format-bridge' ),
+				'category'            => BFB_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -183,6 +211,12 @@ if ( ! function_exists( 'bfb_ability_error' ) ) {
 			),
 		);
 	}
+}
+
+if ( doing_action( 'wp_abilities_api_categories_init' ) ) {
+	bfb_register_ability_category();
+} elseif ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+	add_action( 'wp_abilities_api_categories_init', 'bfb_register_ability_category' );
 }
 
 if ( doing_action( 'wp_abilities_api_init' ) ) {

--- a/tests/smoke-capabilities-abilities.php
+++ b/tests/smoke-capabilities-abilities.php
@@ -18,6 +18,7 @@ if ( ! defined( 'BFB_PATH' ) ) {
 }
 
 $GLOBALS['bfb_smoke_abilities'] = array();
+$GLOBALS['bfb_smoke_ability_categories'] = array();
 
 function bfb_capabilities_smoke_assert( bool $condition, string $message ): void {
 	if ( ! $condition ) {
@@ -45,7 +46,11 @@ function did_action( string $hook_name ): int {
 }
 
 function add_action( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $hook_name, $callback, $priority, $accepted_args );
+	unset( $priority, $accepted_args );
+
+	if ( 'wp_abilities_api_categories_init' === $hook_name && is_callable( $callback ) ) {
+		$callback();
+	}
 }
 
 function do_action( string $hook_name, ...$args ): void {
@@ -63,6 +68,10 @@ function current_user_can( string $capability ): bool {
 
 function wp_register_ability( string $name, array $config ): void {
 	$GLOBALS['bfb_smoke_abilities'][ $name ] = $config;
+}
+
+function wp_register_ability_category( string $slug, array $config ): void {
+	$GLOBALS['bfb_smoke_ability_categories'][ $slug ] = $config;
 }
 
 function parse_blocks( string $content ): array {
@@ -146,9 +155,15 @@ bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/convert', $report[
 bfb_capabilities_smoke_assert( in_array( 'block-format-bridge/normalize', $report['abilities'], true ), 'Capability report should list the normalize ability.' );
 
 $abilities = $GLOBALS['bfb_smoke_abilities'];
+$categories = $GLOBALS['bfb_smoke_ability_categories'];
+bfb_capabilities_smoke_assert( isset( $categories['block-format-bridge'] ), 'BFB ability category should be registered.' );
+bfb_capabilities_smoke_assert( isset( $categories['block-format-bridge']['label'] ), 'BFB ability category should include a label.' );
 bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/get-capabilities'] ), 'Capabilities ability should be registered.' );
 bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/convert'] ), 'Convert ability should be registered.' );
 bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/normalize'] ), 'Normalize ability should be registered.' );
+bfb_capabilities_smoke_assert( 'block-format-bridge' === $abilities['block-format-bridge/get-capabilities']['category'], 'Capabilities ability should declare the BFB category.' );
+bfb_capabilities_smoke_assert( 'block-format-bridge' === $abilities['block-format-bridge/convert']['category'], 'Convert ability should declare the BFB category.' );
+bfb_capabilities_smoke_assert( 'block-format-bridge' === $abilities['block-format-bridge/normalize']['category'], 'Normalize ability should declare the BFB category.' );
 bfb_capabilities_smoke_assert( true === $abilities['block-format-bridge/get-capabilities']['meta']['show_in_rest'], 'Capabilities ability should opt into REST exposure.' );
 bfb_capabilities_smoke_assert( isset( $abilities['block-format-bridge/convert']['input_schema']['properties']['options'] ), 'Convert ability should accept conversion options.' );
 


### PR DESCRIPTION
## Summary
- Register a Block Format Bridge ability category before ability registration.
- Add the category string to each BFB ability so WordPress 6.9 accepts the ability metadata.
- Extend the capability/abilities smoke to cover category registration and per-ability category metadata.

## Tests
- `php tests/smoke-capabilities-abilities.php`
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@fix-ability-categories`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the WordPress 6.9 ability category notice, added the category metadata fix, and ran smoke/Homeboy tests.
