### PR TITLE
Rebuild converter tag label spacing

### DIFF
--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -738,7 +738,7 @@ class HTML_To_Blocks_Transform_Registry
         }, 'transform' => function ($element) {
             return self::create_aria_hidden_inline_span_paragraph($element);
         }), array('blockName' => 'core/paragraph', 'priority' => 8, 'selector' => 'span', 'isMatch' => function ($element) {
-            return self::is_numeric_label_span($element);
+            return self::is_inline_span_label($element);
         }, 'transform' => function ($element) {
             return self::create_inline_span_label_paragraph($element);
         }), array('blockName' => 'core/group', 'priority' => 8, 'selector' => 'div,p', 'isMatch' => function ($element) {
@@ -917,16 +917,16 @@ class HTML_To_Blocks_Transform_Registry
         return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $attributes);
     }
     /**
-     * Checks whether a standalone span is a numeric visual label.
+     * Checks whether a standalone span is a visual label.
      *
-     * Number-only label spans are commonly used as service, step, or index badges.
-     * Keep the span markup inside a native paragraph so class-based presentation
-     * survives without falling back to core/html.
+     * Number-only and tag label spans are commonly used as service, step, index,
+     * and card badges. Keep the span markup inside a native paragraph so
+     * class-based presentation survives without falling back to core/html.
      *
      * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
      * @return bool True when the span can safely become paragraph markup.
      */
-    private static function is_numeric_label_span($element): bool
+    private static function is_inline_span_label($element): bool
     {
         if ('SPAN' !== $element->get_tag_name() || !$element->has_attribute('class')) {
             return \false;
@@ -934,12 +934,15 @@ class HTML_To_Blocks_Transform_Registry
         if (\preg_match('/<\s*[a-z][^>]*>/i', $element->get_inner_html()) === 1) {
             return \false;
         }
-        return \preg_match('/^\d+$/', \trim($element->get_text_content())) === 1;
+        if (\preg_match('/^\d+$/', \trim($element->get_text_content())) === 1) {
+            return \true;
+        }
+        return self::class_matches($element, '/(?:^|\s)tag(?:\s|$)/i');
     }
     /**
-     * Creates a paragraph preserving numeric label span markup.
+     * Creates a paragraph preserving inline label span markup.
      *
-     * @param HTML_To_Blocks_HTML_Element $element Numeric label span.
+     * @param HTML_To_Blocks_HTML_Element $element Inline label span.
      * @return array Block array.
      */
     private static function create_inline_span_label_paragraph($element): array
@@ -3352,6 +3355,9 @@ class HTML_To_Blocks_Transform_Registry
             if (\in_array($element->get_tag_name(), array('P', 'ADDRESS', 'A'), \true)) {
                 return \true;
             }
+            if (self::is_inline_span_label($element)) {
+                return \true;
+            }
             if (self::is_static_visual_label($element)) {
                 return \true;
             }
@@ -3360,6 +3366,9 @@ class HTML_To_Blocks_Transform_Registry
             }
             return \in_array($element->get_tag_name(), array('DIV', 'SPAN'), \true) && array() === $element->get_child_elements() && \trim($element->get_text_content()) !== '';
         }, 'transform' => function ($element) {
+            if (self::is_inline_span_label($element)) {
+                return self::create_inline_span_label_paragraph($element);
+            }
             $content = $element->get_tag_name() === 'A' ? self::get_paragraph_anchor_content($element) : $element->get_inner_html();
             if (self::is_static_checkbox_label($element)) {
                 $content = \trim(\preg_replace('/<\s*input\b[^>]*>/i', '', $content));

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
@@ -227,6 +227,16 @@ $assert(\strpos($service_card_serialized, '<span class="tag">window seats</span>
 $assert(\strpos($service_card_serialized, '<p class="service-number">01</p>') === \false, 'service-card-classed-span-not-rewritten-to-paragraph', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<h3 class="wp-block-heading">Heels &amp; soles</h3>') !== \false, 'service-card-heading-remains-editable', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<p>Heel lifts and sole patching.</p>') !== \false, 'service-card-copy-remains-editable', $service_card_serialized);
+$tag_label_grid = <<<'HTML'
+<div class="collection-grid">
+	<article class="collection"><span class="tag">window seats</span><h3>Deep built-in bench cushions</h3><p>Thicker cores and boxed corners.</p></article>
+	<article class="collection"><span class="tag">dining chairs</span><h3>Flattened chair pads</h3><p>Firm low-profile foam.</p></article>
+</div>
+HTML;
+$tag_label_blocks = html_to_blocks_raw_handler(['HTML' => $tag_label_grid]);
+$tag_label_serialized = serialize_blocks($tag_label_blocks);
+$assert(\strpos($tag_label_serialized, '<span class="tag">window seats</span>') !== \false, 'card-tag-span-preserved', $tag_label_serialized);
+$assert(\strpos($tag_label_serialized, '<p style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><span class="tag">window seats</span></p>') !== \false, 'card-tag-wrapper-resets-margin', $tag_label_serialized);
 $extrachill_shell_grid = <<<'HTML'
 <div class="full-width-breakout ec-edge-shell">
   <div class="home-3x3-grid">


### PR DESCRIPTION
## Summary
- Rebuilds the vendor-prefixed html-to-blocks-converter payload so the tag-label spacing fix from html-to-blocks-converter#347 is actually shipped by Block Format Bridge.

## Testing
- `composer install --no-interaction`
- `composer build`
- `homeboy lint --changed-since origin/main` (blocked: local Homeboy registry reports `extension.not_found` for `wordpress`)
- `homeboy test --changed-since origin/main` (blocked: local Homeboy registry reports `extension.not_found` for `wordpress`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Vendor rebuild and PR preparation; Chris remains responsible for review and validation.