### PR TITLE
Surface conversion materialization metadata

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -88,12 +88,16 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 					'bfb_markdown_input',
 					'bfb_markdown_output',
 					'bfb_html_to_blocks_args',
+					'bfb_html_to_blocks_pre_result',
+					'bfb_html_to_blocks_result',
 					'bfb_html_to_markdown_options',
 				),
 				'actions' => array(
 					'bfb_loaded',
 					'bfb_adapters_registered',
 					'bfb_diagnostic',
+					'bfb_conversion_metadata',
+					'bfb_materialization_request',
 					'bfb_insert_conversion_measured',
 					'bfb_html_to_markdown_converter',
 				),
@@ -243,6 +247,34 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 	}
 }
 
+if ( ! function_exists( 'bfb_filter_html_to_blocks_result' ) ) {
+	/**
+	 * Filter block arrays returned by the HTML conversion substrate.
+	 *
+	 * This hook lets generic conversion substrate integrations expose a final
+	 * block array without coupling BFB to any filesystem or importer behavior.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks  Converted block list.
+	 * @param string                           $content Source HTML.
+	 * @param array<string, mixed>             $options Per-call conversion options.
+	 * @param array<string, mixed>             $args    Raw handler arguments.
+	 * @return array<int, array<string, mixed>> Filtered block list.
+	 */
+	function bfb_filter_html_to_blocks_result( array $blocks, string $content, array $options, array $args ): array {
+		/**
+		 * Filters block arrays returned by the HTML conversion substrate.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param array<int, array<string, mixed>> $blocks  Converted block list.
+		 * @param string                           $content Source HTML.
+		 * @param array<string, mixed>             $options Per-call conversion options.
+		 * @param array<string, mixed>             $args    Raw handler arguments.
+		 */
+		return (array) apply_filters( 'bfb_html_to_blocks_result', $blocks, $content, $options, $args );
+	}
+}
+
 if ( ! function_exists( 'bfb_analyze_blocks' ) ) {
 	/**
 	 * Analyze a parsed block tree for conversion quality signals.
@@ -274,8 +306,10 @@ if ( ! function_exists( 'bfb_conversion_report' ) ) {
 	 * @return array<string, mixed> Conversion report.
 	 */
 	function bfb_conversion_report( string $content, string $from, array $options = array() ): array {
-		$fallback_events = array();
-		$listener        = static function ( string $html, array $context, array $block ) use ( &$fallback_events ): void {
+		$fallback_events          = array();
+		$conversion_metadata      = array();
+		$materialization_requests = array();
+		$fallback_listener        = static function ( string $html, array $context, array $block ) use ( &$fallback_events ): void {
 			$fallback_events[] = array(
 				'reason'     => isset( $context['reason'] ) ? (string) $context['reason'] : '',
 				'tag_name'   => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : '',
@@ -285,23 +319,54 @@ if ( ! function_exists( 'bfb_conversion_report' ) ) {
 				'block_name' => isset( $block['blockName'] ) ? (string) $block['blockName'] : '',
 			);
 		};
+		$metadata_listener        = static function ( array $metadata ) use ( &$conversion_metadata, &$materialization_requests ): void {
+			$normalized = bfb_normalize_conversion_metadata( $metadata );
+			if ( array() === $normalized ) {
+				return;
+			}
 
-		add_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10, 3 );
+			$conversion_metadata[] = $normalized;
+			if ( 'materialization_request' === ( $normalized['type'] ?? '' ) ) {
+				$materialization_requests[] = $normalized;
+			}
+		};
+		$request_listener         = static function ( array $request ) use ( &$conversion_metadata, &$materialization_requests ): void {
+			$normalized = bfb_normalize_conversion_metadata( array_merge( array( 'type' => 'materialization_request' ), $request ) );
+			if ( array() === $normalized ) {
+				return;
+			}
+
+			$conversion_metadata[]      = $normalized;
+			$materialization_requests[] = $normalized;
+		};
+
+		add_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10, 3 );
+		add_action( 'html_to_blocks_conversion_metadata', $metadata_listener, 10, 1 );
+		add_action( 'html_to_blocks_materialization_request', $request_listener, 10, 1 );
+		add_action( 'bfb_conversion_metadata', $metadata_listener, 10, 1 );
+		add_action( 'bfb_materialization_request', $request_listener, 10, 1 );
 		try {
 			$blocks = bfb_to_blocks( $content, $from, $options );
 		} finally {
-			remove_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10 );
+			remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
+			remove_action( 'html_to_blocks_conversion_metadata', $metadata_listener, 10 );
+			remove_action( 'html_to_blocks_materialization_request', $request_listener, 10 );
+			remove_action( 'bfb_conversion_metadata', $metadata_listener, 10 );
+			remove_action( 'bfb_materialization_request', $request_listener, 10 );
 		}
 
-		$analysis                         = bfb_analyze_blocks( $blocks );
-		$analysis['from']                 = $from;
-		$analysis['source_bytes']         = strlen( $content );
-		$analysis['source_text_bytes']    = bfb_text_bytes( $content );
-		$analysis['fallback_events']      = $fallback_events;
-		$analysis['fallback_event_count'] = count( $fallback_events );
-		$analysis['serialized_blocks']    = serialize_blocks( $blocks );
-		$analysis['converted_text_bytes'] = bfb_text_bytes( $analysis['serialized_blocks'] );
-		$analysis['text_retention_ratio'] = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
+		$analysis                                  = bfb_analyze_blocks( $blocks );
+		$analysis['from']                          = $from;
+		$analysis['source_bytes']                  = strlen( $content );
+		$analysis['source_text_bytes']             = bfb_text_bytes( $content );
+		$analysis['fallback_events']               = $fallback_events;
+		$analysis['fallback_event_count']          = count( $fallback_events );
+		$analysis['conversion_metadata']           = $conversion_metadata;
+		$analysis['materialization_requests']      = $materialization_requests;
+		$analysis['materialization_request_count'] = count( $materialization_requests );
+		$analysis['serialized_blocks']             = serialize_blocks( $blocks );
+		$analysis['converted_text_bytes']          = bfb_text_bytes( $analysis['serialized_blocks'] );
+		$analysis['text_retention_ratio']          = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
 
 		$diagnostics = bfb_build_conversion_diagnostics( $analysis );
 
@@ -332,6 +397,7 @@ if ( ! function_exists( 'bfb_build_conversion_diagnostics' ) ) {
 		$total_blocks          = isset( $report['total_blocks'] ) ? (int) $report['total_blocks'] : 0;
 		$core_html_blocks      = isset( $report['core_html_blocks'] ) ? (int) $report['core_html_blocks'] : 0;
 		$fallback_event_count  = isset( $report['fallback_event_count'] ) ? (int) $report['fallback_event_count'] : 0;
+		$materialization_count = isset( $report['materialization_request_count'] ) ? (int) $report['materialization_request_count'] : 0;
 		$source_bytes          = isset( $report['source_bytes'] ) ? (int) $report['source_bytes'] : 0;
 		$source_text_bytes     = isset( $report['source_text_bytes'] ) ? (int) $report['source_text_bytes'] : 0;
 		$converted_text_bytes  = isset( $report['converted_text_bytes'] ) ? (int) $report['converted_text_bytes'] : 0;
@@ -362,6 +428,17 @@ if ( ! function_exists( 'bfb_build_conversion_diagnostics' ) ) {
 				),
 			);
 			$guidance      = 'Conversion completed with explicit fallback evidence. Review fallback_events and fallbacks to identify unsupported fragments; keep future writes routed through BFB unless the user explicitly wants raw HTML blocks.';
+		} elseif ( $materialization_count > 0 ) {
+			$status        = 'success_with_materialization_requests';
+			$diagnostics[] = array(
+				'code'     => 'materialization_requested',
+				'severity' => 'info',
+				'message'  => 'Conversion completed with downstream asset or reference materialization requests.',
+				'details'  => array(
+					'materialization_request_count' => $materialization_count,
+				),
+			);
+			$guidance      = 'Conversion completed without fallback evidence, but downstream materialization is required. Review materialization_requests, write assets in the consuming layer, and replace placeholders before final output.';
 		} elseif ( $suspected_text_loss ) {
 			$status        = 'warning_only_suspicion';
 			$diagnostics[] = array(
@@ -382,6 +459,61 @@ if ( ! function_exists( 'bfb_build_conversion_diagnostics' ) ) {
 			'diagnostics'    => $diagnostics,
 			'agent_guidance' => $guidance,
 		);
+	}
+}
+
+if ( ! function_exists( 'bfb_normalize_conversion_metadata' ) ) {
+	/**
+	 * Normalize conversion metadata emitted by conversion substrates.
+	 *
+	 * BFB stores only structured, filesystem-agnostic data. Downstream consumers
+	 * decide whether and where to write assets, then replace any placeholders.
+	 *
+	 * @param array<string, mixed> $metadata Raw metadata event.
+	 * @return array<string, mixed> Normalized metadata, or empty array when invalid.
+	 */
+	function bfb_normalize_conversion_metadata( array $metadata ): array {
+		$type = isset( $metadata['type'] ) ? sanitize_key( (string) $metadata['type'] ) : '';
+		if ( '' === $type ) {
+			return array();
+		}
+
+		$normalized  = array( 'type' => $type );
+		$scalar_keys = array(
+			'id',
+			'kind',
+			'source',
+			'placeholder',
+			'media_type',
+			'filename',
+			'alt',
+			'label',
+			'classification',
+			'encoding',
+		);
+
+		foreach ( $scalar_keys as $key ) {
+			if ( isset( $metadata[ $key ] ) && is_scalar( $metadata[ $key ] ) ) {
+				$normalized[ $key ] = (string) $metadata[ $key ];
+			}
+		}
+
+		if ( isset( $metadata['payload'] ) && is_string( $metadata['payload'] ) ) {
+			$normalized['payload']       = $metadata['payload'];
+			$normalized['payload_bytes'] = strlen( $metadata['payload'] );
+		} elseif ( isset( $metadata['payload_bytes'] ) && is_numeric( $metadata['payload_bytes'] ) ) {
+			$normalized['payload_bytes'] = max( 0, (int) $metadata['payload_bytes'] );
+		}
+
+		if ( isset( $metadata['metadata'] ) && is_array( $metadata['metadata'] ) ) {
+			$normalized['metadata'] = $metadata['metadata'];
+		}
+
+		if ( isset( $metadata['replacement'] ) && is_array( $metadata['replacement'] ) ) {
+			$normalized['replacement'] = $metadata['replacement'];
+		}
+
+		return $normalized;
 	}
 }
 

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -60,14 +60,19 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 		$args         = (array) apply_filters( 'bfb_html_to_blocks_args', $args, $content, $options );
 		$args['HTML'] = $content;
 
