### PR TITLE
Refresh bundled html-to-blocks converter

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "c9a34ce9d98886da087151478940370b9fd11996"
+                "reference": "691229e35eae98545a98760581da1501dd677ef6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/c9a34ce9d98886da087151478940370b9fd11996",
-                "reference": "c9a34ce9d98886da087151478940370b9fd11996",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/691229e35eae98545a98760581da1501dd677ef6",
+                "reference": "691229e35eae98545a98760581da1501dd677ef6",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-05-13T19:49:53+00:00"
+            "time": "2026-05-14T19:50:49+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -2326,9 +2326,6 @@ class HTML_To_Blocks_Transform_Registry
         if (\preg_match('/(?:^|\s)is-nowrap(?:\s|$)/i', $classes) || \strtolower(self::extract_css_property($style, 'flex-wrap')) === 'nowrap') {
             $attributes['layout']['flexWrap'] = 'nowrap';
         }
-        if (empty($attributes['layout']) && $element && self::is_hero_like_section($element)) {
-            $attributes['layout'] = array('type' => 'flex', 'orientation' => 'vertical', 'justifyContent' => 'center');
-        }
     }
     /**
      * Applies direct dimension declarations to block support attributes.
@@ -3159,14 +3156,27 @@ class HTML_To_Blocks_Transform_Registry
             }
             return \in_array($element->get_tag_name(), array('DIV', 'SPAN'), \true) && array() === $element->get_child_elements() && \trim($element->get_text_content()) !== '';
         }, 'transform' => function ($element) {
-            $content = $element->get_tag_name() === 'A' ? $element->get_outer_html() : $element->get_inner_html();
+            $content = $element->get_tag_name() === 'A' ? self::get_paragraph_anchor_content($element) : $element->get_inner_html();
             if (self::is_static_checkbox_label($element)) {
                 $content = \trim(\preg_replace('/<\s*input\b[^>]*>/i', '', $content));
             }
             $attributes = self::get_block_support_attributes($element, array('anchor' => \true, 'align' => \true, 'text_align' => \true, 'colors' => \true, 'typography' => \true, 'spacing' => \true, 'border' => \true, 'class_name' => \true));
+            if ($element->get_tag_name() === 'A') {
+                unset($attributes['className']);
+            }
             $attributes['content'] = $content;
             return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $attributes);
         }));
+    }
+    /**
+     * Gets paragraph content for a standalone anchor element.
+     *
+     * @param HTML_To_Blocks_HTML_Element $anchor Anchor element.
+     * @return string Paragraph content with link-owned attributes preserved.
+     */
+    private static function get_paragraph_anchor_content($anchor): string
+    {
+        return $anchor->get_outer_html();
     }
     /**
      * Checks whether a label is static visual UI text rather than a form label.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-action-text-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-action-text-transforms.php
@@ -157,6 +157,13 @@ $smoke_assert('core/buttons' !== $class_sensitive_cta_row_transform['blockName']
 $ordinary_link = new HTML_To_Blocks_HTML_Element('p', [], '<p>Read <a href="/more">more</a>.</p>', 'Read <a href="/more">more</a>.');
 $ordinary_link_transform = $find_transform($ordinary_link);
 $smoke_assert('core/paragraph' === $ordinary_link_transform['blockName'], 'ordinary-link-stays-paragraph');
+$standalone_brand_anchor = new HTML_To_Blocks_HTML_Element('a', ['class' => 'brand', 'href' => '#top', 'aria-label' => 'Studio home'], '<a class="brand" href="#top" aria-label="Studio home"><span>Studio</span> <small>Tattoo</small></a>', '<span>Studio</span> <small>Tattoo</small>');
+$standalone_brand_anchor_transform = $find_transform($standalone_brand_anchor);
+$standalone_brand_anchor_block = \call_user_func($standalone_brand_anchor_transform['transform'], $standalone_brand_anchor, $handler);
+$smoke_assert('core/paragraph' === $standalone_brand_anchor_transform['blockName'], 'standalone-brand-anchor-becomes-paragraph');
+$smoke_assert(\strpos($standalone_brand_anchor_block['attrs']['content'], '<a class="brand" href="#top" aria-label="Studio home">') !== \false, 'standalone-brand-anchor-preserves-link-attributes');
+$smoke_assert(!isset($standalone_brand_anchor_block['attrs']['className']), 'standalone-brand-anchor-keeps-class-on-link-only');
+$smoke_assert(\strpos($standalone_brand_anchor_block['innerHTML'], '<!-- wp:html -->') === \false, 'standalone-brand-anchor-avoids-freeform');
 $static_button_tabs = new HTML_To_Blocks_HTML_Element('div', ['class' => 'use-case-tabs'], '<div class="use-case-tabs"><button class="use-case-tab active">Product Managers</button><button class="use-case-tab">Engineering Leads</button><button class="use-case-tab">GTM Teams</button><button class="use-case-tab">Executives</button></div>', '<button class="use-case-tab active">Product Managers</button><button class="use-case-tab">Engineering Leads</button><button class="use-case-tab">GTM Teams</button><button class="use-case-tab">Executives</button>');
 $static_button_tabs_transform = $find_transform($static_button_tabs);
 $static_button_tabs_block = \call_user_func($static_button_tabs_transform['transform'], $static_button_tabs, $handler);

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
@@ -115,18 +115,18 @@ $assert = static function ($condition, $label, $detail = '') use (&$failures, &$
         $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
     }
 };
-$brand_link = '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>';
-foreach ([$brand_link, '<!-- wp:freeform -->' . $brand_link . '<!-- /wp:freeform -->'] as $index => $html) {
-    $serialized = serialize_blocks(html_to_blocks_raw_handler(['HTML' => $html]));
-    $label = 0 === $index ? 'raw' : 'freeform';
-    $assert(!\str_contains($serialized, '<!-- wp:html -->'), $label . '-avoids-core-html', $serialized);
-    $assert(!\str_contains($serialized, '<!-- wp:freeform -->'), $label . '-avoids-core-freeform', $serialized);
-    $assert(\str_contains($serialized, '<!-- wp:paragraph'), $label . '-uses-paragraph-block', $serialized);
-    $assert(\str_contains($serialized, 'href="#top"'), $label . '-preserves-href', $serialized);
-    $assert(\str_contains($serialized, 'aria-label="Studio Code home"'), $label . '-preserves-aria-label', $serialized);
-    $assert(\str_contains($serialized, 'class="brand"'), $label . '-preserves-link-class', $serialized);
-    $assert(\str_contains($serialized, '<span class="mark"></span>'), $label . '-preserves-decorative-span-class', $serialized);
-    $assert(\str_contains($serialized, '<span>Studio Code</span>'), $label . '-preserves-label-span', $serialized);
+$brand_cases = ['simple-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>', 'snippets' => ['href="#top"', 'aria-label="Studio Code home"', 'class="brand"', '<span class="mark"></span>', '<span>Studio Code</span>']], 'formatted-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Wickstead Refill Works home"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a>', 'snippets' => ['href="#top"', 'aria-label="Wickstead Refill Works home"', 'class="brand"', '<span class="brand-mark" aria-hidden="true">W</span>', '<strong>Wickstead</strong>', '<em>Refill Works</em>']]];
+foreach ($brand_cases as $case_name => $case) {
+    foreach ([$case['html'], '<!-- wp:freeform -->' . $case['html'] . '<!-- /wp:freeform -->'] as $index => $html) {
+        $serialized = serialize_blocks(html_to_blocks_raw_handler(['HTML' => $html]));
+        $label = $case_name . '-' . (0 === $index ? 'raw' : 'freeform');
+        $assert(!\str_contains($serialized, '<!-- wp:html -->'), $label . '-avoids-core-html', $serialized);
+        $assert(!\str_contains($serialized, '<!-- wp:freeform -->'), $label . '-avoids-core-freeform', $serialized);
+        $assert(\str_contains($serialized, '<!-- wp:paragraph'), $label . '-uses-paragraph-block', $serialized);
+        foreach ($case['snippets'] as $snippet) {
+            $assert(\str_contains($serialized, $snippet), $label . '-preserves-' . \md5($snippet), $serialized);
+        }
+    }
 }
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-layout-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-layout-transforms.php
@@ -143,13 +143,11 @@ $smoke_assert(($inline_flex_hero_group['attrs']['layout']['orientation'] ?? '') 
 $smoke_assert(($inline_flex_hero_group['attrs']['layout']['justifyContent'] ?? '') === 'center', 'inline-flex-hero-preserves-justify-content');
 $smoke_assert(($inline_flex_hero_group['attrs']['style']['dimensions']['minHeight'] ?? '') === '100svh', 'inline-flex-hero-preserves-min-height');
 $smoke_assert(($inline_flex_hero_group['attrs']['style']['spacing']['padding'] ?? '') === '9rem 2rem 5rem', 'inline-flex-hero-preserves-padding');
-$class_driven_hero = new Layout_Smoke_Element('section', ['class' => 'hero'], '<div class="container"><h1>Launch</h1></div><div class="hero-code-window"></div><div class="hero-scroll-hint"><span class="scroll-line"></span><p>scroll</p></div>');
-$class_driven_transform = $find_transform($class_driven_hero, 'core/group');
-$class_driven_hero_group = $class_driven_transform ? \call_user_func($class_driven_transform['transform'], $class_driven_hero, $handler) : null;
-$smoke_assert($class_driven_hero_group && 'core/group' === $class_driven_hero_group['blockName'], 'class-driven-hero-to-group');
-$smoke_assert(($class_driven_hero_group['attrs']['layout']['type'] ?? '') === 'flex', 'class-driven-hero-uses-flex-layout');
-$smoke_assert(($class_driven_hero_group['attrs']['layout']['orientation'] ?? '') === 'vertical', 'class-driven-hero-uses-vertical-layout');
-$smoke_assert(($class_driven_hero_group['attrs']['layout']['justifyContent'] ?? '') === 'center', 'class-driven-hero-centers-content');
+$class_only_hero = new Layout_Smoke_Element('section', ['class' => 'hero'], '<div class="container"><h1>Launch</h1></div><div class="hero-code-window"></div><div class="hero-scroll-hint"><span class="scroll-line"></span><p>scroll</p></div>');
+$class_only_transform = $find_transform($class_only_hero, 'core/group');
+$class_only_hero_group = $class_only_transform ? \call_user_func($class_only_transform['transform'], $class_only_hero, $handler) : null;
+$smoke_assert($class_only_hero_group && 'core/group' === $class_only_hero_group['blockName'], 'class-only-hero-to-group');
+$smoke_assert(!isset($class_only_hero_group['attrs']['layout']), 'class-only-hero-does-not-invent-flex-layout');
 $stack_group_element = new Layout_Smoke_Element('div', ['class' => 'wp-block-group is-layout-flex is-vertical is-nowrap is-content-justification-space-between custom-stack'], '<p>Stacked copy</p>');
 $stack_group_transform = $find_transform($stack_group_element, 'core/group');
 $stack_group = $stack_group_transform ? \call_user_func($stack_group_transform['transform'], $stack_group_element, $handler) : null;


### PR DESCRIPTION
## Summary
- Refresh the vendored `html-to-blocks-converter` build to include the latest merged transformer fixes for class-only hero layout inference and standalone branded anchors.
- Keep the generated prefixed smoke fixtures in sync with the updated converter package.

## Tests
- `homeboy test --path . --extension wordpress`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Ran the dependency refresh/build and verification after reviewing iterator-produced h2bc fixes; Chris remains responsible for final review.