### PR TITLE
Refresh HTML converter snapshot

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -726,12 +726,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter.git",
-                "reference": "5afe78315a77ccae5ddef74e5967e476aa7a615d"
+                "reference": "c4f9418c8fbf5d13ebf619f654a7209ea05f7989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/5afe78315a77ccae5ddef74e5967e476aa7a615d",
-                "reference": "5afe78315a77ccae5ddef74e5967e476aa7a615d",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/c4f9418c8fbf5d13ebf619f654a7209ea05f7989",
+                "reference": "c4f9418c8fbf5d13ebf619f654a7209ea05f7989",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "source": "https://github.com/chubes4/html-to-blocks-converter/tree/main",
                 "issues": "https://github.com/chubes4/html-to-blocks-converter/issues"
             },
-            "time": "2026-06-07T18:18:54+00:00"
+            "time": "2026-06-07T19:43:57+00:00"
         },
         {
             "name": "fidry/console",

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -876,6 +876,10 @@ class HTML_To_Blocks_Transform_Registry
             return self::is_static_visual_button_container($element);
         }, 'transform' => function ($element) {
             return self::create_static_visual_button_group($element);
+        }), array('blockName' => 'core/group', 'priority' => 8, 'selector' => 'button', 'isMatch' => function ($element) {
+            return self::is_static_toggle_button_chrome($element);
+        }, 'transform' => function ($element) {
+            return self::create_static_toggle_button_group($element);
         }), array('blockName' => 'core/paragraph', 'priority' => 8, 'selector' => 'button', 'isMatch' => function ($element) {
             return self::is_static_navigation_toggle_button($element);
         }, 'transform' => function ($element) {
@@ -1069,6 +1073,55 @@ class HTML_To_Blocks_Transform_Registry
         }
         $class_name = $element->has_attribute('class') ? $element->get_attribute('class') : '';
         return \preg_match('/(?:^|[-_\s])(?:tabs?|chips?|filters?|pills?|segmented|selector|use[-_]?case)(?:$|[-_\s])/i', $class_name) === 1;
+    }
+    /**
+     * Checks whether a button is inert navigation toggle chrome.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+     * @return bool True when the button can safely become native visual chrome.
+     */
+    private static function is_static_toggle_button_chrome($element): bool
+    {
+        if ('BUTTON' !== $element->get_tag_name()) {
+            return \false;
+        }
+        if ($element->has_attribute('form') || $element->has_attribute('name') || $element->has_attribute('value')) {
+            return \false;
+        }
+        $type = \strtolower(\trim((string) ($element->get_attribute('type') ?? '')));
+        if ('' !== $type && 'button' !== $type) {
+            return \false;
+        }
+        $class_name = $element->has_attribute('class') ? $element->get_attribute('class') : '';
+        if (\preg_match('/(?:^|[-_\s])(?:nav[-_\s]?toggle|menu[-_\s]?toggle|hamburger)(?:$|[-_\s])/i', $class_name) !== 1) {
+            return \false;
+        }
+        $children = $element->get_child_elements();
+        if (empty($children)) {
+            return \trim($element->get_text_content()) === '';
+        }
+        foreach ($children as $child) {
+            if (!\in_array($child->get_tag_name(), array('SPAN', 'DIV'), \true)) {
+                return \false;
+            }
+            if (self::is_empty_element($child)) {
+                continue;
+            }
+            if (!self::class_matches($child, '/(?:^|\s)sr-only(?:\s|$)/i') || array() !== $child->get_child_elements()) {
+                return \false;
+            }
+        }
+        return \true;
+    }
+    /**
+     * Creates native visual chrome for an inert navigation toggle button.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Button element.
+     * @return array Block array.
+     */
+    private static function create_static_toggle_button_group($element): array
+    {
+        return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element));
     }
     /**
      * Creates a native group from a static visual button row.

--- a/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-static-site-chrome.php
+++ b/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-static-site-chrome.php
@@ -173,6 +173,19 @@ $assert(\str_contains($salt_star_serialized, 'class="wp-block-list nav-links"'),
 $assert(\str_contains($salt_star_serialized, 'href="#our-bakes"'), 'salt-star-nav-preserves-our-bakes-href', $salt_star_serialized);
 $assert(\str_contains($salt_star_serialized, 'href="#visit"'), 'salt-star-nav-preserves-visit-href', $salt_star_serialized);
 $assert(\str_contains($salt_star_serialized, 'href="#order"'), 'salt-star-nav-preserves-order-href', $salt_star_serialized);
+$restaurant_nav_html = <<<HTML
+<nav class="nav container" aria-label="Primary navigation">
+  <a class="brand" href="index.html"><img src="assets/img/ember-rye-mark.svg" alt="" width="46" height="46"><span><strong>Ember &amp; Rye</strong><small>Wood-Fired Pizza</small></span></a>
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-menu"><span class="sr-only">Toggle navigation</span><span></span><span></span><span></span></button>
+  <ul class="nav-links"><li><a href="menu.html">Menu</a></li><li><a href="reservations.html">Reservations</a></li></ul>
+</nav>
+HTML;
+$restaurant_nav_serialized = serialize_blocks(html_to_blocks_raw_handler(['HTML' => $restaurant_nav_html]));
+$assert(!\str_contains($restaurant_nav_serialized, '<!-- wp:html -->'), 'restaurant-nav-toggle-avoids-core-html-fallback', $restaurant_nav_serialized);
+$assert(\str_contains($restaurant_nav_serialized, '<nav class="wp-block-group nav container" aria-label="Primary navigation">'), 'restaurant-nav-wrapper-survives', $restaurant_nav_serialized);
+$assert(\str_contains($restaurant_nav_serialized, 'class="wp-block-group nav-toggle"'), 'restaurant-nav-toggle-becomes-native-chrome', $restaurant_nav_serialized);
+$assert(\str_contains($restaurant_nav_serialized, '<a class="brand" href="index.html">'), 'restaurant-nav-brand-link-survives', $restaurant_nav_serialized);
+$assert(\str_contains($restaurant_nav_serialized, 'class="wp-block-list nav-links"'), 'restaurant-nav-links-survive', $restaurant_nav_serialized);
 $studio_code_nav_serialized = serialize_blocks(html_to_blocks_raw_handler(array('HTML' => '<nav><div class="nav-logo"><div class="dot"></div>Studio Code</div></nav>')));
 $assert(!\str_contains($studio_code_nav_serialized, '<!-- wp:html -->'), 'studio-code-nav-logo-dot-avoids-core-html', $studio_code_nav_serialized);
 $assert(\str_contains($studio_code_nav_serialized, '<nav class="wp-block-group">'), 'studio-code-nav-wrapper-survives', $studio_code_nav_serialized);


### PR DESCRIPTION
## Summary
- Refresh the bundled `chubes4/html-to-blocks-converter` snapshot from `5afe783` to `c4f9418`.
- Pull in the static nav/menu toggle chrome conversion fix from h2bc PR #419.
- Rebuild `vendor_prefixed/` so runtime BFB consumers get the updated converter behavior.

## Verification
- `php tests/smoke-h2bc-capability-discovery-prefixed.php`
- `php tests/smoke-h2bc-capability-discovery-standalone.php`
- `php tests/smoke-scoped-h2bc-hooks.php`
- `php tests/smoke-content-normalization.php`
- `for test in tests/smoke-*.php; do php "$test" || exit 1; done`

Note: direct `php tests/*.php` is not valid here because `tests/BFBConversionUnitTest.php` requires the WordPress unit test harness (`WP_UnitTestCase`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed the vendored h2bc snapshot, rebuilt scoped runtime files, and ran standalone smoke verification. Chris remains responsible for review and acceptance.