### PR TITLE
Refresh h2bc static form parity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^8.1",
-        "chubes4/html-to-blocks-converter": "dev-fix-static-form-surrogate-parity",
+        "chubes4/html-to-blocks-converter": "dev-main",
         "league/commonmark": "^2.5",
         "league/html-to-markdown": "^5.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         ]
     },
     "require": {
-        "chubes4/html-to-blocks-converter": "dev-main",
         "php": "^8.1",
+        "chubes4/html-to-blocks-converter": "dev-fix-static-form-surrogate-parity",
         "league/commonmark": "^2.5",
         "league/html-to-markdown": "^5.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter",
-                "reference": "6a2f53060402ef97f7e26cc826e392a682b4c3f7"
+                "reference": "78289412228f3d71cc44136dfdd50ea0aad0b82f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/6a2f53060402ef97f7e26cc826e392a682b4c3f7",
-                "reference": "6a2f53060402ef97f7e26cc826e392a682b4c3f7",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/78289412228f3d71cc44136dfdd50ea0aad0b82f",
+                "reference": "78289412228f3d71cc44136dfdd50ea0aad0b82f",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
             ],
             "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
             "homepage": "https://github.com/chubes4/html-to-blocks-converter",
-            "time": "2026-06-07T21:04:36+00:00"
+            "time": "2026-06-07T21:24:15+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "343928b2f3a9da77df759b7787d44dfb",
+    "content-hash": "5e80def02c25e3d6bc32f7207b51fd81",
     "packages": [
         {
             "name": "chubes4/html-to-blocks-converter",
-            "version": "dev-fix-static-form-surrogate-parity",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter",
-                "reference": "78289412228f3d71cc44136dfdd50ea0aad0b82f"
+                "reference": "7336776a65393a1e6856de1c4dd87c0637d17ac2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/78289412228f3d71cc44136dfdd50ea0aad0b82f",
-                "reference": "78289412228f3d71cc44136dfdd50ea0aad0b82f",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/7336776a65393a1e6856de1c4dd87c0637d17ac2",
+                "reference": "7336776a65393a1e6856de1c4dd87c0637d17ac2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -40,7 +41,7 @@
             ],
             "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
             "homepage": "https://github.com/chubes4/html-to-blocks-converter",
-            "time": "2026-06-07T21:24:15+00:00"
+            "time": "2026-06-07T22:31:38+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa21093e6f55653057bedf2e6a1e1b99",
+    "content-hash": "343928b2f3a9da77df759b7787d44dfb",
     "packages": [
         {
             "name": "chubes4/html-to-blocks-converter",
-            "version": "dev-main",
+            "version": "dev-fix-static-form-surrogate-parity",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter",
-                "reference": "94977024d4b676c723232d0a7c3b01c8563c224a"
+                "reference": "6a2f53060402ef97f7e26cc826e392a682b4c3f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/94977024d4b676c723232d0a7c3b01c8563c224a",
-                "reference": "94977024d4b676c723232d0a7c3b01c8563c224a",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/6a2f53060402ef97f7e26cc826e392a682b4c3f7",
+                "reference": "6a2f53060402ef97f7e26cc826e392a682b4c3f7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4"
             },
-            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -41,7 +40,7 @@
             ],
             "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
             "homepage": "https://github.com/chubes4/html-to-blocks-converter",
-            "time": "2026-06-07T20:27:36+00:00"
+            "time": "2026-06-07T21:04:36+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/includes/api.php
+++ b/includes/api.php
@@ -191,10 +191,10 @@ if ( ! function_exists( 'bfb_h2bc_capabilities' ) ) {
 	 */
 	function bfb_h2bc_capabilities(): array {
 		$handler = null;
-		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
-			$handler = '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler';
-		} elseif ( function_exists( 'html_to_blocks_raw_handler' ) ) {
+		if ( function_exists( 'html_to_blocks_raw_handler' ) ) {
 			$handler = 'html_to_blocks_raw_handler';
+		} elseif ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
+			$handler = '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler';
 		}
 
 		$path = null;
@@ -253,8 +253,8 @@ if ( ! function_exists( 'bfb_h2bc_capability_function' ) ) {
 	 */
 	function bfb_h2bc_capability_function(): ?string {
 		$candidates = array(
-			'\BlockFormatBridge\Vendor\html_to_blocks_capabilities',
 			'html_to_blocks_capabilities',
+			'\BlockFormatBridge\Vendor\html_to_blocks_capabilities',
 		);
 		$defined    = get_defined_functions();
 		$functions  = array_map( 'strtolower', $defined['user'] );

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -65,13 +65,13 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 			return bfb_filter_html_to_blocks_result( $pre_result, $content, $options, $args );
 		}
 
-		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
-			$blocks = \BlockFormatBridge\Vendor\html_to_blocks_raw_handler( $args );
+		if ( function_exists( 'html_to_blocks_raw_handler' ) ) {
+			$blocks = html_to_blocks_raw_handler( $args );
 			return bfb_filter_html_to_blocks_result( is_array( $blocks ) ? $blocks : array(), $content, $options, $args );
 		}
 
-		if ( function_exists( 'html_to_blocks_raw_handler' ) ) {
-			$blocks = html_to_blocks_raw_handler( $args );
+		if ( function_exists( '\BlockFormatBridge\Vendor\html_to_blocks_raw_handler' ) ) {
+			$blocks = \BlockFormatBridge\Vendor\html_to_blocks_raw_handler( $args );
 			return bfb_filter_html_to_blocks_result( is_array( $blocks ) ? $blocks : array(), $content, $options, $args );
 		}
 


### PR DESCRIPTION
## Summary
- Refresh the bundled h2bc dependency to consume the static form surrogate parity fix from chubes4/html-to-blocks-converter#421.
- Prefer the root Composer h2bc raw handler and capability functions before older globally loaded prefixed copies.

## Dependency
- Depends on chubes4/html-to-blocks-converter#421.

## Testing
- `composer build`
- BFB smoke tests pass after rebuilding the prefixed vendor bundle.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the dependency refresh and handler-precedence fix; Chris remains responsible for review and validation.