### PR TITLE
Pin Homeboy test runner release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: Extra-Chill/homeboy-action@v2
         with:
           commands: test
+          version: '0.222.4'
           php-version: ${{ matrix.php-version }}
           # The WordPress extension's Playground backend needs Node to install
           # @wp-playground/cli; without this, push-context runs skip Node setup.


### PR DESCRIPTION
## Summary
- Pin the Homeboy GitHub Action to `0.222.4` so the test workflow uses the fixed WP Codebox integration instead of the historical `0.218.0` toolchain that failed before producing PHPUnit counts.
- Keeps the product code and test suite unchanged; this only stabilizes the CI runner used by `.github/workflows/test.yml`.

## Verification
- `homeboy test --json-summary`
- Result: 27 passed, 0 failed, 0 skipped; 360 assertions via WP Codebox/PHPUnit.

Fixes #119.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy CI failure, reproduced the current test command locally, identified the stale runner/toolchain failure mode, and drafted the workflow pin. Chris remains responsible for review and merge.