### PR TITLE
Release v0.8.1

### DIFF
--- a/block-format-bridge.php
+++ b/block-format-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Block Format Bridge
  * Plugin URI: https://github.com/chubes4/block-format-bridge
  * Description: Orchestrates bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API. Composes existing plugins/libraries — owns no parsing logic of its own.
- * Version: 0.8.0
+ * Version: 0.8.1
  * Author: Chris Huber
  * Author URI: https://chubes.net
  * License: GPL-2.0-or-later

--- a/library.php
+++ b/library.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $bfb_library_path    = __DIR__;
-$bfb_library_version = '0.8.0';
+$bfb_library_version = '0.8.1';
 
 // Load Composer/php-scoper dependencies as soon as the bridge package is
 // included, not when the winning BFB version initializes on


### PR DESCRIPTION
## Summary
- Bump Block Format Bridge runtime/plugin version to `0.8.1` so Composer consumers can resolve the latest bundled h2bc snapshot.
- Enables downstream packages to consume the static toggle chrome conversion via semver instead of pinning `dev-main`.

## Verification
- `php tests/smoke-h2bc-capability-discovery-prefixed.php`
- `php tests/smoke-scoped-h2bc-hooks.php`
- `php tests/smoke-multi-consumer-bundled-load.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Bumped release version metadata and ran focused smoke verification. Chris remains responsible for review and acceptance.