### PR TITLE
Add agent-safe conversion diagnostics

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -296,11 +296,124 @@ if ( ! function_exists( 'bfb_conversion_report' ) ) {
 		$analysis                         = bfb_analyze_blocks( $blocks );
 		$analysis['from']                 = $from;
 		$analysis['source_bytes']         = strlen( $content );
+		$analysis['source_text_bytes']    = bfb_text_bytes( $content );
 		$analysis['fallback_events']      = $fallback_events;
 		$analysis['fallback_event_count'] = count( $fallback_events );
 		$analysis['serialized_blocks']    = serialize_blocks( $blocks );
+		$analysis['converted_text_bytes'] = bfb_text_bytes( $analysis['serialized_blocks'] );
+		$analysis['text_retention_ratio'] = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
+
+		$diagnostics = bfb_build_conversion_diagnostics( $analysis );
+
+		$analysis['status']         = $diagnostics['status'];
+		$analysis['diagnostics']    = $diagnostics['diagnostics'];
+		$analysis['agent_guidance'] = $diagnostics['agent_guidance'];
 
 		return $analysis;
+	}
+}
+
+if ( ! function_exists( 'bfb_build_conversion_diagnostics' ) ) {
+	/**
+	 * Build structured, agent-safe diagnostics from a conversion report.
+	 *
+	 * The status values intentionally distinguish native conversion, explicit
+	 * core/html fallback, and suspected text loss so automation can react to the
+	 * right evidence without being nudged toward manually authoring wp:html blocks.
+	 *
+	 * @param array<string, mixed> $report Conversion report data.
+	 * @return array{status:string,diagnostics:array<int,array<string,mixed>>,agent_guidance:string}
+	 */
+	function bfb_build_conversion_diagnostics( array $report ): array {
+		$status      = 'success_native';
+		$diagnostics = array();
+		$guidance    = 'Conversion completed with native blocks. Continue using the conversion layer for future writes.';
+
+		$total_blocks          = isset( $report['total_blocks'] ) ? (int) $report['total_blocks'] : 0;
+		$core_html_blocks      = isset( $report['core_html_blocks'] ) ? (int) $report['core_html_blocks'] : 0;
+		$fallback_event_count  = isset( $report['fallback_event_count'] ) ? (int) $report['fallback_event_count'] : 0;
+		$source_bytes          = isset( $report['source_bytes'] ) ? (int) $report['source_bytes'] : 0;
+		$source_text_bytes     = isset( $report['source_text_bytes'] ) ? (int) $report['source_text_bytes'] : 0;
+		$converted_text_bytes  = isset( $report['converted_text_bytes'] ) ? (int) $report['converted_text_bytes'] : 0;
+		$text_retention_ratio  = isset( $report['text_retention_ratio'] ) ? (float) $report['text_retention_ratio'] : 1.0;
+		$has_fallback_evidence = $core_html_blocks > 0 || $fallback_event_count > 0;
+		$suspected_text_loss   = ! $has_fallback_evidence && $source_text_bytes >= 200 && $text_retention_ratio < 0.5;
+
+		if ( $source_bytes > 0 && 0 === $total_blocks ) {
+			$status        = 'failed';
+			$diagnostics[] = array(
+				'code'     => 'conversion_failed',
+				'severity' => 'error',
+				'message'  => 'The source content did not produce any blocks.',
+				'details'  => array(
+					'source_bytes' => $source_bytes,
+				),
+			);
+			$guidance      = 'Conversion failed. Inspect the source format and adapter availability before retrying; do not bypass conversion with manual wp:html unless raw HTML preservation is explicitly required.';
+		} elseif ( $has_fallback_evidence ) {
+			$status        = 'success_with_fallbacks';
+			$diagnostics[] = array(
+				'code'     => 'core_html_fallback',
+				'severity' => 'warning',
+				'message'  => 'Conversion completed, but some fragments were preserved as core/html fallback blocks.',
+				'details'  => array(
+					'core_html_blocks'     => $core_html_blocks,
+					'fallback_event_count' => $fallback_event_count,
+				),
+			);
+			$guidance      = 'Conversion completed with explicit fallback evidence. Review fallback_events and fallbacks to identify unsupported fragments; keep future writes routed through BFB unless the user explicitly wants raw HTML blocks.';
+		} elseif ( $suspected_text_loss ) {
+			$status        = 'warning_only_suspicion';
+			$diagnostics[] = array(
+				'code'     => 'possible_text_loss',
+				'severity' => 'warning',
+				'message'  => 'Converted block text is much smaller than source text, but no explicit core/html fallback was reported.',
+				'details'  => array(
+					'source_text_bytes'    => $source_text_bytes,
+					'converted_text_bytes' => $converted_text_bytes,
+					'text_retention_ratio' => $text_retention_ratio,
+				),
+			);
+			$guidance      = 'Potential warning-only content loss. Capture this report for the conversion substrate and retry with simpler source structure if needed; do not work around it by manually authoring wp:html blocks.';
+		}
+
+		return array(
+			'status'         => $status,
+			'diagnostics'    => $diagnostics,
+			'agent_guidance' => $guidance,
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_text_retention_ratio' ) ) {
+	/**
+	 * Calculate the ratio of converted text bytes to source text bytes.
+	 *
+	 * @param int $source_text_bytes Source text byte count.
+	 * @param int $converted_text_bytes Converted text byte count.
+	 * @return float Retention ratio in the range 0..1+.
+	 */
+	function bfb_text_retention_ratio( int $source_text_bytes, int $converted_text_bytes ): float {
+		if ( $source_text_bytes <= 0 ) {
+			return 1.0;
+		}
+
+		return round( $converted_text_bytes / $source_text_bytes, 4 );
+	}
+}
+
+if ( ! function_exists( 'bfb_text_bytes' ) ) {
+	/**
+	 * Count visible text bytes in content for loss-suspicion diagnostics.
+	 *
+	 * @param string $content Source or serialized block content.
+	 * @return int Visible text byte count.
+	 */
+	function bfb_text_bytes( string $content ): int {
+		$text = wp_strip_all_tags( $content );
+		$text = preg_replace( '/\s+/', ' ', trim( (string) $text ) );
+
+		return strlen( is_string( $text ) ? $text : '' );
 	}
 }
 
@@ -315,13 +428,9 @@ if ( ! function_exists( 'bfb_analyze_block_list' ) ) {
 	 */
 	function bfb_analyze_block_list( array $blocks, array &$report, array $path = array() ): void {
 		foreach ( $blocks as $index => $block ) {
-			if ( ! is_array( $block ) ) {
-				continue;
-			}
-
 			$name = isset( $block['blockName'] ) ? (string) $block['blockName'] : '';
 			if ( '' !== $name ) {
-				$report['total_blocks']++;
+				++$report['total_blocks'];
 				$report['block_counts'][ $name ] = isset( $report['block_counts'][ $name ] ) ? (int) $report['block_counts'][ $name ] + 1 : 1;
 			}
 
@@ -334,7 +443,7 @@ if ( ! function_exists( 'bfb_analyze_block_list' ) ) {
 					$html = $block['innerHTML'];
 				}
 
-				$report['core_html_blocks']++;
+				++$report['core_html_blocks'];
 				$report['fallbacks'][] = array(
 					'path'    => implode( '.', $block_path ),
 					'bytes'   => strlen( $html ),

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -184,8 +184,31 @@ if ( ! class_exists( 'BFB_CLI_Command' ) ) {
 			}
 
 			WP_CLI::line( sprintf( 'Blocks: %d', (int) $report['total_blocks'] ) );
+			WP_CLI::line( sprintf( 'Status: %s', isset( $report['status'] ) ? (string) $report['status'] : 'unknown' ) );
 			WP_CLI::line( sprintf( 'core/html blocks: %d', (int) $report['core_html_blocks'] ) );
 			WP_CLI::line( sprintf( 'h2bc fallback events: %d', (int) $report['fallback_event_count'] ) );
+			WP_CLI::line( sprintf( 'text retention: %.2f', isset( $report['text_retention_ratio'] ) ? (float) $report['text_retention_ratio'] : 1.0 ) );
+
+			if ( ! empty( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ) {
+				foreach ( $report['diagnostics'] as $diagnostic ) {
+					if ( ! is_array( $diagnostic ) ) {
+						continue;
+					}
+
+					WP_CLI::line(
+						sprintf(
+							'Diagnostic: %s (%s) - %s',
+							isset( $diagnostic['code'] ) ? (string) $diagnostic['code'] : 'unknown',
+							isset( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : 'info',
+							isset( $diagnostic['message'] ) ? (string) $diagnostic['message'] : ''
+						)
+					);
+				}
+			}
+
+			if ( ! empty( $report['agent_guidance'] ) ) {
+				WP_CLI::line( sprintf( 'Agent guidance: %s', (string) $report['agent_guidance'] ) );
+			}
 		}
 
 		/**

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -407,9 +407,55 @@ MARKDOWN;
 		$this->assertSame( 1, $report['total_blocks'] );
 		$this->assertSame( 1, $report['core_html_blocks'] );
 		$this->assertSame( 1, $report['fallback_event_count'] );
+		$this->assertSame( 'success_with_fallbacks', $report['status'] );
+		$this->assertSame( 'core_html_fallback', $report['diagnostics'][0]['code'] ?? null );
+		$this->assertStringContainsString( 'fallback_events', $report['agent_guidance'] ?? '' );
 		$this->assertSame( 'no_transform', $report['fallback_events'][0]['reason'] ?? null );
 		$this->assertSame( 'IFRAME', $report['fallback_events'][0]['tag_name'] ?? null );
 		$this->assertStringContainsString( '<!-- wp:html', $report['serialized_blocks'] );
+	}
+
+	/**
+	 * Conversion diagnostics should separate warning-only suspicion from explicit fallback evidence.
+	 */
+	public function test_conversion_diagnostics_classify_warning_only_suspicion(): void {
+		$diagnostics = bfb_build_conversion_diagnostics(
+			array(
+				'total_blocks'          => 1,
+				'core_html_blocks'      => 0,
+				'fallback_event_count'  => 0,
+				'source_bytes'          => 1400,
+				'source_text_bytes'     => 900,
+				'converted_text_bytes'  => 44,
+				'text_retention_ratio'  => 0.0489,
+			)
+		);
+
+		$this->assertSame( 'warning_only_suspicion', $diagnostics['status'] );
+		$this->assertSame( 'possible_text_loss', $diagnostics['diagnostics'][0]['code'] ?? null );
+		$this->assertSame( 'warning', $diagnostics['diagnostics'][0]['severity'] ?? null );
+		$this->assertStringContainsString( 'do not work around it by manually authoring wp:html blocks', $diagnostics['agent_guidance'] );
+	}
+
+	/**
+	 * Empty block output should remain an error, not a softened warning.
+	 */
+	public function test_conversion_diagnostics_classify_failed_conversion(): void {
+		$diagnostics = bfb_build_conversion_diagnostics(
+			array(
+				'total_blocks'          => 0,
+				'core_html_blocks'      => 0,
+				'fallback_event_count'  => 0,
+				'source_bytes'          => 20,
+				'source_text_bytes'     => 12,
+				'converted_text_bytes'  => 0,
+				'text_retention_ratio'  => 0.0,
+			)
+		);
+
+		$this->assertSame( 'failed', $diagnostics['status'] );
+		$this->assertSame( 'conversion_failed', $diagnostics['diagnostics'][0]['code'] ?? null );
+		$this->assertSame( 'error', $diagnostics['diagnostics'][0]['severity'] ?? null );
 	}
 
 	/**

--- a/tests/smoke-cli-command.php
+++ b/tests/smoke-cli-command.php
@@ -32,6 +32,9 @@ bfb_cli_smoke_assert( strpos( $cli_source, "'json' === \$format" ) !== false, 'C
 bfb_cli_smoke_assert( strpos( $cli_source, 'public function convert' ) !== false, 'CLI should expose a convert subcommand.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'public function analyze' ) !== false, 'CLI should expose an analyze subcommand.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'bfb_conversion_report( $content, $from )' ) !== false, 'Analyze CLI should wrap the conversion report helper.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'Status: %s' ) !== false, 'Analyze summary should surface structured conversion status.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'Diagnostic: %s (%s) - %s' ) !== false, 'Analyze summary should surface structured diagnostics.' );
+bfb_cli_smoke_assert( strpos( $cli_source, 'Agent guidance: %s' ) !== false, 'Analyze summary should surface agent-safe guidance.' );
 bfb_cli_smoke_assert( strpos( $cli_source, "file_get_contents( 'php://stdin' )" ) !== false, 'CLI should read STDIN when --input is omitted.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'file_get_contents( $path )' ) !== false, 'CLI should read file input when --input is present.' );
 bfb_cli_smoke_assert( strpos( $cli_source, 'file_put_contents( $path, $content )' ) !== false, 'CLI should write file output when --output is present.' );


### PR DESCRIPTION
## Summary
- Adds structured conversion statuses and diagnostics to BFB conversion reports so automation can distinguish native success, explicit core/html fallback, suspected warning-only text loss, and hard failure.
- Surfaces the same status, diagnostics, text retention, and agent guidance in the bfb analyze summary output.
- Keeps the actual nested-wrapper conversion fix scoped to upstream h2bc #80.

## Changes
- Adds report fields: status, diagnostics, agent_guidance, source_text_bytes, converted_text_bytes, and text_retention_ratio.
- Classifies warning-only text-loss suspicion without treating it as an explicit fallback event.
- Updates tests for fallback reports, warning-only suspicion, failed conversion, and CLI summary contract.

## Tests
- php -l includes/api.php
- php -l includes/cli.php
- php -l tests/BFBConversionUnitTest.php
- php tests/smoke-cli-command.php
- homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@agent-safe-conversion-diagnostics --file includes/api.php --summary
- homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@agent-safe-conversion-diagnostics --file includes/cli.php --summary
- homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@agent-safe-conversion-diagnostics

Refs #87
Refs chubes4/html-to-blocks-converter#80

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the diagnostics/reporting change; Chris remains responsible for review and merge.