### PR TITLE
chore: refresh bundled h2bc

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "ce2d10d007ef4b19259b0e837789b04536d27698"
+                "reference": "992cb4755a280c40ef15c805a8f08b102a19909c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/ce2d10d007ef4b19259b0e837789b04536d27698",
-                "reference": "ce2d10d007ef4b19259b0e837789b04536d27698",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/992cb4755a280c40ef15c805a8f08b102a19909c",
+                "reference": "992cb4755a280c40ef15c805a8f08b102a19909c",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-05-05T14:18:45+00:00"
+            "time": "2026-05-05T16:41:37+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -931,7 +931,61 @@ class HTML_To_Blocks_Transform_Registry
         if ($element->has_attribute('class')) {
             $attributes['className'] = $element->get_attribute('class');
         }
+        $layout = self::extract_buttons_layout_attributes($element);
+        if (!empty($layout)) {
+            $attributes['layout'] = $layout;
+        }
         return self::create_buttons_block_from_anchors(self::get_direct_anchor_children_from_html($element->get_inner_html()), $attributes);
+    }
+    /**
+     * Extracts core/buttons layout attributes from a source container.
+     *
+     * Maps inline horizontal alignment to Gutenberg-compatible flex layout
+     * attributes so the buttons block round-trips through Gutenberg with the
+     * source horizontal alignment intact. core/buttons defaults to a flex
+     * layout, so the layout type is fixed to flex whenever any horizontal
+     * alignment intent is detected.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Container element.
+     * @return array Layout attribute map (possibly empty).
+     */
+    private static function extract_buttons_layout_attributes($element): array
+    {
+        $style = $element->has_attribute('style') ? $element->get_attribute('style') : '';
+        $classes = $element->has_attribute('class') ? $element->get_attribute('class') : '';
+        $justify = '';
+        if ('' !== $style) {
+            $justify = \strtolower(\trim(self::extract_css_property($style, 'justify-content')));
+        }
+        // Map common CSS justify-content values to Gutenberg's supported values.
+        $mapped_justify = '';
+        switch ($justify) {
+            case 'center':
+                $mapped_justify = 'center';
+                break;
+            case 'flex-start':
+            case 'start':
+            case 'left':
+                $mapped_justify = 'left';
+                break;
+            case 'flex-end':
+            case 'end':
+            case 'right':
+                $mapped_justify = 'right';
+                break;
+            case 'space-between':
+                $mapped_justify = 'space-between';
+                break;
+        }
+        if ('' === $mapped_justify && '' !== $classes) {
+            if (\preg_match('/(?:^|\s)is-content-justification-(left|right|center|space-between)(?:\s|$)/i', $classes, $matches)) {
+                $mapped_justify = \strtolower($matches[1]);
+            }
+        }
+        if ('' === $mapped_justify) {
+            return array();
+        }
+        return array('type' => 'flex', 'justifyContent' => $mapped_justify);
     }
     /**
      * Creates a buttons wrapper with button children from anchors.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-buttons-justify-content.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-buttons-justify-content.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace BlockFormatBridge\Vendor;
+
+/**
+ * Smoke test: core/buttons preserves source horizontal alignment.
+ *
+ * Run: php tests/smoke-buttons-justify-content.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ *
+ * Regression coverage for
+ * https://github.com/chubes4/html-to-blocks-converter/issues/247 — when a
+ * button row carries inline `justify-content` the wrapper must round-trip
+ * through Gutenberg's flex layout attributes instead of dropping the value.
+ */
+// phpcs:disable
+\define('ABSPATH', __DIR__);
+if (!\function_exists('BlockFormatBridge\Vendor\esc_attr')) {
+    function esc_attr($value)
+    {
+        return \htmlspecialchars((string) $value, \ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\esc_url')) {
+    function esc_url($value)
+    {
+        return \htmlspecialchars((string) $value, \ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!\function_exists('BlockFormatBridge\Vendor\wp_strip_all_tags')) {
+    function wp_strip_all_tags($value)
+    {
+        return wp_strip_all_tags((string) $value);
+    }
+}
+class WP_Block_Type_Registry
+{
+    private static $instance;
+    public static function get_instance()
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+    public function is_registered($name)
+    {
+        return \true;
+    }
+    public function get_registered($name)
+    {
+        $attributes = \array_fill_keys(['anchor', 'className', 'content', 'layout', 'linkTarget', 'rel', 'text', 'url'], ['type' => 'string']);
+        // core/buttons stores layout as an object.
+        $attributes['layout'] = ['type' => 'object'];
+        return (object) ['attributes' => $attributes];
+    }
+}
+\class_alias('BlockFormatBridge\Vendor\WP_Block_Type_Registry', 'WP_Block_Type_Registry', \false);
+require_once \dirname(__DIR__) . '/includes/class-html-element.php';
+require_once \dirname(__DIR__) . '/includes/class-block-factory.php';
+require_once \dirname(__DIR__) . '/includes/class-transform-registry.php';
+$failures = [];
+$assertions = 0;
+$smoke_assert = function ($condition, $label, $detail = '') use (&$failures, &$assertions) {
+    $assertions++;
+    if (!$condition) {
+        $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
+    }
+};
+$find_transform = function ($element) {
+    foreach (HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform) {
+        try {
+            $is_match = \call_user_func($transform['isMatch'], $element);
+        } catch (\Throwable $e) {
+            $is_match = \false;
+        }
+        if ($is_match) {
+            return $transform;
+        }
+    }
+    return null;
+};
+$handler = function ($args) {
+    return [HTML_To_Blocks_Block_Factory::create_block('core/paragraph', ['content' => \trim($args['HTML'] ?? '')])];
+};
+// -------------------------------------------------------------------------
+// Issue #247: inline justify-content on a button-anchor row must survive
+// as Gutenberg-compatible flex layout attributes on the core/buttons block.
+// -------------------------------------------------------------------------
+$centered_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'actions', 'style' => 'justify-content:center'], '<div class="actions" style="justify-content:center"><a class="button" href="#top">Launch Studio Code</a><a class="button secondary" href="#workflow">Review the pipeline</a></div>', '<a class="button" href="#top">Launch Studio Code</a><a class="button secondary" href="#workflow">Review the pipeline</a>');
+$centered_transform = $find_transform($centered_actions);
+$centered_block = \call_user_func($centered_transform['transform'], $centered_actions, $handler);
+$smoke_assert(null !== $centered_transform, 'centered-actions-transform-found');
+$smoke_assert('core/buttons' === $centered_transform['blockName'], 'centered-actions-becomes-buttons');
+$smoke_assert('core/buttons' === $centered_block['blockName'], 'centered-actions-block-name');
+$smoke_assert('actions' === $centered_block['attrs']['className'], 'centered-actions-class-preserved');
+$smoke_assert(isset($centered_block['attrs']['layout']), 'centered-actions-layout-attribute-set');
+$smoke_assert(($centered_block['attrs']['layout']['type'] ?? '') === 'flex', 'centered-actions-layout-type-flex');
+$smoke_assert(($centered_block['attrs']['layout']['justifyContent'] ?? '') === 'center', 'centered-actions-justify-center');
+$smoke_assert(\count($centered_block['innerBlocks']) === 2, 'centered-actions-child-count');
+// -------------------------------------------------------------------------
+// Other inline horizontal alignments map to Gutenberg-supported values.
+// -------------------------------------------------------------------------
+$right_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'cta-actions', 'style' => 'display:flex;justify-content:flex-end'], '<div class="cta-actions" style="display:flex;justify-content:flex-end"><a class="btn" href="/a">A</a><a class="btn" href="/b">B</a></div>', '<a class="btn" href="/a">A</a><a class="btn" href="/b">B</a>');
+$right_transform = $find_transform($right_actions);
+$right_block = \call_user_func($right_transform['transform'], $right_actions, $handler);
+$smoke_assert('core/buttons' === $right_transform['blockName'], 'right-actions-becomes-buttons');
+$smoke_assert(($right_block['attrs']['layout']['justifyContent'] ?? '') === 'right', 'right-actions-justify-flex-end-mapped-to-right');
+$left_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'cta-actions', 'style' => 'justify-content:flex-start'], '<div class="cta-actions" style="justify-content:flex-start"><a class="btn" href="/a">A</a><a class="btn" href="/b">B</a></div>', '<a class="btn" href="/a">A</a><a class="btn" href="/b">B</a>');
+$left_transform = $find_transform($left_actions);
+$left_block = \call_user_func($left_transform['transform'], $left_actions, $handler);
+$smoke_assert(($left_block['attrs']['layout']['justifyContent'] ?? '') === 'left', 'left-actions-flex-start-mapped-to-left');
+$between_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'cta-actions', 'style' => 'justify-content:space-between'], '<div class="cta-actions" style="justify-content:space-between"><a class="btn" href="/a">A</a><a class="btn" href="/b">B</a></div>', '<a class="btn" href="/a">A</a><a class="btn" href="/b">B</a>');
+$between_transform = $find_transform($between_actions);
+$between_block = \call_user_func($between_transform['transform'], $between_actions, $handler);
+$smoke_assert(($between_block['attrs']['layout']['justifyContent'] ?? '') === 'space-between', 'between-actions-justify-preserved');
+// -------------------------------------------------------------------------
+// is-content-justification-* utility classes also drive the layout attribute.
+// -------------------------------------------------------------------------
+$class_centered_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'actions is-content-justification-center'], '<div class="actions is-content-justification-center"><a class="btn" href="/a">A</a><a class="btn" href="/b">B</a></div>', '<a class="btn" href="/a">A</a><a class="btn" href="/b">B</a>');
+$class_centered_transform = $find_transform($class_centered_actions);
+$class_centered_block = \call_user_func($class_centered_transform['transform'], $class_centered_actions, $handler);
+$smoke_assert(($class_centered_block['attrs']['layout']['justifyContent'] ?? '') === 'center', 'class-utility-centered-justify-preserved');
+// -------------------------------------------------------------------------
+// No alignment hint -> no layout attribute (preserve previous default).
+// -------------------------------------------------------------------------
+$plain_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'actions'], '<div class="actions"><a class="btn" href="/a">A</a><a class="btn" href="/b">B</a></div>', '<a class="btn" href="/a">A</a><a class="btn" href="/b">B</a>');
+$plain_transform = $find_transform($plain_actions);
+$plain_block = \call_user_func($plain_transform['transform'], $plain_actions, $handler);
+$smoke_assert('core/buttons' === $plain_transform['blockName'], 'plain-actions-still-buttons');
+$smoke_assert(!isset($plain_block['attrs']['layout']), 'plain-actions-no-layout-attribute');
+// -------------------------------------------------------------------------
+// Unsupported justify-content values fall through silently.
+// -------------------------------------------------------------------------
+$weird_actions = new HTML_To_Blocks_HTML_Element('div', ['class' => 'actions', 'style' => 'justify-content:space-evenly'], '<div class="actions" style="justify-content:space-evenly"><a class="btn" href="/a">A</a><a class="btn" href="/b">B</a></div>', '<a class="btn" href="/a">A</a><a class="btn" href="/b">B</a>');
+$weird_transform = $find_transform($weird_actions);
+$weird_block = \call_user_func($weird_transform['transform'], $weird_actions, $handler);
+$smoke_assert(!isset($weird_block['attrs']['layout']), 'unsupported-justify-value-skipped');
+echo 'Assertions: ' . $assertions . \PHP_EOL;
+if (empty($failures)) {
+    echo 'ALL PASS' . \PHP_EOL;
+    exit(0);
+}
+echo 'FAILURES (' . \count($failures) . '):' . \PHP_EOL;
+foreach ($failures as $failure) {
+    echo '  - ' . $failure . \PHP_EOL;
+}
+exit(1);


### PR DESCRIPTION
## Summary
- Refreshes the bundled `chubes4/html-to-blocks-converter` dependency from `ce2d10d007ef4b19259b0e837789b04536d27698` to `992cb4755a280c40ef15c805a8f08b102a19909c`.
- Rebuilds `vendor_prefixed/` so BFB consumes the merged H2BC fix for preserving inline `justify-content` on `core/buttons` containers.
- Includes the newly scoped upstream smoke test for button alignment preservation.

## Testing
- `homeboy test --path /Users/chubes/Developer/block-format-bridge@refresh-h2bc-buttons-justify`
- `php vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-buttons-justify-content.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Refreshing the vendored dependency, running validation, and drafting this PR body. Chris remains responsible for review and merge.