### PR TITLE
Add conversion quality reports

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -7,6 +7,8 @@
  *   bfb_convert( $content, $from, $to, $options ) — universal conversion
  *   bfb_to_blocks( $content, $from, $options )    — block-array conversion
  *   bfb_normalize( $content, $format )      — declared-format validation
+ *   bfb_analyze_blocks( $blocks )           — block quality report
+ *   bfb_conversion_report( $content, $from ) — conversion quality report
  *   bfb_capabilities()                      — conversion substrate report
  *   bfb_get_adapter( $slug )                — registry lookup
  *
@@ -238,6 +240,125 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 		}
 
 		return $to_adapter->from_blocks( $blocks, $options );
+	}
+}
+
+if ( ! function_exists( 'bfb_analyze_blocks' ) ) {
+	/**
+	 * Analyze a parsed block tree for conversion quality signals.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed block list.
+	 * @return array<string, mixed> Quality report.
+	 */
+	function bfb_analyze_blocks( array $blocks ): array {
+		$report = array(
+			'total_blocks'     => 0,
+			'block_counts'     => array(),
+			'core_html_blocks' => 0,
+			'fallbacks'        => array(),
+		);
+
+		bfb_analyze_block_list( $blocks, $report );
+
+		return $report;
+	}
+}
+
+if ( ! function_exists( 'bfb_conversion_report' ) ) {
+	/**
+	 * Convert content to blocks and return quality metrics alongside the result.
+	 *
+	 * @param string               $content Source content.
+	 * @param string               $from    Source format slug.
+	 * @param array<string, mixed> $options Per-call conversion options.
+	 * @return array<string, mixed> Conversion report.
+	 */
+	function bfb_conversion_report( string $content, string $from, array $options = array() ): array {
+		$fallback_events = array();
+		$listener        = static function ( string $html, array $context, array $block ) use ( &$fallback_events ): void {
+			$fallback_events[] = array(
+				'reason'     => isset( $context['reason'] ) ? (string) $context['reason'] : '',
+				'tag_name'   => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : '',
+				'occurrence' => isset( $context['occurrence'] ) ? (int) $context['occurrence'] : null,
+				'bytes'      => strlen( $html ),
+				'preview'    => bfb_preview_html( $html ),
+				'block_name' => isset( $block['blockName'] ) ? (string) $block['blockName'] : '',
+			);
+		};
+
+		add_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10, 3 );
+		try {
+			$blocks = bfb_to_blocks( $content, $from, $options );
+		} finally {
+			remove_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10 );
+		}
+
+		$analysis                         = bfb_analyze_blocks( $blocks );
+		$analysis['from']                 = $from;
+		$analysis['source_bytes']         = strlen( $content );
+		$analysis['fallback_events']      = $fallback_events;
+		$analysis['fallback_event_count'] = count( $fallback_events );
+		$analysis['serialized_blocks']    = serialize_blocks( $blocks );
+
+		return $analysis;
+	}
+}
+
+if ( ! function_exists( 'bfb_analyze_block_list' ) ) {
+	/**
+	 * Walk parsed blocks and populate a quality report.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed block list.
+	 * @param array<string, mixed>             $report Report being populated.
+	 * @param array<int, int>                  $path   Current block path.
+	 * @return void
+	 */
+	function bfb_analyze_block_list( array $blocks, array &$report, array $path = array() ): void {
+		foreach ( $blocks as $index => $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name = isset( $block['blockName'] ) ? (string) $block['blockName'] : '';
+			if ( '' !== $name ) {
+				$report['total_blocks']++;
+				$report['block_counts'][ $name ] = isset( $report['block_counts'][ $name ] ) ? (int) $report['block_counts'][ $name ] + 1 : 1;
+			}
+
+			$block_path = array_merge( $path, array( $index ) );
+			if ( 'core/html' === $name ) {
+				$html = '';
+				if ( isset( $block['attrs']['content'] ) && is_string( $block['attrs']['content'] ) ) {
+					$html = $block['attrs']['content'];
+				} elseif ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ) {
+					$html = $block['innerHTML'];
+				}
+
+				$report['core_html_blocks']++;
+				$report['fallbacks'][] = array(
+					'path'    => implode( '.', $block_path ),
+					'bytes'   => strlen( $html ),
+					'preview' => bfb_preview_html( $html ),
+				);
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				bfb_analyze_block_list( $block['innerBlocks'], $report, $block_path );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'bfb_preview_html' ) ) {
+	/**
+	 * Build a compact one-line preview for reports.
+	 *
+	 * @param string $html HTML fragment.
+	 * @return string Preview text.
+	 */
+	function bfb_preview_html( string $html ): string {
+		$preview = preg_replace( '/\s+/', ' ', trim( $html ) );
+		return substr( is_string( $preview ) ? $preview : trim( $html ), 0, 700 );
 	}
 }
 

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -133,6 +133,62 @@ if ( ! class_exists( 'BFB_CLI_Command' ) ) {
 		}
 
 		/**
+		 * Analyze conversion quality for content.
+		 *
+		 * ## OPTIONS
+		 *
+		 * --from=<format>
+		 * : Source format slug.
+		 *
+		 * [--input=<file>]
+		 * : Read input from a file instead of STDIN.
+		 *
+		 * [--format=<format>]
+		 * : Output format. Supports `json` or `summary`.
+		 * ---
+		 * default: summary
+		 * ---
+		 *
+		 * @param array<int, string>   $args       Positional arguments.
+		 * @param array<string, mixed> $assoc_args Associative arguments.
+		 * @return void
+		 */
+		public function analyze( array $args, array $assoc_args ): void {
+			unset( $args );
+
+			$from   = isset( $assoc_args['from'] ) ? (string) $assoc_args['from'] : '';
+			$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'summary';
+
+			if ( '' === $from ) {
+				WP_CLI::error( 'Missing required --from=<format> argument.' );
+			}
+
+			if ( 'blocks' !== $from && ! bfb_get_adapter( $from ) ) {
+				WP_CLI::error( sprintf( 'No BFB adapter registered for source format: %s', $from ) );
+			}
+
+			if ( ! in_array( $format, array( 'summary', 'json' ), true ) ) {
+				WP_CLI::error( 'Unsupported --format value. Use "summary" or "json".' );
+			}
+
+			$content = $this->read_input( isset( $assoc_args['input'] ) ? (string) $assoc_args['input'] : '' );
+			$report  = bfb_conversion_report( $content, $from );
+
+			if ( 'json' === $format ) {
+				$output = wp_json_encode( $report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+				if ( false === $output ) {
+					WP_CLI::error( 'Failed to encode analysis report as JSON.' );
+				}
+				WP_CLI::line( $output );
+				return;
+			}
+
+			WP_CLI::line( sprintf( 'Blocks: %d', (int) $report['total_blocks'] ) );
+			WP_CLI::line( sprintf( 'core/html blocks: %d', (int) $report['core_html_blocks'] ) );
+			WP_CLI::line( sprintf( 'h2bc fallback events: %d', (int) $report['fallback_event_count'] ) );
+		}
+
+		/**
 		 * Read command input.
 		 *
 		 * @param string $path Optional input file path.

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -370,6 +370,49 @@ MARKDOWN;
 	}
 
 	/**
+	 * Block analysis should expose fallback details without every consumer reimplementing metrics.
+	 */
+	public function test_block_analysis_reports_core_html_fallback_details(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/group',
+				'attrs'       => array(),
+				'innerBlocks' => array(
+					array(
+						'blockName' => 'core/html',
+						'attrs'     => array(
+							'content' => '<div class="widget"> Unsupported widget </div>',
+						),
+					),
+				),
+			),
+		);
+
+		$report = bfb_analyze_blocks( $blocks );
+
+		$this->assertSame( 2, $report['total_blocks'] );
+		$this->assertSame( 1, $report['core_html_blocks'] );
+		$this->assertSame( 1, $report['block_counts']['core/html'] ?? null );
+		$this->assertSame( '0.0', $report['fallbacks'][0]['path'] ?? null );
+		$this->assertStringContainsString( 'Unsupported widget', $report['fallbacks'][0]['preview'] ?? '' );
+	}
+
+	/**
+	 * Conversion reports should include h2bc fallback reasons captured during conversion.
+	 */
+	public function test_conversion_report_captures_h2bc_fallback_events(): void {
+		$report = bfb_conversion_report( '<iframe src="https://example.com/widget"></iframe>', 'html' );
+
+		$this->assertSame( 'html', $report['from'] );
+		$this->assertSame( 1, $report['total_blocks'] );
+		$this->assertSame( 1, $report['core_html_blocks'] );
+		$this->assertSame( 1, $report['fallback_event_count'] );
+		$this->assertSame( 'no_transform', $report['fallback_events'][0]['reason'] ?? null );
+		$this->assertSame( 'IFRAME', $report['fallback_events'][0]['tag_name'] ?? null );
+		$this->assertStringContainsString( '<!-- wp:html', $report['serialized_blocks'] );
+	}
+
+	/**
 	 * Blocks should render to HTML through WordPress' real render_block() path.
 	 */
 	public function test_blocks_to_html_renders_static_and_dynamic_blocks(): void {

--- a/tests/smoke-cli-command.php
+++ b/tests/smoke-cli-command.php
@@ -30,6 +30,8 @@ bfb_cli_smoke_assert( strpos( $cli_source, 'public function capabilities' ) !== 
 bfb_cli_smoke_assert( strpos( $cli_source, 'bfb_capabilities()' ) !== false, 'Capabilities CLI should wrap the PHP report helper.' );
 bfb_cli_smoke_assert( strpos( $cli_source, "'json' === \$format" ) !== false, 'Capabilities CLI should support --format=json.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'public function convert' ) !== false, 'CLI should expose a convert subcommand.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'public function analyze' ) !== false, 'CLI should expose an analyze subcommand.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'bfb_conversion_report( $content, $from )' ) !== false, 'Analyze CLI should wrap the conversion report helper.' );
 bfb_cli_smoke_assert( strpos( $cli_source, "file_get_contents( 'php://stdin' )" ) !== false, 'CLI should read STDIN when --input is omitted.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'file_get_contents( $path )' ) !== false, 'CLI should read file input when --input is present.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'file_put_contents( $path, $content )' ) !== false, 'CLI should write file output when --output is present.' );


### PR DESCRIPTION
## Summary
- Add `bfb_analyze_blocks()` for reusable block-tree quality metrics.
- Add `bfb_conversion_report()` to convert content while capturing h2bc fallback reasons and serialized output.
- Add `wp bfb analyze --from=<format>` for JSON/summary reporting.

## Why
Studio, Static Site Importer, and other BFB consumers should not each reimplement their own `core/html` fallback counters. This makes conversion-quality reporting part of BFB's public substrate.

## Tests
- `php -l includes/api.php`
- `php -l includes/cli.php`
- `php tests/smoke-cli-command.php`
- `/opt/homebrew/bin/homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper/CLI/test changes and ran the validation commands; Chris directed the API ownership decision.
