### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -24,6 +24,13 @@ if ( ! function_exists( 'bfb_register_ability_category' ) ) {
 			return;
 		}
 
+		// Core's wp_abilities_api_categories_init action can fire more than once
+		// per request on multisite. Guard against re-registering an already
+		// registered category, which trips a _doing_it_wrong notice.
+		if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( BFB_ABILITY_CATEGORY ) ) {
+			return;
+		}
+
 		wp_register_ability_category(
 			BFB_ABILITY_CATEGORY,
 			array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "block-format-bridge" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On the Extra Chill multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. Core's `WP_Ability_Categories_Registry::register()` warns via `_doing_it_wrong` whenever an already-registered category gets registered again.

`bfb_register_ability_category()` called `wp_register_ability_category()` unconditionally inside its `wp_abilities_api_categories_init` callback, with no idempotency guard — so on the second hook fire it re-registered the `block-format-bridge` category and tripped the notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` (itself guarded with `function_exists` since it ships with the same core API). A repeat fire is now a clean no-op. The existing `function_exists( 'wp_register_ability_category' )` guard is preserved. No change to the slug, label, description, or hook.

This plugin registers a single category (`block-format-bridge`); that one call is now guarded.