### PR TITLE
Add import-grade Markdown fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ BFB includes two adapters:
 - **`BFB_Markdown_Adapter`** — `to_blocks()` runs CommonMark + GFM and routes the resulting HTML through the HTML
   adapter. `from_blocks()` renders blocks via `render_block()` and pipes the HTML through league/html-to-markdown.
 
+Markdown input is treated as a content body only. BFB does not parse YAML frontmatter, TOML frontmatter, or any other
+document metadata envelope; callers that import files are responsible for stripping and interpreting frontmatter before
+passing the body to `bfb_convert( $markdown, 'markdown', 'blocks' )`. BFB also does not support MDX component syntax unless
+a future dedicated adapter is registered for it.
+
 Every cross-format conversion routes through the block-array pivot:
 
 ```

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -388,6 +388,62 @@ MARKDOWN;
 	}
 
 	/**
+	 * Import-grade Markdown bodies should become native blocks without SSI-specific APIs.
+	 */
+	public function test_markdown_to_blocks_covers_import_grade_body_fixtures(): void {
+		$fixtures = array(
+			'docs'    => array(
+				'file'     => 'import-grade-docs.md',
+				'blocks'   => array( 'core/heading', 'core/paragraph', 'core/list', 'core/list-item', 'core/table', 'core/code', 'core/quote' ),
+				'snippets' => array(
+					'<!-- wp:heading {"level":1} -->',
+					'<h2 class="wp-block-heading">Preflight</h2>',
+					'<td>Markdown</td><td>Native blocks</td>',
+					'const format = &#039;markdown&#039;;',
+				),
+			),
+			'article' => array(
+				'file'     => 'import-grade-article.md',
+				'blocks'   => array( 'core/heading', 'core/paragraph', 'core/quote', 'core/list', 'core/list-item', 'core/code' ),
+				'snippets' => array(
+					'<h1 class="wp-block-heading">The Import-Grade Article</h1>',
+					'<img src="https://example.com/migration-diagram.png" alt="Migration diagram"',
+					'<strong>bold decisions</strong>',
+					'bfb_convert( $markdown, &#039;markdown&#039;, &#039;blocks&#039; );',
+				),
+			),
+			'landing' => array(
+				'file'     => 'import-grade-landing.md',
+				'blocks'   => array( 'core/heading', 'core/paragraph', 'core/list', 'core/list-item', 'core/separator', 'core/table', 'core/quote' ),
+				'snippets' => array(
+					'<h1 class="wp-block-heading">Ship Cleaner Imports</h1>',
+					'<a href="https://example.com/start">Start the import</a>',
+					'<!-- wp:separator -->',
+					'<td>Landing pages</td><td>Content blocks</td>',
+				),
+			),
+		);
+
+		foreach ( $fixtures as $label => $fixture ) {
+			$markdown   = $this->markdown_fixture( $fixture['file'] );
+			$serialized = bfb_convert( $markdown, 'markdown', 'blocks' );
+			$blocks     = parse_blocks( $serialized );
+			$flat       = $this->flatten_blocks( $blocks );
+
+			$this->assertNotSame( '', $serialized, "{$label} fixture should produce serialized blocks." );
+			$this->assertNotContains( 'core/html', $flat, "{$label} fixture should not fall back to raw HTML blocks." );
+
+			foreach ( $fixture['blocks'] as $block_name ) {
+				$this->assertContains( $block_name, $flat, "{$label} fixture should include {$block_name}." );
+			}
+
+			foreach ( $fixture['snippets'] as $snippet ) {
+				$this->assertStringContainsString( $snippet, $serialized, "{$label} fixture should serialize {$snippet}." );
+			}
+		}
+	}
+
+	/**
 	 * Compiler consumers should get block arrays without reaching into adapters.
 	 */
 	public function test_bfb_to_blocks_exposes_compiler_facing_block_array_helper(): void {
@@ -794,6 +850,22 @@ MARKDOWN;
 		$this->assertNotSame( '', $serialized, "{$from} conversion should produce serialized blocks." );
 
 		return parse_blocks( $serialized );
+	}
+
+	/**
+	 * Load a Markdown fixture body.
+	 *
+	 * @param string $file Fixture filename.
+	 * @return string Fixture contents.
+	 */
+	private function markdown_fixture( string $file ): string {
+		$path = __DIR__ . '/fixtures/markdown/' . $file;
+		$this->assertFileExists( $path );
+
+		$contents = file_get_contents( $path );
+		$this->assertIsString( $contents );
+
+		return $contents;
 	}
 
 	/**

--- a/tests/fixtures/markdown/import-grade-article.md
+++ b/tests/fixtures/markdown/import-grade-article.md
@@ -1,0 +1,21 @@
+# The Import-Grade Article
+
+Long-form editorial content should survive Markdown conversion as readable WordPress blocks.
+
+![Migration diagram](https://example.com/migration-diagram.png "Migration diagram")
+
+## Why It Matters
+
+Paragraphs can mix **bold decisions**, *editorial nuance*, and [traceable links](https://example.com/source) without dropping inline semantics.
+
+> A converted article should preserve quotes as quotes, not opaque HTML.
+
+- Preserve headings.
+- Preserve media references.
+- Preserve list structure.
+
+## Implementation Notes
+
+```php
+bfb_convert( $markdown, 'markdown', 'blocks' );
+```

--- a/tests/fixtures/markdown/import-grade-docs.md
+++ b/tests/fixtures/markdown/import-grade-docs.md
@@ -1,0 +1,22 @@
+# Import Runbook
+
+Use this checklist when validating a mixed-source import before writing content.
+
+## Preflight
+
+1. Confirm the source document has no frontmatter in the body handed to BFB.
+2. Verify images are reachable before materialization.
+3. Record any unsupported markup as upstream converter gaps.
+
+## Fixture Matrix
+
+| Source | Expected |
+| ------ | -------- |
+| HTML   | Native blocks |
+| Markdown | Native blocks |
+
+```js
+const format = 'markdown';
+```
+
+> Frontmatter parsing belongs to the caller before conversion.

--- a/tests/fixtures/markdown/import-grade-landing.md
+++ b/tests/fixtures/markdown/import-grade-landing.md
@@ -1,0 +1,23 @@
+# Ship Cleaner Imports
+
+Turn static bodies from mixed sources into editable WordPress content without asking SSI for a special path.
+
+## What You Get
+
+- Markdown headings become heading blocks.
+- Body copy becomes paragraph blocks.
+- Calls to action remain traceable links.
+
+[Start the import](https://example.com/start)
+
+---
+
+## Proof Points
+
+| Capability | Result |
+| ---------- | ------ |
+| Docs | Structured blocks |
+| Articles | Editorial blocks |
+| Landing pages | Content blocks |
+
+> MDX components are intentionally outside this adapter contract.


### PR DESCRIPTION
## Summary
- Adds import-grade Markdown body fixtures for docs, article, and landing-page shapes used by mixed-source import stress tests.
- Covers Markdown -> Blocks conversion with native block-name assertions and key serialized block snippets, without adding SSI-specific API surface.
- Documents that frontmatter parsing is caller-owned and MDX requires a future dedicated adapter.

Closes #96.

## Tests
- `homeboy test --path \"/Users/chubes/Developer/block-format-bridge@test-import-grade-markdown-fixtures-96\" -- --filter=test_markdown_to_blocks_covers_import_grade_body_fixtures`

## Blockers
- None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the Markdown fixtures, PHPUnit coverage, README boundary documentation, and ran the targeted test command for Chris to review.