### PR TITLE
Update h2bc caption figure transform

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "63f458b985cf38fed93f4843c91f801ab3258979"
+                "reference": "c9a34ce9d98886da087151478940370b9fd11996"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/63f458b985cf38fed93f4843c91f801ab3258979",
-                "reference": "63f458b985cf38fed93f4843c91f801ab3258979",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/c9a34ce9d98886da087151478940370b9fd11996",
+                "reference": "c9a34ce9d98886da087151478940370b9fd11996",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-05-12T21:17:33+00:00"
+            "time": "2026-05-13T19:49:53+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -2083,11 +2083,15 @@ class HTML_To_Blocks_Transform_Registry
             return self::is_decorative_figure_with_caption($element);
         }, 'transform' => function ($element) {
             $children = $element->get_child_elements();
-            $visual = $children[0];
-            $caption = $children[1];
+            $caption = \end($children);
             $caption_attrs = self::get_block_support_attributes($caption, array('class_name' => \true));
+            $inner_blocks = array();
+            if (\count($children) === 2) {
+                $inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_empty_decorative_group_attributes($children[0]));
+            }
             $caption_attrs['content'] = \trim($caption->get_inner_html());
-            return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), array(HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_empty_decorative_group_attributes($visual)), HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $caption_attrs)));
+            $inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $caption_attrs);
+            return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), $inner_blocks);
         }), array('blockName' => 'core/group', 'priority' => 15, 'isMatch' => function ($element) {
             return self::is_group_element($element);
         }, 'transform' => function ($element, $handler) {
@@ -2982,10 +2986,14 @@ class HTML_To_Blocks_Transform_Registry
             return \false;
         }
         $children = $element->get_child_elements();
-        if (\count($children) !== 2) {
+        if (\count($children) < 1 || \count($children) > 2) {
             return \false;
         }
-        return self::is_empty_decorative_element($children[0]) && 'FIGCAPTION' === $children[1]->get_tag_name() && \trim(wp_strip_all_tags($children[1]->get_inner_html())) !== '';
+        $caption = \end($children);
+        if ('FIGCAPTION' !== $caption->get_tag_name() || \trim(wp_strip_all_tags($caption->get_inner_html())) === '') {
+            return \false;
+        }
+        return \count($children) === 1 || self::is_empty_decorative_element($children[0]);
     }
     /**
      * Checks whether an empty element carries visual background styling.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-decorative-visual-clusters.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-decorative-visual-clusters.php
@@ -176,6 +176,24 @@ $assert(\str_contains($stars_serialized, 'ss-quote-stars'), 'stars-wrapper-class
 $assert(\str_contains($stars_serialized, '5 out of 5 stars'), 'stars-aria-label-survives', $stars_serialized);
 $assert(\substr_count(\html_entity_decode($star_content, \ENT_QUOTES, 'UTF-8'), '★') === 5, 'five-stars-survive', $star_content);
 $assert(!\in_array('core/html', $stars_names, \true), 'stars-have-no-html-fallback', $stars_serialized);
+$caption_only_figure_html = <<<'HTML'
+<figure class="gallery-tile tile-script"><figcaption>Marked scripts at the table</figcaption></figure>
+HTML;
+$caption_only_figure_blocks = html_to_blocks_raw_handler(['HTML' => $caption_only_figure_html]);
+$caption_only_figure_serialized = serialize_blocks($caption_only_figure_blocks);
+$caption_only_figure_names = $flatten_block_names($caption_only_figure_blocks);
+$assert(\in_array('core/group', $caption_only_figure_names, \true), 'caption-only-figure-becomes-group', $caption_only_figure_serialized);
+$assert(\in_array('core/paragraph', $caption_only_figure_names, \true), 'caption-only-figure-caption-becomes-paragraph', $caption_only_figure_serialized);
+$assert(\str_contains($caption_only_figure_serialized, 'gallery-tile tile-script'), 'caption-only-figure-class-survives', $caption_only_figure_serialized);
+$assert(\str_contains($caption_only_figure_serialized, 'Marked scripts at the table'), 'caption-only-figure-caption-survives', $caption_only_figure_serialized);
+$assert(!\in_array('core/html', $caption_only_figure_names, \true), 'caption-only-figure-has-no-html-fallback', $caption_only_figure_serialized);
+$linked_figure_html = <<<'HTML'
+<figure class="product-card"><a href="/menu">View menu</a><figcaption>Menu tile</figcaption></figure>
+HTML;
+$linked_figure_blocks = html_to_blocks_raw_handler(['HTML' => $linked_figure_html]);
+$linked_figure_names = $flatten_block_names($linked_figure_blocks);
+$linked_figure_serialized = serialize_blocks($linked_figure_blocks);
+$assert(!\in_array('core/group', $linked_figure_names, \true), 'functional-figure-child-does-not-use-decorative-group-transform', $linked_figure_serialized);
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;


### PR DESCRIPTION
## Summary
- Update the vendored html-to-blocks-converter build to include chubes4/html-to-blocks-converter#302.
- Propagate caption-only decorative figure handling into Block Format Bridge.

## Testing
- `homeboy test --path /Users/chubes/Developer/block-format-bridge@update-h2bc-caption-figure --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Propagated the merged h2bc dependency/build output and ran local validation.