### PR TITLE
Refresh bundled html-to-blocks separator serialization

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "0200b05af6cace238cfc0d205b9eddf04e999714"
+                "reference": "63f458b985cf38fed93f4843c91f801ab3258979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/0200b05af6cace238cfc0d205b9eddf04e999714",
-                "reference": "0200b05af6cace238cfc0d205b9eddf04e999714",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/63f458b985cf38fed93f4843c91f801ab3258979",
+                "reference": "63f458b985cf38fed93f4843c91f801ab3258979",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-05-12T19:43:27+00:00"
+            "time": "2026-05-12T21:17:33+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-block-factory.php
@@ -215,7 +215,7 @@ class HTML_To_Blocks_Block_Factory
                 $content = $attributes['content'] ?? '';
                 return '<pre' . self::html_attrs(array('class' => self::merge_block_class('wp-block-preformatted', $attributes))) . '>' . $content . '</pre>';
             case 'core/separator':
-                return '<hr' . self::html_attrs(array('class' => self::merge_block_class('wp-block-separator has-css-opacity', $attributes))) . '/>';
+                return '<hr' . self::html_attrs(array('class' => self::merge_block_class('wp-block-separator has-css-opacity', $attributes))) . ' />';
             case 'core/table':
                 return self::generate_table_html($attributes);
             case 'core/video':

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-block-supports.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-block-supports.php
@@ -175,13 +175,13 @@ $custom_separator_transform = $find_transform($custom_separator, 'core/separator
 $custom_separator_block = $custom_separator_transform ? \call_user_func($custom_separator_transform['transform'], $custom_separator) : null;
 $assert($custom_separator_block && 'core/separator' === $custom_separator_block['blockName'], 'custom-separator-transform-found');
 $assert(($custom_separator_block['attrs']['className'] ?? '') === 'ep-divider', 'custom-separator-preserves-class');
-$assert(($custom_separator_block['innerHTML'] ?? '') === '<hr class="wp-block-separator has-css-opacity ep-divider"/>', 'custom-separator-serializes-gutenberg-default-opacity-class', $custom_separator_block['innerHTML'] ?? '');
+$assert(($custom_separator_block['innerHTML'] ?? '') === '<hr class="wp-block-separator has-css-opacity ep-divider" />', 'custom-separator-serializes-gutenberg-default-opacity-class', $custom_separator_block['innerHTML'] ?? '');
 $ruler_separator = new Block_Supports_Smoke_Element('div', ['class' => 'ruler', 'aria-hidden' => 'true']);
 $ruler_separator_transform = $find_transform($ruler_separator, 'core/separator');
 $ruler_separator_block = $ruler_separator_transform ? \call_user_func($ruler_separator_transform['transform'], $ruler_separator) : null;
 $assert($ruler_separator_block && 'core/separator' === $ruler_separator_block['blockName'], 'ruler-separator-transform-found');
 $assert(($ruler_separator_block['attrs']['className'] ?? '') === 'ruler', 'ruler-separator-preserves-class');
-$assert(($ruler_separator_block['innerHTML'] ?? '') === '<hr class="wp-block-separator has-css-opacity ruler"/>', 'ruler-separator-serializes-as-native-separator', $ruler_separator_block['innerHTML'] ?? '');
+$assert(($ruler_separator_block['innerHTML'] ?? '') === '<hr class="wp-block-separator has-css-opacity ruler" />', 'ruler-separator-serializes-as-native-separator', $ruler_separator_block['innerHTML'] ?? '');
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;


### PR DESCRIPTION
## Summary
- Refresh the bundled `html-to-blocks-converter` dependency to include canonical `core/separator` serialization.
- Rebuild the prefixed vendor copy so downstream Static Site Importer snapshots match WordPress' stored block markup.

## Verification
- `homeboy test --path /Users/chubes/Developer/block-format-bridge@update-h2bc-separator-serialization --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Propagated the merged converter fix into Block Format Bridge, rebuilt prefixed vendor files, and ran verification. Chris remains responsible for review and merge.