### PR TITLE
fix: refresh bundled h2bc to 0.6.7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -722,16 +722,16 @@
     "packages-dev": [
         {
             "name": "chubes4/html-to-blocks-converter",
-            "version": "v0.6.6",
+            "version": "v0.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "88222a394d8396e48a3d7c8da4256847a04a679c"
+                "reference": "c3bed49704186a2c916b19bcfaf5f21c5f08e4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/88222a394d8396e48a3d7c8da4256847a04a679c",
-                "reference": "88222a394d8396e48a3d7c8da4256847a04a679c",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/c3bed49704186a2c916b19bcfaf5f21c5f08e4cd",
+                "reference": "c3bed49704186a2c916b19bcfaf5f21c5f08e4cd",
                 "shasum": ""
             },
             "require": {
@@ -755,10 +755,10 @@
             "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
             "homepage": "https://github.com/chubes4/html-to-blocks-converter",
             "support": {
-                "source": "https://github.com/chubes4/html-to-blocks-converter/tree/v0.6.6",
+                "source": "https://github.com/chubes4/html-to-blocks-converter/tree/v0.6.7",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-04-30T03:17:41+00:00"
+            "time": "2026-04-30T12:05:40+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/html-to-blocks-converter.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/html-to-blocks-converter.php
@@ -6,7 +6,7 @@ namespace BlockFormatBridge\Vendor;
  * Plugin Name: HTML to Blocks Converter
  * Plugin URI: https://github.com/chubes4/html-to-blocks-converter
  * Description: Converts raw HTML to Gutenberg blocks — on write (wp_insert_post) and on read (REST API for the editor)
- * Version: 0.6.6
+ * Version: 0.6.7
  * Author: Chris Huber
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -1384,7 +1384,7 @@ class HTML_To_Blocks_Transform_Registry
         if ($tag !== 'DIV') {
             return \false;
         }
-        return self::class_matches($element, '/(?:^|[-_\s])(group|section|container|wrapper|content|main|article|aside|header|footer|inner|row)(?:$|[-_\s])/i');
+        return self::class_matches($element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card)(?:$|[-_\s])/i');
     }
     /**
      * Checks whether an element is a cover/hero wrapper.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/library.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/library.php
@@ -20,7 +20,7 @@ if (!\defined('ABSPATH')) {
     return;
 }
 $html_to_blocks_library_path = __DIR__;
-$html_to_blocks_library_version = '0.6.6';
+$html_to_blocks_library_version = '0.6.7';
 if (!\class_exists('BlockFormatBridge\Vendor\HTML_To_Blocks_Versions', \false)) {
     require_once $html_to_blocks_library_path . '/includes/class-html-to-blocks-versions.php';
 }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-layout-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-layout-transforms.php
@@ -142,10 +142,22 @@ $smoke_assert(($stack_group['attrs']['className'] ?? '') === 'custom-stack', 'gr
 $main = new Layout_Smoke_Element('main', ['class' => 'site-shell'], '<section class="hero"><h1>Site Editor Template Smoke</h1><p>Template raw HTML should become blocks.</p></section>');
 $main_transform = $find_transform($main, 'core/group');
 $main_group = $main_transform ? \call_user_func($main_transform['transform'], $main, $handler) : null;
-$landmark_tags = ['header', 'footer', 'article', 'aside', 'nav'];
+$landmark_tags = ['header', 'footer', 'article', 'aside'];
 $smoke_assert($main_group && $main_group['blockName'] === 'core/group', 'main-landmark-to-group');
 $smoke_assert(\strpos($main_group['attrs']['className'] ?? '', 'site-shell') !== \false, 'main-landmark-preserves-class');
 $smoke_assert(($main_group['innerBlocks'][0]['blockName'] ?? '') === 'core/heading', 'main-landmark-recurses-children');
+$wrap_group_element = new Layout_Smoke_Element('div', ['class' => 'wrap'], '<h2>Wrapped static-site copy</h2>');
+$wrap_group_transform = $find_transform($wrap_group_element, 'core/group');
+$wrap_group = $wrap_group_transform ? \call_user_func($wrap_group_transform['transform'], $wrap_group_element, $handler) : null;
+$smoke_assert($wrap_group && $wrap_group['blockName'] === 'core/group', 'wrap-wrapper-to-group');
+$smoke_assert(($wrap_group['attrs']['className'] ?? '') === 'wrap', 'wrap-wrapper-preserves-class');
+$smoke_assert(($wrap_group['innerBlocks'][0]['blockName'] ?? '') === 'core/heading', 'wrap-wrapper-recurses-children');
+$grid_group_element = new Layout_Smoke_Element('div', ['class' => 'grid cols-3'], '<article class="card"><h3>Card</h3><p>Copy</p></article>');
+$grid_group_transform = $find_transform($grid_group_element, 'core/group');
+$grid_group = $grid_group_transform ? \call_user_func($grid_group_transform['transform'], $grid_group_element, $handler) : null;
+$smoke_assert($grid_group && $grid_group['blockName'] === 'core/group', 'grid-wrapper-to-group');
+$smoke_assert(($grid_group['attrs']['className'] ?? '') === 'grid cols-3', 'grid-wrapper-preserves-class');
+$smoke_assert(($grid_group['innerBlocks'][0]['blockName'] ?? '') === 'core/paragraph', 'grid-wrapper-recurses-children');
 foreach ($landmark_tags as $tag) {
     $landmark = new Layout_Smoke_Element($tag, [], '<p>Landmark copy</p>');
     $landmark_transform = $find_transform($landmark, 'core/group');


### PR DESCRIPTION
## Summary
- Refresh the bundled `chubes4/html-to-blocks-converter` copy from v0.6.6 to v0.6.7.
- Carries the h2bc static-wrapper group fix so common generated-site wrappers like `wrap`, `grid`, and `card` recurse into native blocks instead of raw HTML fallback.

## Tests
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@refresh-h2bc-0-6-7`
- `homeboy audit block-format-bridge --path /Users/chubes/Developer/block-format-bridge@refresh-h2bc-0-6-7 --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed the bundled h2bc artifact after the upstream h2bc release and ran focused verification; Chris remains responsible for review and merge.
