### PR TITLE
Refresh bundled html-to-blocks converter

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "691229e35eae98545a98760581da1501dd677ef6"
+                "reference": "1b8e69715fd05f4a4c525980889ac50c4a8569e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/691229e35eae98545a98760581da1501dd677ef6",
-                "reference": "691229e35eae98545a98760581da1501dd677ef6",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/1b8e69715fd05f4a4c525980889ac50c4a8569e6",
+                "reference": "1b8e69715fd05f4a4c525980889ac50c4a8569e6",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-05-14T19:50:49+00:00"
+            "time": "2026-05-15T12:00:47+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -3176,7 +3176,13 @@ class HTML_To_Blocks_Transform_Registry
      */
     private static function get_paragraph_anchor_content($anchor): string
     {
-        return $anchor->get_outer_html();
+        $html = $anchor->get_outer_html();
+        $class = $anchor->has_attribute('class') ? (string) $anchor->get_attribute('class') : '';
+        if (\preg_match('/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class)) {
+            $html = \preg_replace('/<\s*div\b([^>]*)>/i', '<span$1>', $html) ?? $html;
+            $html = \preg_replace('/<\s*\/\s*div\s*>/i', '</span>', $html) ?? $html;
+        }
+        return $html;
     }
     /**
      * Checks whether a label is static visual UI text rather than a form label.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
@@ -837,7 +837,7 @@ function html_to_blocks_normalise_blocks($html)
                 if (!$in_paragraph) {
                     $in_paragraph = \true;
                 }
-                $paragraph_buffer .= $element_html;
+                $paragraph_buffer .= html_to_blocks_normalise_phrasing_fragment($element_html);
             }
             continue;
         }
@@ -857,4 +857,18 @@ function html_to_blocks_normalise_blocks($html)
         $output .= '<p>' . \trim($paragraph_buffer) . '</p>';
     }
     return !empty($output) ? $output : $html;
+}
+/**
+ * Normalize standalone phrasing fragments before wrapping them in paragraphs.
+ *
+ * @param string $html HTML fragment.
+ * @return string Normalized fragment.
+ */
+function html_to_blocks_normalise_phrasing_fragment(string $html): string
+{
+    if (\preg_match('/^\s*<\s*a\b[^>]*\sclass=("|\')([^"\']*)\1/i', $html, $matches) && \preg_match('/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $matches[2])) {
+        $html = \preg_replace('/<\s*div\b([^>]*)>/i', '<span$1>', $html) ?? $html;
+        $html = \preg_replace('/<\s*\/\s*div\s*>/i', '</span>', $html) ?? $html;
+    }
+    return $html;
 }

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
@@ -115,7 +115,7 @@ $assert = static function ($condition, $label, $detail = '') use (&$failures, &$
         $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
     }
 };
-$brand_cases = ['simple-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>', 'snippets' => ['href="#top"', 'aria-label="Studio Code home"', 'class="brand"', '<span class="mark"></span>', '<span>Studio Code</span>']], 'formatted-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Wickstead Refill Works home"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a>', 'snippets' => ['href="#top"', 'aria-label="Wickstead Refill Works home"', 'class="brand"', '<span class="brand-mark" aria-hidden="true">W</span>', '<strong>Wickstead</strong>', '<em>Refill Works</em>']]];
+$brand_cases = ['simple-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>', 'snippets' => ['href="#top"', 'aria-label="Studio Code home"', 'class="brand"', '<span class="mark"></span>', '<span>Studio Code</span>']], 'formatted-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Wickstead Refill Works home"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a>', 'snippets' => ['href="#top"', 'aria-label="Wickstead Refill Works home"', 'class="brand"', '<span class="brand-mark" aria-hidden="true">W</span>', '<strong>Wickstead</strong>', '<em>Refill Works</em>']], 'div-wrapped-logo-brand' => ['html' => '<a class="footer-logo" href="#"><div class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></div>Relay Atlas</a>', 'snippets' => ['href="#"', 'class="footer-logo"', '<span class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></span>', 'Relay Atlas']]];
 foreach ($brand_cases as $case_name => $case) {
     foreach ([$case['html'], '<!-- wp:freeform -->' . $case['html'] . '<!-- /wp:freeform -->'] as $index => $html) {
         $serialized = serialize_blocks(html_to_blocks_raw_handler(['HTML' => $html]));
@@ -126,6 +126,7 @@ foreach ($brand_cases as $case_name => $case) {
         foreach ($case['snippets'] as $snippet) {
             $assert(\str_contains($serialized, $snippet), $label . '-preserves-' . \md5($snippet), $serialized);
         }
+        $assert(!\str_contains($serialized, '<div'), $label . '-normalizes-block-wrappers', $serialized);
     }
 }
 echo 'Assertions: ' . $assertions . \PHP_EOL;


### PR DESCRIPTION
## Summary
- Refreshes the bundled html-to-blocks converter to include brand/logo anchor wrapper normalization.
- Keeps downstream importers on the shared converter contract instead of preserving brand anchors as freeform islands.

## Testing
- `homeboy test --path . --extension wordpress`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed the vendored converter, inspected the dependency diff, and ran verification. Chris remains responsible for review and merge decisions.