### PR TITLE
Add BFB context passthrough coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Every adapter implements the `BFB_Format_Adapter` contract:
 ```php
 interface BFB_Format_Adapter {
     public function slug(): string;
-    public function to_blocks( string $content ): array;
-    public function from_blocks( array $blocks ): string;
+    public function to_blocks( string $content, array $options = array() ): array;
+    public function from_blocks( array $blocks, array $options = array() ): string;
     public function detect( string $content ): bool; // reserved for future use
 }
 ```
@@ -196,7 +196,24 @@ $md = bfb_convert( '<h1>X</h1>', 'html', 'markdown' );
 
 // Markdown → HTML (composes via blocks)
 $html = bfb_convert( '# X', 'markdown', 'html' );
+
+// HTML → blocks with importer-neutral per-call context forwarded to h2bc args.
+$blocks = bfb_convert(
+    '<h1>Hello</h1><p>World</p>',
+    'html',
+    'blocks',
+    array(
+        'context' => array(
+            'source' => 'static-site-importer',
+            'mode'   => 'import',
+        ),
+    )
+);
 ```
+
+The optional fourth argument is a generic per-call options array. For HTML → Blocks, BFB forwards those options alongside
+the reserved `HTML` argument passed to `html_to_blocks_raw_handler()`, so downstream tools can pass structured `context`
+without BFB gaining importer-specific API.
 
 ### `bfb_to_blocks( $content, $from ): array`
 

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -48,8 +48,8 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 		 * Filters the argument array passed to html-to-blocks-converter.
 		 *
 		 * BFB reserves the `HTML` key for source content. Per-call conversion
-		 * options, such as `mode`, are forwarded alongside it for h2bc to
-		 * consume when supported.
+		 * options, such as `context` and `mode`, are forwarded alongside it for
+		 * h2bc to consume when supported.
 		 *
 		 * @since 0.5.0
 		 *

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -109,6 +109,22 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 		$default = bfb_convert( $html, 'html', 'blocks' );
 		$this->assertNotSame( '', $default, 'Default 3-argument conversion should remain supported.' );
 
+		$default_args = null;
+		$default_listener = static function ( array $args ) use ( &$default_args ): array {
+			$default_args = $args;
+			return $args;
+		};
+
+		add_filter( 'bfb_html_to_blocks_args', $default_listener, 10, 1 );
+		try {
+			bfb_convert( $html, 'html', 'blocks' );
+		} finally {
+			remove_filter( 'bfb_html_to_blocks_args', $default_listener, 10 );
+		}
+
+		$this->assertIsArray( $default_args, 'Default conversion should still expose h2bc raw-handler arguments.' );
+		$this->assertArrayNotHasKey( 'context', $default_args, 'Default conversion should not inject conversion context.' );
+
 		$seen_args = null;
 		$listener  = static function ( array $args, string $content, array $options ) use ( &$seen_args ): array {
 			$seen_args = array(
@@ -121,7 +137,18 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 
 		add_filter( 'bfb_html_to_blocks_args', $listener, 10, 3 );
 		try {
-			$with_options = bfb_convert( $html, 'html', 'blocks', array( 'mode' => 'fidelity' ) );
+			$with_options = bfb_convert(
+				$html,
+				'html',
+				'blocks',
+				array(
+					'context' => array(
+						'source' => 'static-site-importer',
+						'mode'   => 'import',
+					),
+					'mode'    => 'fidelity',
+				)
+			);
 		} finally {
 			remove_filter( 'bfb_html_to_blocks_args', $listener, 10 );
 		}
@@ -129,8 +156,26 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 		$this->assertNotSame( '', $with_options, '4-argument conversion should produce serialized blocks.' );
 		$this->assertIsArray( $seen_args, 'HTML adapter should expose h2bc raw-handler arguments.' );
 		$this->assertSame( 'fidelity', $seen_args['args']['mode'] ?? null, 'Mode option should be forwarded to h2bc args.' );
+		$this->assertSame(
+			array(
+				'source' => 'static-site-importer',
+				'mode'   => 'import',
+			),
+			$seen_args['args']['context'] ?? null,
+			'Generic conversion context should be forwarded to h2bc args.'
+		);
 		$this->assertSame( $html, $seen_args['args']['HTML'] ?? null, 'BFB should preserve the reserved HTML raw-handler arg.' );
-		$this->assertSame( array( 'mode' => 'fidelity' ), $seen_args['options'] ?? null, 'HTML adapter should receive public conversion options.' );
+		$this->assertSame(
+			array(
+				'context' => array(
+					'source' => 'static-site-importer',
+					'mode'   => 'import',
+				),
+				'mode'    => 'fidelity',
+			),
+			$seen_args['options'] ?? null,
+			'HTML adapter should receive public conversion options.'
+		);
 
 		$probe = new class() implements BFB_Format_Adapter {
 			/**


### PR DESCRIPTION
## Summary
- Strengthens BFB conversion smoke coverage so `bfb_convert( $html, 'html', 'blocks', array( 'context' => ... ) )` proves generic context reaches h2bc raw-handler args.
- Asserts default HTML conversion still omits context when no options are provided.
- Documents the generic per-call options/context path without adding WooCommerce-specific API.

## Tests
- `homeboy test`
- `homeboy lint --changed-only`

## Notes
- Full `homeboy lint` still reports pre-existing PHPStan findings outside this PR; PHPCS passed and changed-only lint passed.

Closes #93.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementation draft and verification; Chris remains responsible.