### PR TITLE
chore: refresh bundled h2bc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/html-to-markdown": "^5.1"
     },
     "require-dev": {
-        "chubes4/html-to-blocks-converter": "^0.7",
+        "chubes4/html-to-blocks-converter": "dev-main",
         "humbug/php-scoper": "^0.18.19"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "337cf370d621dae8f4895840f29c6940",
+    "content-hash": "17bb65e574fb5f8bb9fff608767bf4a3",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -722,21 +722,22 @@
     "packages-dev": [
         {
             "name": "chubes4/html-to-blocks-converter",
-            "version": "v0.7.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "094b24fd1e2c51db5f86e8bb3b6c902480116fc2"
+                "reference": "ce2d10d007ef4b19259b0e837789b04536d27698"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/094b24fd1e2c51db5f86e8bb3b6c902480116fc2",
-                "reference": "094b24fd1e2c51db5f86e8bb3b6c902480116fc2",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/ce2d10d007ef4b19259b0e837789b04536d27698",
+                "reference": "ce2d10d007ef4b19259b0e837789b04536d27698",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -755,10 +756,10 @@
             "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
             "homepage": "https://github.com/chubes4/html-to-blocks-converter",
             "support": {
-                "source": "https://github.com/chubes4/html-to-blocks-converter/tree/v0.7.0",
+                "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-05-04T15:04:58+00:00"
+            "time": "2026-05-05T14:18:45+00:00"
         },
         {
             "name": "fidry/console",
@@ -2484,7 +2485,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "chubes4/html-to-blocks-converter": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
@@ -277,7 +277,9 @@ class HTML_To_Blocks_Block_Factory
         $is_svg_image = \preg_match('/\.svg(?:$|[?#])/i', (string) $url) === 1;
         $is_resized = $is_svg_image && !empty($attributes['width']) && !empty($attributes['height']);
         if ($is_resized) {
-            $img_attrs['style'] = 'width:' . $attributes['width'] . ';height:' . $attributes['height'];
+            $width = self::image_style_dimension($attributes['width']);
+            $height = self::image_style_dimension($attributes['height']);
+            $img_attrs['style'] = 'width:' . $width . ';height:' . $height;
             $img_attrs['width'] = null;
             $img_attrs['height'] = null;
         }
@@ -295,6 +297,20 @@ class HTML_To_Blocks_Block_Factory
             $class .= ' align' . $attributes['align'];
         }
         return '<figure class="' . esc_attr($class) . '">' . $img . $figcaption . '</figure>';
+    }
+    /**
+     * Normalizes image dimension attributes for CSS style declarations.
+     *
+     * @param mixed $value Dimension attribute value.
+     * @return string CSS dimension value.
+     */
+    private static function image_style_dimension($value): string
+    {
+        $value = \trim((string) $value);
+        if (\preg_match('/^-?(?:\d+|\d*\.\d+)$/', $value)) {
+            return $value . 'px';
+        }
+        return $value;
     }
     /**
      * Generates HTML for table block

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-element.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-html-element.php
@@ -292,6 +292,7 @@ class HTML_To_Blocks_HTML_Element
         $children = array();
         $root_depth = null;
         $occurrence_counters = array();
+        $tag_positions = array();
         while ($processor->next_tag()) {
             if ($processor->is_tag_closer()) {
                 continue;
@@ -308,7 +309,10 @@ class HTML_To_Blocks_HTML_Element
             if ($depth !== $root_depth + 1) {
                 continue;
             }
-            $element_html = self::extract_element_html_at_occurrence($this->outer_html, $tag_lower, $occurrence);
+            if (!isset($tag_positions[$tag_lower])) {
+                $tag_positions[$tag_lower] = self::find_tag_positions($this->outer_html, $tag_lower);
+            }
+            $element_html = self::extract_element_html_at_occurrence($this->outer_html, $tag_lower, $occurrence, $tag_positions[$tag_lower]);
             if ($element_html) {
                 $element = self::from_html($element_html);
                 if ($element) {
@@ -326,9 +330,9 @@ class HTML_To_Blocks_HTML_Element
      * @param int    $occurrence Which occurrence (0-based)
      * @return string|null
      */
-    private static function extract_element_html_at_occurrence(string $html, string $tag_name, int $occurrence): ?string
+    private static function extract_element_html_at_occurrence(string $html, string $tag_name, int $occurrence, ?array $positions = null): ?string
     {
-        $positions = self::find_tag_positions($html, $tag_name);
+        $positions = $positions ?? self::find_tag_positions($html, $tag_name);
         if (!isset($positions[$occurrence])) {
             return null;
         }
@@ -372,21 +376,22 @@ class HTML_To_Blocks_HTML_Element
     private static function extract_balanced_element(string $html, string $tag_name): ?string
     {
         $depth = 0;
-        $len = \strlen($html);
-        $i = 0;
-        $open_pattern = '/^<' . \preg_quote($tag_name, '/') . '(?:\s|>)/i';
-        $close_pattern = '/^<\/' . \preg_quote($tag_name, '/') . '\s*>/i';
-        while ($i < $len) {
-            $remaining = \substr($html, $i);
-            if (\preg_match($open_pattern, $remaining)) {
-                ++$depth;
-            } elseif (\preg_match($close_pattern, $remaining, $close_match)) {
+        $tag_pattern = '/<\/?' . \preg_quote($tag_name, '/') . '(?:\s[^>]*)?>/i';
+        $matched_count = \preg_match_all($tag_pattern, $html, $matches, \PREG_OFFSET_CAPTURE);
+        if (\false === $matched_count || 0 === $matched_count) {
+            return null;
+        }
+        foreach ($matches[0] as $match) {
+            $tag_markup = $match[0];
+            $offset = $match[1];
+            if (0 === \strpos($tag_markup, '</')) {
                 --$depth;
                 if (0 === $depth) {
-                    return \substr($html, 0, $i + \strlen($close_match[0]));
+                    return \substr($html, 0, $offset + \strlen($tag_markup));
                 }
+                continue;
             }
-            ++$i;
+            ++$depth;
         }
         return null;
     }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -15,6 +15,12 @@ class HTML_To_Blocks_Transform_Registry
 {
     private static ?array $transforms = null;
     /**
+     * Repeated-card children validated during transform matching.
+     *
+     * @var array<int,array<int,HTML_To_Blocks_HTML_Element>>
+     */
+    private static array $repeated_card_grid_children = array();
+    /**
      * Gets all raw transforms for core blocks
      * Sorted by priority (lower = higher priority)
      *
@@ -1764,10 +1770,10 @@ class HTML_To_Blocks_Transform_Registry
                 $inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/column', $column_attributes, $column_blocks);
             }
             return HTML_To_Blocks_Block_Factory::create_block('core/columns', self::get_common_layout_attributes($element), $inner_blocks);
-        }), array('blockName' => 'core/group', 'priority' => 12, 'isMatch' => function ($element) {
+        }), array('blockName' => 'core/group', 'priority' => 3, 'isMatch' => function ($element) {
             return self::is_repeated_card_grid_element($element);
-        }, 'transform' => function ($element, $handler) {
-            return self::create_repeated_card_grid_group($element, $handler);
+        }, 'transform' => function ($element, $handler, $args = array()) {
+            return self::create_repeated_card_grid_group($element, $handler, $args);
         }), array('blockName' => 'core/column', 'priority' => 14, 'isMatch' => function ($element) {
             return self::is_column_element($element);
         }, 'transform' => function ($element, $handler) {
@@ -2324,13 +2330,15 @@ class HTML_To_Blocks_Transform_Registry
      */
     private static function is_repeated_card_grid_element($element): bool
     {
+        $cache_key = \spl_object_id($element);
+        unset(self::$repeated_card_grid_children[$cache_key]);
         if (!\in_array($element->get_tag_name(), array('DIV', 'SECTION'), \true)) {
             return \false;
         }
         if (!self::class_matches($element, '/(?:^|[-_\s])(?:grid|cards?|network|list)(?:$|[-_\s]|\d)/i')) {
             return \false;
         }
-        $card_count = 0;
+        $cards = array();
         foreach ($element->get_child_elements() as $child) {
             if (self::is_empty_decorative_element($child)) {
                 continue;
@@ -2338,9 +2346,13 @@ class HTML_To_Blocks_Transform_Registry
             if (!self::is_card_grid_item_element($child)) {
                 return \false;
             }
-            ++$card_count;
+            $cards[] = $child;
         }
-        return $card_count >= 2;
+        if (\count($cards) < 2) {
+            return \false;
+        }
+        self::$repeated_card_grid_children[$cache_key] = $cards;
+        return \true;
     }
     /**
      * Checks whether an element is one repeated card/grid item.
@@ -2368,16 +2380,84 @@ class HTML_To_Blocks_Transform_Registry
      * @param callable                    $handler Recursive raw handler.
      * @return array Block array.
      */
-    private static function create_repeated_card_grid_group($element, callable $handler): array
+    private static function create_repeated_card_grid_group($element, callable $handler, array $args = array()): array
     {
         $inner_blocks = array();
+        $cache_key = \spl_object_id($element);
+        $children = self::$repeated_card_grid_children[$cache_key] ?? $element->get_child_elements();
+        unset(self::$repeated_card_grid_children[$cache_key]);
+        $diagnostic = self::get_commerce_product_grid_diagnostic($element, $args);
+        if (null !== $diagnostic && \function_exists('do_action')) {
+            \do_action('html_to_blocks_commerce_product_grid_detected', $diagnostic, $element, $args);
+        }
+        foreach ($children as $child) {
+            $inner_blocks[] = self::create_card_grid_item_group($child, $handler);
+        }
+        return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), $inner_blocks);
+    }
+    /**
+     * Builds a diagnostic payload for explicit commerce-context product grids.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The grid wrapper.
+     * @param array                       $args Raw handler arguments.
+     * @return array|null Diagnostic payload, or null when the commerce gate is closed.
+     */
+    private static function get_commerce_product_grid_diagnostic($element, array $args): ?array
+    {
+        if (!self::has_explicit_commerce_context($args) || !self::is_product_grid_element($element)) {
+            return null;
+        }
+        $products = array();
         foreach ($element->get_child_elements() as $child) {
             if (self::is_empty_decorative_element($child)) {
                 continue;
             }
-            $inner_blocks[] = self::create_card_grid_item_group($child, $handler);
+            $products[] = \array_filter(array('slug' => $child->get_attribute('data-product-slug') ?? '', 'name' => self::get_first_text_for_selectors($child, array('.product-card__name', '.ss-product-name', 'h1', 'h2', 'h3', 'h4')), 'price' => self::get_first_text_for_selectors($child, array('.product-card__price', '.ss-product-price')), 'category' => self::get_first_text_for_selectors($child, array('.product-card__category', '.ss-product-category')), 'badge' => self::get_first_text_for_selectors($child, array('.product-card__badge', '.ss-product-badge')), 'cta' => self::get_first_text_for_selectors($child, array('.product-card__cta', '.ss-product-cta', 'a')), 'has_image' => null !== $child->query_selector('img'), 'placeholder' => null !== $child->query_selector('.product-card__image-placeholder')), function ($value) {
+                return !\is_string($value) || '' !== $value;
+            });
         }
-        return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), $inner_blocks);
+        return array('type' => 'commerce_product_grid', 'status' => 'static_editable_placeholder', 'product_count' => \count($products), 'products' => $products, 'message' => 'Explicit commerce context detected; h2bc preserved editor-valid static product cards for downstream materialization.');
+    }
+    /**
+     * Checks whether raw-handler args explicitly opt into commerce-aware handling.
+     *
+     * @param array $args Raw handler arguments.
+     * @return bool True when explicit commerce context is present.
+     */
+    private static function has_explicit_commerce_context(array $args): bool
+    {
+        $context = $args['context'] ?? array();
+        if (!\is_array($context)) {
+            return \false;
+        }
+        return !empty($context['commerce']) || !empty($context['products']) || !empty($context['product_context']);
+    }
+    /**
+     * Checks whether a repeated card grid carries high-confidence product-grid markers.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element The grid wrapper.
+     * @return bool True when the grid is product-like.
+     */
+    private static function is_product_grid_element($element): bool
+    {
+        return self::class_matches($element, '/(?:^|[-_\s])products?(?:$|[-_\s])/i') || self::class_matches($element, '/(?:^|[-_\s])shop(?:$|[-_\s])/i') || 'product-grid' === ($element->get_attribute('data-commerce-region') ?? '');
+    }
+    /**
+     * Gets the first non-empty text from a simple selector list.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Source element.
+     * @param array                       $selectors Simple selectors to inspect.
+     * @return string Text content or empty string.
+     */
+    private static function get_first_text_for_selectors($element, array $selectors): string
+    {
+        foreach ($selectors as $selector) {
+            $match = $element->query_selector($selector);
+            if ($match && \trim($match->get_text_content()) !== '') {
+                return \trim($match->get_text_content());
+            }
+        }
+        return '';
     }
     /**
      * Creates one editable card group, preserving whole-card links as CTA buttons.
@@ -2388,13 +2468,69 @@ class HTML_To_Blocks_Transform_Registry
      */
     private static function create_card_grid_item_group($element, callable $handler): array
     {
-        $link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child($element);
-        $content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
-        $inner_blocks = $handler(array('HTML' => $content_html));
+        $children = $element->get_child_elements();
+        $link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child($element, $children);
+        $inner_blocks = self::create_card_grid_item_inner_blocks($link_element ?: $element, $link_element ? null : $children);
+        if (null === $inner_blocks) {
+            $content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
+            $inner_blocks = $handler(array('HTML' => $content_html));
+        }
         if ($link_element && $link_element->has_attribute('href')) {
             $inner_blocks[] = self::create_button_block_from_anchor(self::create_card_grid_cta_anchor($link_element));
         }
         return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), $inner_blocks);
+    }
+    /**
+     * Convert common repeated-card children without re-entering the full raw handler.
+     *
+     * This keeps repeated card grids on the WordPress HTML API path while avoiding a
+     * fresh full transform pass for every card in large static exports.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Card content element.
+     * @return array<int,array<string,mixed>>|null Blocks, or null when the shape needs the generic handler.
+     */
+    private static function create_card_grid_item_inner_blocks($element, ?array $children = null): ?array
+    {
+        $blocks = array();
+        foreach ($children ?? $element->get_child_elements() as $child) {
+            $block = self::create_card_grid_child_block($child);
+            if (null === $block) {
+                return null;
+            }
+            if (!empty($block)) {
+                $blocks[] = $block;
+            }
+        }
+        return $blocks;
+    }
+    /**
+     * Convert one common card child to a native block.
+     *
+     * @param HTML_To_Blocks_HTML_Element $child Card child element.
+     * @return array<string,mixed>|array{}|null Block, empty array for ignored decorative children, or null for fallback.
+     */
+    private static function create_card_grid_child_block($child): ?array
+    {
+        if (self::is_empty_decorative_element($child)) {
+            return array();
+        }
+        $tag = $child->get_tag_name();
+        if (\preg_match('/^H[1-6]$/', $tag)) {
+            return HTML_To_Blocks_Block_Factory::create_block('core/heading', \array_merge(self::get_block_support_attributes($child, array('anchor' => \true, 'class_name' => \true)), array('level' => (int) \substr($tag, 1), 'content' => $child->get_inner_html())));
+        }
+        if ('IMG' === $tag) {
+            return self::create_image_block_from_img($child);
+        }
+        if (\in_array($tag, array('OL', 'UL'), \true)) {
+            return self::create_list_block_from_element($child);
+        }
+        if ('P' === $tag || 'SPAN' === $tag) {
+            return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', \array_merge(self::get_block_support_attributes($child, array('anchor' => \true, 'class_name' => \true)), array('content' => $child->get_inner_html())));
+        }
+        if ('A' === $tag && self::is_button_like_anchor($child)) {
+            return HTML_To_Blocks_Block_Factory::create_block('core/buttons', array(), array(self::create_button_block_from_anchor($child)));
+        }
+        return null;
     }
     /**
      * Gets a single whole-card anchor child when it is the card's only content.
@@ -2402,9 +2538,9 @@ class HTML_To_Blocks_Transform_Registry
      * @param HTML_To_Blocks_HTML_Element $element The card item.
      * @return HTML_To_Blocks_HTML_Element|null Anchor child or null.
      */
-    private static function get_single_complex_card_anchor_child($element): ?HTML_To_Blocks_HTML_Element
+    private static function get_single_complex_card_anchor_child($element, ?array $children = null): ?HTML_To_Blocks_HTML_Element
     {
-        $children = \array_values(\array_filter($element->get_child_elements(), function ($child) {
+        $children = \array_values(\array_filter($children ?? $element->get_child_elements(), function ($child) {
             return !self::is_empty_decorative_element($child);
         }));
         if (\count($children) !== 1 || 'A' !== $children[0]->get_tag_name() || array() === $children[0]->get_child_elements()) {

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
@@ -37,11 +37,70 @@ function html_to_blocks_raw_handler($args)
             $result[] = $piece;
             continue;
         }
-        $piece = html_to_blocks_normalise_blocks($piece);
+        if (!html_to_blocks_can_skip_normalise_blocks($piece)) {
+            $piece = html_to_blocks_normalise_blocks($piece);
+        }
         $blocks = html_to_blocks_convert($piece, \array_merge($args, array('HTML' => $piece)));
         $result = \array_merge($result, $blocks);
     }
     return \array_filter($result);
+}
+/**
+ * Determine whether block normalization can be skipped for an already wrapped fragment.
+ *
+ * Normalization only needs to repair top-level phrasing content. A fragment that is
+ * already one complete block-like root can go straight to raw conversion, avoiding
+ * an extra full scan of large generated HTML pages.
+ *
+ * @param string $html HTML fragment.
+ * @return bool True when normalization can be skipped.
+ */
+function html_to_blocks_can_skip_normalise_blocks(string $html): bool
+{
+    $html = \trim($html);
+    if ('' === $html || '<' !== $html[0] || !\preg_match('/^<\s*([a-z0-9:-]+)/i', $html, $matches)) {
+        return \false;
+    }
+    $tag_name = \strtoupper($matches[1]);
+    if (\in_array($tag_name, html_to_blocks_phrasing_tag_names(), \true)) {
+        return \false;
+    }
+    return \trim((string) html_to_blocks_extract_balanced_element($html, $tag_name)) === $html;
+}
+/**
+ * Gets tag names treated as phrasing content by block normalization.
+ *
+ * @return string[] Uppercase tag names.
+ */
+function html_to_blocks_phrasing_tag_names(): array
+{
+    return array('A', 'ABBR', 'B', 'BDI', 'BDO', 'BR', 'CITE', 'CODE', 'DATA', 'DFN', 'EM', 'I', 'KBD', 'MARK', 'Q', 'RP', 'RT', 'RUBY', 'S', 'SAMP', 'SMALL', 'SPAN', 'STRONG', 'SUB', 'SUP', 'TIME', 'U', 'VAR', 'WBR');
+}
+/**
+ * Calculate elapsed wall time in milliseconds.
+ *
+ * @param float $started Started timestamp from microtime(true).
+ * @return float Elapsed milliseconds.
+ */
+function html_to_blocks_elapsed_ms(float $started): float
+{
+    return (\microtime(\true) - $started) * 1000;
+}
+/**
+ * Accumulate per-transform trace metrics.
+ *
+ * @param array  $metrics Metrics accumulator.
+ * @param string $name    Transform metric key.
+ * @param string $field   Metric field.
+ * @param float  $value   Value to add.
+ * @return void
+ */
+function html_to_blocks_record_transform_metric(array &$metrics, string $name, string $field, float $value): void
+{
+    if (!isset($metrics['transforms'][$name])) {
+        $metrics['transforms'][$name] = array('count' => 0, 'execute_ms' => 0.0);
+    }
+    $metrics['transforms'][$name][$field] = ($metrics['transforms'][$name][$field] ?? 0) + $value;
 }
 /**
  * Converts HTML directly to blocks using registered transforms
@@ -54,6 +113,13 @@ function html_to_blocks_convert($html, $args = array())
 {
     if (empty(\trim($html))) {
         return array();
+    }
+    $collect_metrics = \function_exists('has_action') && \has_action('html_to_blocks_convert_metrics');
+    $metrics = null;
+    $convert_started = 0.0;
+    if ($collect_metrics) {
+        $metrics = array('html_bytes' => \strlen($html), 'token_count' => 0, 'top_level_element_count' => 0, 'extract_ms' => 0.0, 'element_parse_ms' => 0.0, 'transform_match_ms' => 0.0, 'transform_execute_ms' => 0.0, 'content_measure_ms' => 0.0, 'total_ms' => 0.0, 'transforms' => array());
+        $convert_started = \microtime(\true);
     }
     $processor = \WP_HTML_Processor::create_fragment($html);
     if (!$processor) {
@@ -72,6 +138,9 @@ function html_to_blocks_convert($html, $args = array())
     $tag_positions = array();
     $ignored_decorative_html_length = 0;
     while ($processor->next_token()) {
+        if ($collect_metrics) {
+            ++$metrics['token_count'];
+        }
         $token_type = $processor->get_token_type();
         $depth = $processor->get_current_depth();
         if ('#text' === $token_type && $depth === $top_level_depth) {
@@ -96,7 +165,14 @@ function html_to_blocks_convert($html, $args = array())
         if ($depth !== $top_level_depth) {
             continue;
         }
+        if ($collect_metrics) {
+            ++$metrics['top_level_element_count'];
+        }
+        $phase_started = $collect_metrics ? \microtime(\true) : 0.0;
         $element_html = html_to_blocks_extract_element_at_occurrence($html, $tag_name, $tag_positions[$tag_name], $occurrence);
+        if ($collect_metrics) {
+            $metrics['extract_ms'] += html_to_blocks_elapsed_ms($phase_started);
+        }
         if (!$element_html) {
             if (\defined('WP_DEBUG') && \WP_DEBUG) {
                 // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Gated diagnostic logging for WP_DEBUG.
@@ -104,7 +180,11 @@ function html_to_blocks_convert($html, $args = array())
             }
             continue;
         }
+        $phase_started = $collect_metrics ? \microtime(\true) : 0.0;
         $element = HTML_To_Blocks_HTML_Element::from_html($element_html);
+        if ($collect_metrics) {
+            $metrics['element_parse_ms'] += html_to_blocks_elapsed_ms($phase_started);
+        }
         if (!$element) {
             $blocks[] = html_to_blocks_create_unsupported_html_fallback_block($element_html, array('reason' => 'element_parse_failed', 'tag_name' => $tag_name, 'occurrence' => $occurrence));
             continue;
@@ -117,18 +197,35 @@ function html_to_blocks_convert($html, $args = array())
             $ignored_decorative_html_length += \strlen($element_html);
             continue;
         }
+        $phase_started = $collect_metrics ? \microtime(\true) : 0.0;
         $raw_transform = html_to_blocks_find_transform($element, $transforms);
+        if ($collect_metrics) {
+            $metrics['transform_match_ms'] += html_to_blocks_elapsed_ms($phase_started);
+        }
         if (!$raw_transform) {
+            if ($collect_metrics) {
+                html_to_blocks_record_transform_metric($metrics, 'fallback:no_transform', 'count', 1);
+            }
             $blocks[] = html_to_blocks_create_unsupported_html_fallback_block($element_html, array('reason' => 'no_transform', 'tag_name' => $element->get_tag_name(), 'occurrence' => $occurrence));
         } else {
             $transform_fn = $raw_transform['transform'] ?? null;
+            $metric_name = (string) ($raw_transform['blockName'] ?? 'unknown') . ':p' . (string) ($raw_transform['priority'] ?? 'default');
+            if ($collect_metrics) {
+                html_to_blocks_record_transform_metric($metrics, $metric_name, 'count', 1);
+            }
             if ($transform_fn && \is_callable($transform_fn)) {
+                $phase_started = $collect_metrics ? \microtime(\true) : 0.0;
                 $raw_handler_fn = 'BlockFormatBridge\Vendor\html_to_blocks_raw_handler';
                 $raw_handler_callback = function ($nested_args) use ($args, $raw_handler_fn) {
                     $nested_args = \is_array($nested_args) ? $nested_args : array();
                     return \call_user_func($raw_handler_fn, \array_merge($args, $nested_args));
                 };
                 $block = \call_user_func($transform_fn, $element, $raw_handler_callback, $args);
+                if ($collect_metrics) {
+                    $elapsed = html_to_blocks_elapsed_ms($phase_started);
+                    $metrics['transform_execute_ms'] += $elapsed;
+                    html_to_blocks_record_transform_metric($metrics, $metric_name, 'execute_ms', $elapsed);
+                }
                 if ($element->has_attribute('class')) {
                     $existing_class = $block['attrs']['className'] ?? '';
                     $node_class = $element->get_attribute('class');
@@ -139,9 +236,15 @@ function html_to_blocks_convert($html, $args = array())
                 }
                 $blocks[] = $block;
             } else {
+                $phase_started = $collect_metrics ? \microtime(\true) : 0.0;
                 $block_name = $raw_transform['blockName'];
                 $attributes = HTML_To_Blocks_Attribute_Parser::get_block_attributes($block_name, $element_html);
                 $blocks[] = HTML_To_Blocks_Block_Factory::create_block($block_name, $attributes);
+                if ($collect_metrics) {
+                    $elapsed = html_to_blocks_elapsed_ms($phase_started);
+                    $metrics['transform_execute_ms'] += $elapsed;
+                    html_to_blocks_record_transform_metric($metrics, $metric_name, 'execute_ms', $elapsed);
+                }
             }
         }
     }
@@ -157,7 +260,13 @@ function html_to_blocks_convert($html, $args = array())
         $blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/paragraph', array('content' => \trim($html)));
     }
     // Check for significant content loss (input had content but output is empty/minimal)
+    $phase_started = $collect_metrics ? \microtime(\true) : 0.0;
     $output_content_length = html_to_blocks_measure_block_content_length($blocks);
+    if ($collect_metrics) {
+        $metrics['content_measure_ms'] += html_to_blocks_elapsed_ms($phase_started);
+        $metrics['total_ms'] = html_to_blocks_elapsed_ms($convert_started);
+        \do_action('html_to_blocks_convert_metrics', $metrics, $args);
+    }
     $diagnostic_html_length = \max(0, $original_html_length - $ignored_decorative_html_length);
     if ($diagnostic_html_length > 100 && $output_content_length < $diagnostic_html_length * 0.1) {
         if (\defined('WP_DEBUG') && \WP_DEBUG) {
@@ -182,6 +291,9 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder($element): bo
         return \false;
     }
     $attributes = $element->get_attributes();
+    if ('DIV' === $element->get_tag_name() && array() === $attributes) {
+        return \true;
+    }
     $class_name = isset($attributes['class']) ? (string) $attributes['class'] : '';
     $style = isset($attributes['style']) ? (string) $attributes['style'] : '';
     $role = isset($attributes['role']) ? \strtolower(\trim((string) $attributes['role'])) : '';
@@ -528,21 +640,22 @@ function html_to_blocks_extract_element_at_occurrence($html, $tag_name, $positio
 function html_to_blocks_extract_balanced_element($html, $tag_name)
 {
     $depth = 0;
-    $len = \strlen($html);
-    $i = 0;
-    $open_pattern = '/^<' . \preg_quote($tag_name, '/') . '(?:\s|>)/i';
-    $close_pattern = '/^<\/' . \preg_quote($tag_name, '/') . '\s*>/i';
-    while ($i < $len) {
-        $remaining = \substr($html, $i);
-        if (\preg_match($open_pattern, $remaining)) {
-            ++$depth;
-        } elseif (\preg_match($close_pattern, $remaining, $close_match)) {
+    $tag_pattern = '/<\/?' . \preg_quote($tag_name, '/') . '(?:\s[^>]*)?>/i';
+    $matched_count = \preg_match_all($tag_pattern, $html, $matches, \PREG_OFFSET_CAPTURE);
+    if (\false === $matched_count || 0 === $matched_count) {
+        return null;
+    }
+    foreach ($matches[0] as $match) {
+        $tag_markup = $match[0];
+        $offset = $match[1];
+        if (0 === \strpos($tag_markup, '</')) {
             --$depth;
             if (0 === $depth) {
-                return \substr($html, 0, $i + \strlen($close_match[0]));
+                return \substr($html, 0, $offset + \strlen($tag_markup));
             }
+            continue;
         }
-        ++$i;
+        ++$depth;
     }
     return null;
 }
@@ -618,7 +731,7 @@ function html_to_blocks_normalise_blocks($html)
     if (!$processor) {
         return $html;
     }
-    $phrasing_tags = array('A', 'ABBR', 'B', 'BDI', 'BDO', 'BR', 'CITE', 'CODE', 'DATA', 'DFN', 'EM', 'I', 'KBD', 'MARK', 'Q', 'RP', 'RT', 'RUBY', 'S', 'SAMP', 'SMALL', 'SPAN', 'STRONG', 'SUB', 'SUP', 'TIME', 'U', 'VAR', 'WBR');
+    $phrasing_tags = html_to_blocks_phrasing_tag_names();
     $body_depth = 2;
     $top_level_depth = $body_depth + 1;
     $output = '';

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/RawHandlerFixturesUnitTest.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/RawHandlerFixturesUnitTest.php
@@ -61,6 +61,34 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase
         }
     }
     /**
+     * Balanced element extraction should preserve nested same-tag content.
+     */
+    public function test_balanced_element_extraction_preserves_nested_same_tag_content(): void
+    {
+        $html = '<div class="outer"><div class="inner">Nested</div><p>After</p></div><div>Sibling</div>';
+        $this->assertSame('<div class="outer"><div class="inner">Nested</div><p>After</p></div>', html_to_blocks_extract_balanced_element($html, 'DIV'));
+    }
+    /**
+     * Child extraction should preserve direct children with nested same-tag content.
+     */
+    public function test_child_extraction_preserves_nested_same_tag_content(): void
+    {
+        $element = HTML_To_Blocks_HTML_Element::from_html('<section><article class="card"><div class="media"><div class="dot"></div></div><p>Card</p></article><article><p>Second</p></article></section>');
+        $children = $element ? $element->get_child_elements() : array();
+        $this->assertCount(2, $children);
+        $this->assertStringContainsString('<div class="dot"></div>', $children[0]->get_outer_html());
+        $this->assertSame('ARTICLE', $children[0]->get_tag_name());
+    }
+    /**
+     * Already wrapped block-like fragments should skip normalization.
+     */
+    public function test_single_block_root_can_skip_normalization(): void
+    {
+        $this->assertTrue(html_to_blocks_can_skip_normalise_blocks('<main><section><p>Wrapped</p></section></main>'));
+        $this->assertFalse(html_to_blocks_can_skip_normalise_blocks('<span>Inline</span>'));
+        $this->assertFalse(html_to_blocks_can_skip_normalise_blocks('<section>One</section><section>Two</section>'));
+    }
+    /**
      * Supported fixture matrix.
      *
      * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-extrachill-edge-shell-hero.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-extrachill-edge-shell-hero.php
@@ -3,9 +3,9 @@
 namespace BlockFormatBridge\Vendor;
 
 /**
- * Smoke test: trivial theme-part fragments avoid core/html blocks.
+ * Smoke test: Extra Chill edge-shell hero wrapper becomes editable blocks.
  *
- * Run: php tests/smoke-trivial-theme-part-fragments.php
+ * Run: php tests/smoke-extrachill-edge-shell-hero.php
  */
 // phpcs:disable
 if (!\defined('ABSPATH')) {
@@ -24,6 +24,13 @@ if (!\class_exists('WP_HTML_Processor', \false)) {
         \fwrite(\STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n");
         exit(1);
     }
+    $core_root = \dirname($wp_html_api_path);
+    if (\is_file($core_root . '/class-wp-token-map.php')) {
+        require_once $core_root . '/class-wp-token-map.php';
+    }
+    if (\is_file($wp_html_api_path . '/html5-named-character-references.php')) {
+        require_once $wp_html_api_path . '/html5-named-character-references.php';
+    }
     foreach (['class-wp-html-attribute-token.php', 'class-wp-html-span.php', 'class-wp-html-text-replacement.php', 'class-wp-html-decoder.php', 'class-wp-html-doctype-info.php', 'class-wp-html-unsupported-exception.php', 'class-wp-html-token.php', 'class-wp-html-tag-processor.php', 'class-wp-html-stack-event.php', 'class-wp-html-open-elements.php', 'class-wp-html-active-formatting-elements.php', 'class-wp-html-processor-state.php', 'class-wp-html-processor.php'] as $file) {
         require_once $wp_html_api_path . '/' . $file;
     }
@@ -37,7 +44,7 @@ if (!\class_exists('WP_Block_Type_Registry', \false)) {
         }
         public function is_registered($name)
         {
-            return \in_array($name, ['core/group', 'core/html', 'core/image', 'core/paragraph'], \true);
+            return \in_array($name, ['core/button', 'core/buttons', 'core/group', 'core/heading', 'core/html', 'core/paragraph'], \true);
         }
         public function get_registered($name)
         {
@@ -54,7 +61,7 @@ foreach (['esc_attr', 'esc_html', 'esc_url'] as $function_name) {
 if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
     function wp_strip_all_tags($text)
     {
-        return wp_strip_all_tags($text);
+        return \strip_tags((string) $text);
     }
 }
 if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
@@ -63,13 +70,13 @@ if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
         return '(?!)';
     }
 }
-$fallback_events = [];
+$unsupported_fallback_events = [];
 if (!\function_exists('do_action')) {
     function do_action($hook_name, ...$args)
     {
-        global $fallback_events;
+        global $unsupported_fallback_events;
         if ('html_to_blocks_unsupported_html_fallback' === $hook_name) {
-            $fallback_events[] = $args;
+            $unsupported_fallback_events[] = $args;
         }
     }
 }
@@ -79,17 +86,15 @@ if (!\function_exists('BlockFormatBridge\Vendor\serialize_blocks')) {
         $output = '';
         foreach ($blocks as $block) {
             $name = $block['blockName'] ?? '';
-            $attrs = \array_diff_key($block['attrs'] ?? [], ['content' => \true]);
+            $attrs = \array_diff_key($block['attrs'] ?? [], ['content' => \true, 'text' => \true]);
             $attrs_json = empty($attrs) ? '' : ' ' . \json_encode($attrs, \JSON_UNESCAPED_SLASHES);
             if ('core/html' === $name) {
                 $output .= '<!-- wp:html -->' . ($block['attrs']['content'] ?? $block['innerHTML'] ?? '') . '<!-- /wp:html -->';
                 continue;
             }
             $output .= '<!-- wp:' . \substr($name, 5) . $attrs_json . ' -->';
-            $output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+            $output .= $block['innerHTML'] ?? '';
             $output .= serialize_blocks($block['innerBlocks'] ?? []);
-            $inner_content = $block['innerContent'] ?? [];
-            $output .= \end($inner_content) ? \end($inner_content) : '';
             $output .= '<!-- /wp:' . \substr($name, 5) . ' -->';
         }
         return $output;
@@ -109,45 +114,42 @@ $assert = static function ($condition, $label, $detail = '') use (&$failures, &$
         $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
     }
 };
-$flatten_blocks = static function (array $blocks) use (&$flatten_blocks): array {
-    $flat = [];
+$flatten_block_names = static function (array $blocks) use (&$flatten_block_names): array {
+    $names = [];
     foreach ($blocks as $block) {
-        $flat[] = $block;
-        $flat = \array_merge($flat, $flatten_blocks($block['innerBlocks'] ?? []));
+        $names[] = $block['blockName'] ?? '';
+        $names = \array_merge($names, $flatten_block_names($block['innerBlocks'] ?? []));
     }
-    return $flat;
+    return $names;
 };
-$html = <<<'HTML'
-<div class="hero-grid"></div>
-<div class="hero-glow"></div>
-<div></div>
-<br>
-<span class="dot dot-r"></span>
-<span class="dot dot-y"></span>
-<span class="dot dot-g"></span>
-<img src="http://example.test/wp-content/themes/studio-code-launch/assets/icons/theme-part-footer-1-4532f13fa9ef8514.svg" alt="" decoding="async">
-<div class="nav-logo-mark"><img src="http://localhost:9159/wp-content/themes/studio-code/assets/icons/theme-part-header-1-b57d7c946b676f82.svg" alt="" decoding="async"></div>
-<span class="footer-brand-icon"><img src="/assets/logo.png" alt="Footer logo"></span>
+$edge_shell_hero = <<<'HTML'
+<div class="full-width-breakout ec-edge-shell">
+  <section id="hero-section">
+    <h2>Join the Online Music Scene</h2>
+    <h3>A melting pot for independent music</h3>
+    <div class="hero-buttons-container">
+      <a class="home-hero-button" href="https://extrachill.com/register/">Create your profile</a>
+      <a class="home-hero-button secondary" href="https://extrachill.com/network/">Explore the network</a>
+    </div>
+  </section>
+</div>
 HTML;
-$blocks = html_to_blocks_raw_handler(['HTML' => $html]);
-$flat = $flatten_blocks($blocks);
-$names = \array_map(static function ($block) {
-    return $block['blockName'] ?? '';
-}, $flat);
+$blocks = html_to_blocks_raw_handler(['HTML' => $edge_shell_hero]);
 $serialized = serialize_blocks($blocks);
-$assert(!\in_array('core/html', $names, \true), 'trivial-fragments-do-not-use-core-html', \implode(', ', $names));
-$assert(\count($fallback_events) === 0, 'trivial-fragments-emit-no-fallback-events', (string) \count($fallback_events));
-$assert(\in_array('core/group', $names, \true), 'hero-grid-converts-to-native-group', \implode(', ', $names));
-$assert(\in_array('core/image', $names, \true), 'footer-svg-img-converts-to-core-image', \implode(', ', $names));
-$assert(!\str_contains($serialized, '<!-- wp:html -->'), 'serialized-output-has-no-wp-html', $serialized);
-$assert(!\str_contains($serialized, '<div></div>'), 'empty-structural-div-is-dropped', $serialized);
-$assert(!\str_contains($serialized, '<!-- wp:html --><br>'), 'standalone-br-does-not-serialize-as-html', $serialized);
-$assert(\str_contains($serialized, 'theme-part-footer-1-4532f13fa9ef8514.svg'), 'footer-image-url-survives', $serialized);
-$assert(\str_contains($serialized, 'nav-logo-mark'), 'svg-wrapper-class-survives', $serialized);
-$assert(\str_contains($serialized, 'theme-part-header-1-b57d7c946b676f82.svg'), 'wrapped-svg-url-survives', $serialized);
-$assert(\str_contains($serialized, 'footer-brand-icon'), 'normal-image-wrapper-class-survives', $serialized);
-$assert(\str_contains($serialized, '/assets/logo.png'), 'wrapped-normal-image-url-survives', $serialized);
-$assert(\str_contains($serialized, 'Footer logo'), 'wrapped-normal-image-alt-survives', $serialized);
+$names = $flatten_block_names($blocks);
+$assert(\count($blocks) === 1, 'edge-shell-single-wrapper');
+$assert(($blocks[0]['blockName'] ?? '') === 'core/group', 'edge-shell-wrapper-is-group');
+$assert(!\in_array('core/html', $names, \true), 'edge-shell-does-not-fallback-to-core-html', 'Blocks: ' . \implode(', ', $names));
+$assert(\count($unsupported_fallback_events) === 0, 'edge-shell-emits-no-unsupported-fallback-events', (string) \count($unsupported_fallback_events));
+$assert(\in_array('core/heading', $names, \true), 'edge-shell-creates-heading-blocks');
+$assert(\in_array('core/buttons', $names, \true), 'edge-shell-creates-buttons-block');
+$assert(\strpos($serialized, 'full-width-breakout ec-edge-shell') !== \false, 'edge-shell-preserves-wrapper-classes', $serialized);
+$assert(\strpos($serialized, 'hero-section') !== \false, 'edge-shell-preserves-section-anchor', $serialized);
+$assert(\strpos($serialized, 'hero-buttons-container') !== \false, 'edge-shell-preserves-button-wrapper-class', $serialized);
+$assert(\strpos($serialized, 'Join the Online Music Scene') !== \false, 'edge-shell-preserves-heading');
+$assert(\strpos($serialized, 'A melting pot for independent music') !== \false, 'edge-shell-preserves-subheading');
+$assert(\strpos($serialized, 'https://extrachill.com/register/') !== \false, 'edge-shell-preserves-primary-button-url');
+$assert(\strpos($serialized, 'https://extrachill.com/network/') !== \false, 'edge-shell-preserves-secondary-button-url');
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-form-fallback-scope.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-form-fallback-scope.php
@@ -54,7 +54,7 @@ foreach (['esc_attr', 'esc_html', 'esc_url'] as $function_name) {
 if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
     function wp_strip_all_tags($text)
     {
-        return wp_strip_all_tags($text);
+        return \strip_tags((string) $text);
     }
 }
 if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
@@ -164,6 +164,26 @@ $assert(\str_contains($wrapped_form_serialized, 'Browse archive'), 'generic-form
 $assert(\str_contains($wrapped_form_serialized, '<!-- wp:html --><form class="search-form"'), 'generic-form-is-local-core-html-island', $wrapped_form_serialized);
 $assert(\count($fallback_events) === 1, 'generic-form-wrapper-emits-one-local-form-fallback', (string) \count($fallback_events));
 $assert(($fallback_events[0][1]['tag_name'] ?? '') === 'FORM', 'generic-form-fallback-context-is-form', \print_r($fallback_events, \true));
+$extrachill_network_search = <<<'HTML'
+<div class="home-network-search">
+  <h2 class="home-network-search-header">Search the Network</h2>
+  <p class="home-network-search-description">Find artists, events, discussions, and more across Extra Chill.</p>
+  <form action="https://extrachill.com/" class="search-form searchform" method="get">
+    <label for="home-network-search-input">Search for:</label>
+    <input id="home-network-search-input" name="s" type="search" value="" />
+    <button type="submit">Search</button>
+  </form>
+</div>
+HTML;
+$fallback_events = [];
+$network_search_serialized = serialize_blocks(html_to_blocks_raw_handler(['HTML' => $extrachill_network_search]));
+$assert(!\str_contains($network_search_serialized, '<!-- wp:html --><div class="home-network-search"'), 'extrachill-network-search-wrapper-is-not-core-html', $network_search_serialized);
+$assert(\str_contains($network_search_serialized, '<div class="wp-block-group home-network-search">'), 'extrachill-network-search-wrapper-becomes-group', $network_search_serialized);
+$assert(\str_contains($network_search_serialized, 'Search the Network'), 'extrachill-network-search-heading-remains-editable', $network_search_serialized);
+$assert(\str_contains($network_search_serialized, 'Find artists, events, discussions, and more across Extra Chill.'), 'extrachill-network-search-description-remains-editable', $network_search_serialized);
+$assert(\str_contains($network_search_serialized, '<!-- wp:html --><form action="https://extrachill.com/" class="search-form searchform" method="get">'), 'extrachill-network-search-form-is-local-core-html-island', $network_search_serialized);
+$assert(\count($fallback_events) === 1, 'extrachill-network-search-emits-one-local-form-fallback', (string) \count($fallback_events));
+$assert(($fallback_events[0][1]['tag_name'] ?? '') === 'FORM', 'extrachill-network-search-fallback-context-is-form', \print_r($fallback_events, \true));
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-product-grid-context-gate.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-product-grid-context-gate.php
@@ -61,7 +61,7 @@ foreach (['esc_attr', 'esc_html', 'esc_url'] as $function_name) {
 if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
     function wp_strip_all_tags($text)
     {
-        return wp_strip_all_tags($text);
+        return \strip_tags((string) $text);
     }
 }
 if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
@@ -71,12 +71,16 @@ if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
     }
 }
 $unsupported_fallback_events = [];
+$commerce_product_grid_events = [];
 if (!\function_exists('do_action')) {
     function do_action($hook_name, ...$args)
     {
-        global $unsupported_fallback_events;
+        global $unsupported_fallback_events, $commerce_product_grid_events;
         if ('html_to_blocks_unsupported_html_fallback' === $hook_name) {
             $unsupported_fallback_events[] = $args;
+        }
+        if ('html_to_blocks_commerce_product_grid_detected' === $hook_name) {
+            $commerce_product_grid_events[] = $args;
         }
     }
 }
@@ -144,11 +148,19 @@ $product_grid_html = <<<'HTML'
       <span class="product-card__price">$9 per roll</span>
       <a class="product-card__cta" href="/shop/sea-salt-butter/">View butter</a>
     </article>
+    <article class="product-card product-card--seasonal" data-product-slug="strawberry-jam">
+      <div class="product-card__image-placeholder" aria-label="Strawberry jam jar placeholder"><span>Seasonal</span></div>
+      <span class="product-card__category">Pantry</span>
+      <span class="product-card__badge">Limited</span>
+      <h3 class="product-card__name">Strawberry Jam</h3>
+      <p class="product-card__description">Peak-season berries simmered with lemon and cane sugar for bright spoonable fruit.</p>
+      <span class="product-card__price">$11 per jar</span>
+      <a class="product-card__cta" href="/shop/strawberry-jam/">View jam</a>
+    </article>
   </div>
 </section>
 HTML;
-// Future context-enabled expectations, after issue #228 threads conversion context.
-// First primitive should stay editor-valid and materializable without creating Woo products.
+// First context-enabled primitive stays editor-valid and materializable without creating Woo products.
 $expected_context_enabled_shape = ['gate' => 'explicit commerce/product context only', 'block_names' => ['core/group', 'core/heading', 'core/group', 'core/group', 'core/image', 'core/paragraph', 'core/paragraph', 'core/heading', 'core/paragraph', 'core/paragraph', 'core/buttons', 'core/button'], 'notes' => 'Preserve static editable placeholders until SSI or another importer materializes product state.'];
 $blocks = html_to_blocks_raw_handler(['HTML' => $product_grid_html]);
 $serialized = serialize_blocks($blocks);
@@ -161,16 +173,35 @@ $assert(!\in_array('core/html', $names, \true), 'product-grid-does-not-fallback-
 $assert(\count($unsupported_fallback_events) === 0, 'product-grid-emits-no-unsupported-fallback-events', (string) \count($unsupported_fallback_events));
 $assert(!\preg_match('/(?:^|, )woocommerce\//', $name_list), 'product-grid-does-not-create-commerce-blocks', $name_list);
 $assert(\strpos($serialized, '<!-- wp:woocommerce/') === \false, 'product-grid-serialization-has-no-woocommerce-blocks', $serialized);
-foreach (['product-grid', 'product-card', 'product-card__category', 'product-card__badge', 'product-card__price', 'product-card__cta'] as $class_name) {
+$assert(\count($commerce_product_grid_events) === 0, 'no-context-emits-no-commerce-diagnostic', (string) \count($commerce_product_grid_events));
+foreach (['product-grid', 'product-card', 'product-card__category', 'product-card__badge', 'product-card__price', 'product-card__cta', 'product-card__image-placeholder'] as $class_name) {
     $assert(\strpos($serialized, $class_name) !== \false, 'product-grid-preserves-' . $class_name, $serialized);
 }
-foreach (['Country Sourdough', '$14 per loaf', 'Bread', 'Best Seller', '/shop/country-sourdough/', 'Sea Salt Cultured Butter', '$9 per roll', 'Dairy', 'New Batch', '/shop/sea-salt-butter/'] as $snippet) {
+foreach (['Country Sourdough', '$14 per loaf', 'Bread', 'Best Seller', '/shop/country-sourdough/', 'Sea Salt Cultured Butter', '$9 per roll', 'Dairy', 'New Batch', '/shop/sea-salt-butter/', 'Strawberry Jam', '$11 per jar', 'Pantry', 'Limited', '/shop/strawberry-jam/'] as $snippet) {
     $assert(\strpos($serialized, $snippet) !== \false, 'product-grid-preserves-' . \preg_replace('/[^a-z0-9]+/i', '-', \strtolower($snippet)), $serialized);
 }
-$assert(\substr_count($serialized, 'product-card__image') === 2, 'product-grid-preserves-two-images', $serialized);
-$assert(\substr_count($serialized, '<h3 class="wp-block-heading product-card__name">') === 2, 'product-grid-preserves-two-product-name-headings', $serialized);
-$assert(\substr_count($serialized, 'product-card__price') === 2, 'product-grid-preserves-two-prices', $serialized);
-$assert(\substr_count($serialized, 'product-card__cta') === 2, 'product-grid-preserves-two-ctas', $serialized);
+$assert(\substr_count($serialized, '<!-- wp:image') === 2, 'product-grid-preserves-two-images', $serialized);
+$assert(\substr_count($serialized, 'product-card__image-placeholder') >= 1, 'product-grid-preserves-one-placeholder', $serialized);
+$assert(\substr_count($serialized, '<h3 class="wp-block-heading product-card__name">') === 3, 'product-grid-preserves-three-product-name-headings', $serialized);
+$assert(\substr_count($serialized, 'product-card__price') === 3, 'product-grid-preserves-three-prices', $serialized);
+$assert(\substr_count($serialized, 'product-card__cta') === 3, 'product-grid-preserves-three-ctas', $serialized);
+$commerce_product_grid_events = [];
+$context_blocks = html_to_blocks_raw_handler(['HTML' => $product_grid_html, 'context' => ['commerce' => ['source' => 'static-site-importer']]]);
+$context_serialized = serialize_blocks($context_blocks);
+$context_names = $flatten_block_names($context_blocks);
+$context_name_list = \implode(', ', $context_names);
+$commerce_diagnostic = $commerce_product_grid_events[0][0] ?? [];
+$assert(\count($commerce_product_grid_events) === 1, 'context-emits-one-commerce-diagnostic', (string) \count($commerce_product_grid_events));
+$assert(($commerce_diagnostic['type'] ?? '') === 'commerce_product_grid', 'context-diagnostic-type', \json_encode($commerce_diagnostic));
+$assert(($commerce_diagnostic['status'] ?? '') === 'static_editable_placeholder', 'context-diagnostic-status', \json_encode($commerce_diagnostic));
+$assert(($commerce_diagnostic['product_count'] ?? 0) === 3, 'context-diagnostic-product-count', \json_encode($commerce_diagnostic));
+$assert(($commerce_diagnostic['products'][0]['slug'] ?? '') === 'country-sourdough', 'context-diagnostic-first-product-slug', \json_encode($commerce_diagnostic));
+$assert(($commerce_diagnostic['products'][1]['name'] ?? '') === 'Sea Salt Cultured Butter', 'context-diagnostic-second-product-name', \json_encode($commerce_diagnostic));
+$assert(($commerce_diagnostic['products'][2]['placeholder'] ?? \false) === \true, 'context-diagnostic-third-product-placeholder', \json_encode($commerce_diagnostic));
+$assert(!\in_array('core/html', $context_names, \true), 'context-product-grid-does-not-fallback-to-core-html', $context_name_list);
+$assert(!\preg_match('/(?:^|, )woocommerce\//', $context_name_list), 'context-product-grid-does-not-create-commerce-blocks', $context_name_list);
+$assert(\strpos($context_serialized, '<!-- wp:woocommerce/') === \false, 'context-product-grid-serialization-has-no-woocommerce-blocks', $context_serialized);
+$assert(\strpos($context_serialized, 'Strawberry Jam') !== \false, 'context-product-grid-remains-editor-valid-static-output', $context_serialized);
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
@@ -61,7 +61,7 @@ foreach (['esc_attr', 'esc_html', 'esc_url'] as $function_name) {
 if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
     function wp_strip_all_tags($text)
     {
-        return wp_strip_all_tags($text);
+        return \strip_tags((string) $text);
     }
 }
 if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
@@ -211,6 +211,37 @@ $assert(\strpos($wrapped_serialized, 'article-grid') !== \false, 'generic-wrappe
 $assert(\strpos($wrapped_serialized, 'First story') !== \false && \strpos($wrapped_serialized, 'Second story') !== \false, 'generic-wrapper-preserves-card-content', $wrapped_serialized);
 $assert(!\in_array('core/html', $wrapped_names, \true), 'generic-wrapper-does-not-fallback-to-core-html', 'Blocks: ' . \implode(', ', $wrapped_names));
 $assert(\count($unsupported_fallback_events) === 0, 'generic-wrapper-emits-no-unsupported-fallback-events', (string) \count($unsupported_fallback_events));
+$extrachill_shell_grid = <<<'HTML'
+<div class="full-width-breakout ec-edge-shell">
+  <div class="home-3x3-grid">
+    <!-- Interviews Column -->
+    <div class="home-3x3-col">
+      <a class="home-3x3-card" href="https://extrachill.com/interviews/artist-profile">
+        <h3 class="home-3x3-title">Inside the Lowcountry Scene</h3>
+        <p class="home-3x3-excerpt">Interviews with independent artists building something real.</p>
+      </a>
+    </div>
+    <div class="home-3x3-col">
+      <a class="home-3x3-card" href="https://extrachill.com/events/weekend-guide">
+        <h3 class="home-3x3-title">Weekend Guide</h3>
+        <p class="home-3x3-excerpt">Shows worth leaving the house for.</p>
+      </a>
+    </div>
+  </div>
+</div>
+HTML;
+$unsupported_fallback_events = [];
+$shell_grid_blocks = html_to_blocks_raw_handler(['HTML' => $extrachill_shell_grid]);
+$shell_grid_serialized = serialize_blocks($shell_grid_blocks);
+$shell_grid_names = $flatten_block_names($shell_grid_blocks);
+$assert(\count($shell_grid_blocks) === 1, 'extrachill-shell-grid-single-wrapper');
+$assert(($shell_grid_blocks[0]['blockName'] ?? '') === 'core/group', 'extrachill-shell-grid-wrapper-is-group');
+$assert(\strpos($shell_grid_serialized, 'full-width-breakout ec-edge-shell') !== \false, 'extrachill-shell-grid-preserves-shell-classes', $shell_grid_serialized);
+$assert(\strpos($shell_grid_serialized, 'home-3x3-grid') !== \false, 'extrachill-shell-grid-preserves-grid-class', $shell_grid_serialized);
+$assert(\strpos($shell_grid_serialized, 'Inside the Lowcountry Scene') !== \false, 'extrachill-shell-grid-preserves-first-card', $shell_grid_serialized);
+$assert(\strpos($shell_grid_serialized, 'Weekend Guide') !== \false, 'extrachill-shell-grid-preserves-second-card', $shell_grid_serialized);
+$assert(!\in_array('core/html', $shell_grid_names, \true), 'extrachill-shell-grid-does-not-fallback-to-core-html', 'Blocks: ' . \implode(', ', $shell_grid_names));
+$assert(\count($unsupported_fallback_events) === 0, 'extrachill-shell-grid-emits-no-unsupported-fallback-events', (string) \count($unsupported_fallback_events));
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-resized-svg-image-serialization.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-resized-svg-image-serialization.php
@@ -105,7 +105,8 @@ $assert(($svg['attrs']['width'] ?? '') === '14', 'svg-source-width-becomes-block
 $assert(($svg['attrs']['height'] ?? '') === '14', 'svg-source-height-becomes-block-attribute', \var_export($svg['attrs'] ?? [], \true));
 $assert(\str_contains($serialized_svg, '<figure class="wp-block-image is-resized">'), 'svg-figure-has-is-resized-class', $serialized_svg);
 $assert(\str_contains($serialized_svg, 'alt=""'), 'svg-image-serializes-empty-alt', $serialized_svg);
-$assert(\str_contains($serialized_svg, 'style="width:14;height:14"'), 'svg-image-serializes-resized-style', $serialized_svg);
+$assert(\str_contains($serialized_svg, 'style="width:14px;height:14px"'), 'svg-image-serializes-valid-resized-style', $serialized_svg);
+$assert(!\str_contains($serialized_svg, 'style="width:14;height:14"'), 'svg-image-does-not-serialize-unitless-resized-style', $serialized_svg);
 $assert(!\str_contains($serialized_svg, 'width="14"'), 'svg-image-omits-raw-width-attribute', $serialized_svg);
 $assert(!\str_contains($serialized_svg, 'height="14"'), 'svg-image-omits-raw-height-attribute', $serialized_svg);
 $assert(\str_contains($serialized_bitmap, 'width="900"'), 'bitmap-image-keeps-width-attribute', $serialized_bitmap);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/traces/large-html-raw-handler.trace.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/traces/large-html-raw-handler.trace.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Homeboy trace: large repeated-card raw-handler conversion.
+ *
+ * @package HTMLToBlocksConverter
+ */
+if (!\defined('ABSPATH')) {
+    \define('ABSPATH', __DIR__);
+}
+if (!\class_exists('WP_HTML_Processor', \false)) {
+    $wp_html_api_candidates = \array_filter(array(\getenv('WP_HTML_API_PATH') ? \getenv('WP_HTML_API_PATH') : '', '/wordpress/wp-includes/html-api', '/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api'));
+    $wp_html_api_path = '';
+    foreach ($wp_html_api_candidates as $candidate) {
+        if (\is_file(\rtrim($candidate, '/') . '/class-wp-html-processor.php')) {
+            $wp_html_api_path = \rtrim($candidate, '/');
+            break;
+        }
+    }
+    if ('' === $wp_html_api_path) {
+        \fwrite(\STDERR, "WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n");
+        exit(1);
+    }
+    $core_root = \dirname($wp_html_api_path);
+    if (\is_file($core_root . '/class-wp-token-map.php')) {
+        require_once $core_root . '/class-wp-token-map.php';
+    }
+    if (\is_file($wp_html_api_path . '/html5-named-character-references.php')) {
+        require_once $wp_html_api_path . '/html5-named-character-references.php';
+    }
+    foreach (array('class-wp-html-attribute-token.php', 'class-wp-html-span.php', 'class-wp-html-text-replacement.php', 'class-wp-html-decoder.php', 'class-wp-html-doctype-info.php', 'class-wp-html-unsupported-exception.php', 'class-wp-html-token.php', 'class-wp-html-tag-processor.php', 'class-wp-html-stack-event.php', 'class-wp-html-open-elements.php', 'class-wp-html-active-formatting-elements.php', 'class-wp-html-processor-state.php', 'class-wp-html-processor.php') as $file) {
+        require_once $wp_html_api_path . '/' . $file;
+    }
+}
+if (!\class_exists('WP_Block_Type_Registry', \false)) {
+    class WP_Block_Type_Registry
+    {
+        public static function get_instance()
+        {
+            return new self();
+        }
+        public function is_registered($name)
+        {
+            return \in_array($name, array('core/button', 'core/buttons', 'core/group', 'core/heading', 'core/html', 'core/image', 'core/paragraph'), \true);
+        }
+        public function get_registered($name)
+        {
+            return (object) array('attributes' => array());
+        }
+    }
+    \class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
+}
+foreach (array('esc_attr', 'esc_html', 'esc_url') as $function_name) {
+    if (!\function_exists($function_name)) {
+        eval('function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
+    function wp_strip_all_tags($text)
+    {
+        return \strip_tags((string) $text);
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\get_shortcode_regex')) {
+    function get_shortcode_regex()
+    {
+        return '(?!)';
+    }
+}
+$metrics_events = array();
+if (!\function_exists('do_action')) {
+    function do_action($hook_name, ...$args)
+    {
+        global $metrics_events;
+        if ('html_to_blocks_convert_metrics' === $hook_name) {
+            $metrics_events[] = $args[0] ?? array();
+        }
+    }
+}
+if (!\function_exists('has_action')) {
+    function has_action($hook_name)
+    {
+        return 'html_to_blocks_convert_metrics' === $hook_name;
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\serialize_blocks')) {
+    function serialize_blocks(array $blocks): string
+    {
+        $output = '';
+        foreach ($blocks as $block) {
+            $name = $block['blockName'] ?? '';
+            $attrs = \array_diff_key($block['attrs'] ?? array(), array('content' => \true, 'text' => \true));
+            $attrs_json = empty($attrs) ? '' : ' ' . \json_encode($attrs, \JSON_UNESCAPED_SLASHES);
+            $output .= '<!-- wp:' . \substr($name, 5) . $attrs_json . ' -->';
+            $output .= $block['innerHTML'] ?? '';
+            $output .= serialize_blocks($block['innerBlocks'] ?? array());
+            $output .= '<!-- /wp:' . \substr($name, 5) . ' -->';
+        }
+        return $output;
+    }
+}
+$repo_root = \getenv('HOMEBOY_TRACE_COMPONENT_PATH') ?: \dirname(__DIR__, 2);
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+$results_file = \getenv('HOMEBOY_TRACE_RESULTS_FILE');
+if (!\is_string($results_file) || '' === $results_file) {
+    \fwrite(\STDERR, "HOMEBOY_TRACE_RESULTS_FILE is required\n");
+    exit(2);
+}
+$target_bytes = (int) (\getenv('H2BC_TRACE_TARGET_BYTES') ?: 131072);
+$html = html_to_blocks_trace_large_repeated_cards($target_bytes);
+$started = \microtime(\true);
+$blocks = html_to_blocks_raw_handler(array('HTML' => $html));
+$total_ms = (\microtime(\true) - $started) * 1000;
+$main_metrics = array();
+$aggregate_transforms = array();
+foreach ($metrics_events as $event) {
+    foreach ((array) ($event['transforms'] ?? array()) as $name => $stats) {
+        if (!isset($aggregate_transforms[$name])) {
+            $aggregate_transforms[$name] = array('count' => 0, 'execute_ms' => 0.0);
+        }
+        $aggregate_transforms[$name]['count'] += (int) ($stats['count'] ?? 0);
+        $aggregate_transforms[$name]['execute_ms'] += (float) ($stats['execute_ms'] ?? 0);
+    }
+    if (!isset($event['html_bytes']) || (int) $event['html_bytes'] < 100000) {
+        continue;
+    }
+    $main_metrics = $event;
+    break;
+}
+if (empty($main_metrics)) {
+    $main_metrics = array('total_ms' => $total_ms);
+}
+\uasort($aggregate_transforms, static function (array $left, array $right): int {
+    return $right['execute_ms'] <=> $left['execute_ms'];
+});
+$top_transform_name = (string) \array_key_first($aggregate_transforms);
+$top_transform_stats = $top_transform_name ? $aggregate_transforms[$top_transform_name] : array('count' => 0, 'execute_ms' => 0.0);
+$timeline = array(array('t_ms' => 0, 'source' => 'trace', 'event' => 'start', 'data' => array('html_bytes' => \strlen($html))));
+$spans = array();
+$cursor = 0;
+foreach (array('extract_ms', 'element_parse_ms', 'transform_match_ms', 'transform_execute_ms', 'content_measure_ms') as $metric) {
+    $duration = isset($main_metrics[$metric]) && \is_numeric($main_metrics[$metric]) ? (float) $main_metrics[$metric] : 0.0;
+    $phase = \preg_replace('/_ms$/', '', $metric);
+    $timeline[] = array('t_ms' => (int) \round($cursor), 'source' => 'h2bc', 'event' => $phase . '_start', 'data' => array('phase' => $phase));
+    $cursor += $duration;
+    $timeline[] = array('t_ms' => (int) \round($cursor), 'source' => 'h2bc', 'event' => $phase . '_end', 'data' => array('phase' => $phase, 'duration_ms' => $duration));
+    $spans[] = array('id' => $phase, 'from' => 'h2bc.' . $phase . '_start', 'to' => 'h2bc.' . $phase . '_end');
+}
+$timeline[] = array('t_ms' => (int) \round($total_ms), 'source' => 'trace', 'event' => 'end', 'data' => array('blocks' => \count($blocks), 'total_ms' => $total_ms, 'html_bytes' => \strlen($html), 'top_transform' => $top_transform_name, 'top_transforms' => \array_slice($aggregate_transforms, 0, 8, \true), 'metrics' => $main_metrics));
+\file_put_contents($results_file, \json_encode(array('component_id' => 'html-to-blocks-converter', 'scenario_id' => \getenv('HOMEBOY_TRACE_SCENARIO') ?: 'large-html-raw-handler', 'status' => 'pass', 'summary' => \sprintf('%d KB raw handler: %.1f ms total; transform execution %.1f ms; matching %.1f ms; top transform %s %.1f ms (%d calls)', (int) \round($target_bytes / 1024), $total_ms, (float) ($main_metrics['transform_execute_ms'] ?? 0), (float) ($main_metrics['transform_match_ms'] ?? 0), $top_transform_name, (float) ($top_transform_stats['execute_ms'] ?? 0), (int) ($top_transform_stats['count'] ?? 0)), 'timeline' => $timeline, 'span_definitions' => $spans, 'assertions' => array(), 'artifacts' => array()), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES) . "\n");
+function html_to_blocks_trace_large_repeated_cards(int $target_bytes): string
+{
+    $head = '<main><section class="bench-grid">';
+    $tail = '</section></main>';
+    $html = $head;
+    $i = 0;
+    while (\strlen($html) + \strlen($tail) < $target_bytes) {
+        $i++;
+        $html .= \sprintf('<article class="bench-card"><h2>Benchmark Card %1$d</h2><p>This static section exercises repeated card conversion through WordPress HTML APIs.</p><ul><li>Feature %1$d</li><li>Detail %1$d</li><li>Outcome %1$d</li></ul><p><a class="button" href="#card-%1$d">Read more</a></p></article>', $i);
+    }
+    return $html . $tail;
+}


### PR DESCRIPTION
## Summary
- Refresh bundled html-to-blocks-converter to current `main` so BFB includes the empty structural div and SVG image dimension fixes.
- Regenerate the scoped vendor bundle.

## Tests
- `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@refresh-h2bc-large-html`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed the vendored H2BC bundle and ran validation under Chris's direction.