+		$pre_result = apply_filters( 'bfb_html_to_blocks_pre_result', null, $content, $options, $args );
+		if ( is_array( $pre_result ) ) {
+			return bfb_filter_html_to_blocks_result( $pre_result, $content, $options, $args );
+		}
+
 		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
 			$blocks = \BlockFormatBridge\Vendor\html_to_blocks_raw_handler( $args );
-			return is_array( $blocks ) ? $blocks : array();
+			return bfb_filter_html_to_blocks_result( is_array( $blocks ) ? $blocks : array(), $content, $options, $args );
 		}
 
 		if ( function_exists( 'html_to_blocks_raw_handler' ) ) {
 			$blocks = html_to_blocks_raw_handler( $args );
-			return is_array( $blocks ) ? $blocks : array();
+			return bfb_filter_html_to_blocks_result( is_array( $blocks ) ? $blocks : array(), $content, $options, $args );
 		}
 
 		// Should only happen in a broken build: BFB requires

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -416,6 +416,85 @@ MARKDOWN;
 	}
 
 	/**
+	 * Conversion reports should surface generic downstream materialization requests.
+	 */
+	public function test_conversion_report_surfaces_safe_svg_materialization_metadata(): void {
+		$safe_svg = '<svg viewBox="0 0 24 24" aria-label="Check"><path d="M20 6 9 17l-5-5" fill="none" stroke="currentColor" stroke-width="2"/></svg>';
+
+		$pre_result = static function ( $pre_result, string $content ): array {
+			unset( $pre_result );
+
+			do_action(
+				'html_to_blocks_materialization_request',
+				array(
+					'id'             => 'svg-icon-check',
+					'kind'           => 'asset',
+					'source'         => 'inline',
+					'classification' => 'safe_svg_icon',
+					'media_type'     => 'image/svg+xml',
+					'filename'       => 'svg-icon-check.svg',
+					'placeholder'    => 'bfb-materialization://svg-icon-check',
+					'payload'        => $content,
+					'alt'            => 'Check',
+					'replacement'    => array(
+						'block_name' => 'core/image',
+						'attrs'      => array(
+							'url' => 'bfb-materialization://svg-icon-check',
+							'alt' => 'Check',
+						),
+					),
+				)
+			);
+
+			return array(
+				array(
+					'blockName'    => 'core/image',
+					'attrs'        => array(
+						'url' => 'bfb-materialization://svg-icon-check',
+						'alt' => 'Check',
+					),
+					'innerBlocks'  => array(),
+					'innerHTML'    => '<figure class="wp-block-image"><img src="bfb-materialization://svg-icon-check" alt="Check"/></figure>',
+					'innerContent' => array( '<figure class="wp-block-image"><img src="bfb-materialization://svg-icon-check" alt="Check"/></figure>' ),
+				),
+			);
+		};
+
+		add_filter( 'bfb_html_to_blocks_pre_result', $pre_result, 10, 2 );
+		try {
+			$report = bfb_conversion_report( $safe_svg, 'html' );
+		} finally {
+			remove_filter( 'bfb_html_to_blocks_pre_result', $pre_result, 10 );
+		}
+
+		$this->assertSame( 1, $report['total_blocks'] );
+		$this->assertSame( 0, $report['core_html_blocks'] );
+		$this->assertSame( 0, $report['fallback_event_count'] );
+		$this->assertSame( 1, $report['materialization_request_count'] );
+		$this->assertSame( 'success_with_materialization_requests', $report['status'] );
+		$this->assertSame( 'materialization_requested', $report['diagnostics'][0]['code'] ?? null );
+		$this->assertSame( 'safe_svg_icon', $report['materialization_requests'][0]['classification'] ?? null );
+		$this->assertSame( 'image/svg+xml', $report['materialization_requests'][0]['media_type'] ?? null );
+		$this->assertStringContainsString( '<svg viewBox=', $report['materialization_requests'][0]['payload'] ?? '' );
+		$this->assertStringNotContainsString( '<!-- wp:html', $report['serialized_blocks'] );
+	}
+
+	/**
+	 * Unsafe SVG should stay on the explicit unsupported fallback path.
+	 */
+	public function test_conversion_report_keeps_unsafe_svg_as_fallback_diagnostic(): void {
+		$report = bfb_conversion_report( '<svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"/></svg>', 'html' );
+
+		$this->assertSame( 1, $report['core_html_blocks'] );
+		$this->assertSame( 1, $report['fallback_event_count'] );
+		$this->assertSame( 0, $report['materialization_request_count'] );
+		$this->assertSame( 'success_with_fallbacks', $report['status'] );
+		$this->assertSame( 'core_html_fallback', $report['diagnostics'][0]['code'] ?? null );
+		$this->assertSame( 'SVG', $report['fallback_events'][0]['tag_name'] ?? null );
+		$this->assertStringContainsString( '<!-- wp:html', $report['serialized_blocks'] );
+	}
+
+	/**
 	 * Conversion diagnostics should separate warning-only suspicion from explicit fallback evidence.
 	 */
 	public function test_conversion_diagnostics_classify_warning_only_suspicion(): void {


### PR DESCRIPTION
## Summary
- Adds a generic BFB conversion metadata/materialization request collector to `bfb_conversion_report()`.
- Exposes filesystem-agnostic HTML conversion hook points so h2bc can provide safe SVG placeholder blocks plus asset materialization metadata.
- Adds coverage for safe SVG materialization metadata with zero `core/html` fallbacks, and unsafe SVG preserving fallback diagnostics.

Closes #89.
Related: chubes4/html-to-blocks-converter#133.

## Tests
- `/opt/homebrew/bin/homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@svg-asset-metadata-report`
- `/opt/homebrew/bin/homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@svg-asset-metadata-report` (fails on existing PHPStan baseline-style findings; introduced formatting/type warnings were fixed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the BFB implementation and tests; Chris remains responsible for review and final acceptance.