### PR TITLE
Add source fragment conversion contract

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -86,6 +86,27 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 		);
 
 		wp_register_ability(
+			'block-format-bridge/convert-fragment',
+			array(
+				'label'               => __( 'Convert Source Fragment', 'block-format-bridge' ),
+				'description'         => __( 'Convert a standalone HTML fragment to block markup with fragment-scoped diagnostics and provenance.', 'block-format-bridge' ),
+				'category'            => BFB_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'html'    => array( 'type' => 'string' ),
+						'options' => array( 'type' => 'object' ),
+					),
+					'required'   => array( 'html' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'bfb_ability_convert_fragment',
+				'permission_callback' => 'bfb_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		wp_register_ability(
 			'block-format-bridge/normalize',
 			array(
 				'label'               => __( 'Normalize Content Format', 'block-format-bridge' ),
@@ -159,6 +180,26 @@ if ( ! function_exists( 'bfb_ability_convert' ) ) {
 			'to'      => $to,
 			'content' => $result,
 		);
+	}
+}
+
+if ( ! function_exists( 'bfb_ability_convert_fragment' ) ) {
+	/**
+	 * Ability callback for source-fragment conversion.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function bfb_ability_convert_fragment( array $input ): array {
+		$html    = isset( $input['html'] ) ? (string) $input['html'] : '';
+		$options = isset( $input['options'] ) && is_array( $input['options'] ) ? $input['options'] : array();
+
+		$result = bfb_convert_fragment( $html, $options );
+		if ( empty( $result['success'] ) && '' !== $html ) {
+			return bfb_ability_error( 'bfb_fragment_conversion_failed', 'BFB fragment conversion failed.', $result );
+		}
+
+		return $result;
 	}
 }
 

--- a/includes/api.php
+++ b/includes/api.php
@@ -9,6 +9,7 @@
  *   bfb_normalize( $content, $format )      — declared-format validation
  *   bfb_analyze_blocks( $blocks )           — block quality report
  *   bfb_conversion_report( $content, $from ) — conversion quality report
+ *   bfb_convert_fragment( $html, $options )  — scoped fragment conversion
  *   bfb_capabilities()                      — conversion substrate report
  *   bfb_get_adapter( $slug )                — registry lookup
  *
@@ -66,9 +67,13 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 			),
 			'formats'        => $formats,
 			'conversions'    => array(
-				'html_to_blocks' => array(
+				'html_to_blocks'            => array(
 					'available' => (bool) $h2bc['available'],
 					'provider'  => 'html-to-blocks-converter',
+				),
+				'source_fragment_to_blocks' => array(
+					'available' => (bool) $h2bc['available'],
+					'provider'  => 'block-format-bridge',
 				),
 			),
 			'h2bc'           => $h2bc,
@@ -105,8 +110,71 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 			'abilities'      => array(
 				'block-format-bridge/get-capabilities',
 				'block-format-bridge/convert',
+				'block-format-bridge/convert-fragment',
 				'block-format-bridge/normalize',
 			),
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_convert_fragment' ) ) {
+	/**
+	 * Convert a standalone source fragment to editor-valid block markup.
+	 *
+	 * This generic contract is intentionally small: callers pass a localized
+	 * HTML fragment plus optional provenance hints, and BFB returns serialized
+	 * block markup with diagnostics scoped to that fragment. Full-document
+	 * conversion remains on bfb_convert() / bfb_conversion_report().
+	 *
+	 * Supported provenance option keys: source_id, source_selector, region_id,
+	 * label. The values are copied into the returned scope and forwarded through
+	 * conversion context for substrate integrations that can use them.
+	 *
+	 * @param string               $html    Standalone HTML fragment.
+	 * @param array<string, mixed> $options Per-call conversion and provenance options.
+	 * @return array<string, mixed> Fragment conversion envelope.
+	 */
+	function bfb_convert_fragment( string $html, array $options = array() ): array {
+		$scope = bfb_normalize_fragment_scope( $options );
+
+		$conversion_options = $options;
+		$context            = isset( $conversion_options['context'] ) && is_array( $conversion_options['context'] ) ? $conversion_options['context'] : array();
+		$context            = array_merge(
+			$context,
+			array(
+				'conversion_scope' => 'fragment',
+				'source_fragment'  => $scope,
+			)
+		);
+
+		$conversion_options['context'] = $context;
+
+		$report     = bfb_conversion_report( $html, 'html', $conversion_options );
+		$serialized = isset( $report['serialized_blocks'] ) && is_string( $report['serialized_blocks'] ) ? $report['serialized_blocks'] : '';
+		$blocks     = '' !== $serialized ? parse_blocks( $serialized ) : array();
+		$status     = isset( $report['status'] ) ? (string) $report['status'] : 'failed';
+
+		$report['scope'] = $scope;
+		if ( isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ) {
+			$report['diagnostics'] = bfb_scope_fragment_diagnostics( $report['diagnostics'], $scope );
+		}
+
+		return array(
+			'success'           => 'failed' !== $status,
+			'status'            => $status,
+			'from'              => 'html',
+			'to'                => 'blocks',
+			'scope'             => $scope,
+			'content'           => $serialized,
+			'serialized_blocks' => $serialized,
+			'blocks'            => $blocks,
+			'diagnostics'       => isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array(),
+			'provenance'        => array(
+				'scope'        => $scope,
+				'source_bytes' => strlen( $html ),
+				'source_hash'  => hash( 'sha256', $html ),
+			),
+			'report'            => $report,
 		);
 	}
 }
@@ -272,6 +340,63 @@ if ( ! function_exists( 'bfb_filter_html_to_blocks_result' ) ) {
 		 * @param array<string, mixed>             $args    Raw handler arguments.
 		 */
 		return (array) apply_filters( 'bfb_html_to_blocks_result', $blocks, $content, $options, $args );
+	}
+}
+
+if ( ! function_exists( 'bfb_normalize_fragment_scope' ) ) {
+	/**
+	 * Normalize source-fragment provenance into a stable public shape.
+	 *
+	 * @param array<string, mixed> $options Fragment conversion options.
+	 * @return array<string, string>
+	 */
+	function bfb_normalize_fragment_scope( array $options ): array {
+		$scope = array( 'type' => 'fragment' );
+		$keys  = array( 'source_id', 'source_selector', 'region_id', 'label' );
+
+		foreach ( $keys as $key ) {
+			if ( isset( $options[ $key ] ) && is_scalar( $options[ $key ] ) ) {
+				$value = trim( (string) $options[ $key ] );
+				if ( '' !== $value ) {
+					$scope[ $key ] = $value;
+				}
+			}
+		}
+
+		if ( isset( $options['scope'] ) && is_array( $options['scope'] ) ) {
+			foreach ( $keys as $key ) {
+				if ( isset( $options['scope'][ $key ] ) && is_scalar( $options['scope'][ $key ] ) && ! isset( $scope[ $key ] ) ) {
+					$value = trim( (string) $options['scope'][ $key ] );
+					if ( '' !== $value ) {
+						$scope[ $key ] = $value;
+					}
+				}
+			}
+		}
+
+		return $scope;
+	}
+}
+
+if ( ! function_exists( 'bfb_scope_fragment_diagnostics' ) ) {
+	/**
+	 * Attach source-fragment scope to every diagnostic entry.
+	 *
+	 * @param array<int, array<string, mixed>> $diagnostics Diagnostics.
+	 * @param array<string, string>            $scope       Fragment scope.
+	 * @return array<int, array<string, mixed>> Scoped diagnostics.
+	 */
+	function bfb_scope_fragment_diagnostics( array $diagnostics, array $scope ): array {
+		foreach ( $diagnostics as $index => $diagnostic ) {
+			$details          = isset( $diagnostic['details'] ) && is_array( $diagnostic['details'] ) ? $diagnostic['details'] : array();
+			$details['scope'] = $scope;
+
+			$diagnostic['scope']   = $scope;
+			$diagnostic['details'] = $details;
+			$diagnostics[ $index ] = $diagnostic;
+		}
+
+		return $diagnostics;
 	}
 }
 

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -472,6 +472,73 @@ MARKDOWN;
 	}
 
 	/**
+	 * Source-fragment conversion should produce scoped block output for targeted updates.
+	 */
+	public function test_source_fragment_conversion_returns_scoped_hero_block_output(): void {
+		$fragment = '<section id="hero" class="hero hero-dark">'
+			. '<div class="container"><p class="eyebrow">New season</p><h1>Launch faster</h1>'
+			. '<p>Use a targeted update instead of importing the whole page.</p>'
+			. '<a class="wp-block-button__link" href="/start">Start now</a></div></section>';
+		$seen_args = null;
+		$listener  = static function ( array $args ) use ( &$seen_args ): array {
+			$seen_args = $args;
+			return $args;
+		};
+
+		add_filter( 'bfb_html_to_blocks_args', $listener, 10, 1 );
+		try {
+			$result = bfb_convert_fragment(
+				$fragment,
+				array(
+					'source_id'       => 'homepage-v2',
+					'source_selector' => '#hero',
+					'region_id'       => 'hero',
+				)
+			);
+		} finally {
+			remove_filter( 'bfb_html_to_blocks_args', $listener, 10 );
+		}
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'html', $result['from'] );
+		$this->assertSame( 'blocks', $result['to'] );
+		$this->assertSame( 'fragment', $result['scope']['type'] ?? null );
+		$this->assertSame( '#hero', $result['scope']['source_selector'] ?? null );
+		$this->assertSame( 'hero', $result['scope']['region_id'] ?? null );
+		$this->assertSame( $result['scope'], $result['provenance']['scope'] ?? null );
+		$this->assertSame( 'fragment', $seen_args['context']['conversion_scope'] ?? null );
+		$this->assertSame( '#hero', $seen_args['context']['source_fragment']['source_selector'] ?? null );
+		$this->assertNotSame( '', $result['content'] );
+		$this->assertStringContainsString( '<!-- wp:', $result['content'] );
+
+		$flat = $this->flatten_blocks( $result['blocks'] );
+		$this->assertContains( 'core/group', $flat, 'Hero section should become native group blocks.' );
+		$this->assertNotContains( 'core/html', $flat, 'Hero fragment should not require raw HTML fallback.' );
+		$this->assertStringContainsString( 'Launch faster', $result['content'] );
+		$this->assertStringContainsString( 'Use a targeted update instead of importing the whole page.', $result['content'] );
+
+		$this->assertSame( $result['scope'], $result['report']['scope'] ?? null );
+		$this->assertSame( 0, $result['report']['fallback_event_count'] ?? null );
+	}
+
+	/**
+	 * Fragment fallback diagnostics should stay attached to the fragment scope.
+	 */
+	public function test_source_fragment_conversion_scopes_fallback_diagnostics(): void {
+		$result = bfb_convert_fragment(
+			'<section id="widget"><iframe src="https://example.com/widget"></iframe></section>',
+			array( 'source_selector' => '#widget' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'success_with_fallbacks', $result['status'] );
+		$this->assertSame( '#widget', $result['diagnostics'][0]['scope']['source_selector'] ?? null );
+		$this->assertSame( '#widget', $result['diagnostics'][0]['details']['scope']['source_selector'] ?? null );
+		$this->assertSame( '#widget', $result['report']['diagnostics'][0]['scope']['source_selector'] ?? null );
+		$this->assertSame( 1, $result['report']['fallback_event_count'] ?? null );
+	}
+
+	/**
 	 * Block analysis should expose fallback details without every consumer reimplementing metrics.
 	 */
 	public function test_block_analysis_reports_core_html_fallback_details(): void {


### PR DESCRIPTION
## Summary
- Add `bfb_convert_fragment()` for standalone HTML fragment conversion to serialized block markup.
- Return fragment-scoped diagnostics and provenance for targeted update workflows.
- Expose `block-format-bridge/convert-fragment` ability and smoke coverage for hero/section fragments plus scoped fallback diagnostics.

Fixes #92.

## Testing
- `php -l includes/api.php`
- `php -l includes/abilities.php`
- `php -l tests/BFBConversionUnitTest.php`
- `homeboy test --path /Users/chubes/Developer/block-format-bridge@source-fragment-conversion`
- `homeboy lint --path /Users/chubes/Developer/block-format-bridge@source-fragment-conversion`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the source-fragment conversion contract, ability surface, and smoke coverage; Chris remains responsible for review and testing.
