### PR TITLE
Fix transformer Composer install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: Extra-Chill/homeboy-action@v2
         with:
           commands: test
-          version: '0.222.4'
+          version: '0.245.0'
           php-version: ${{ matrix.php-version }}
           # The WordPress extension's Playground backend needs Node to install
           # @wp-playground/cli; without this, push-context runs skip Node setup.

--- a/block-format-bridge.php
+++ b/block-format-bridge.php
@@ -63,4 +63,9 @@ if ( version_compare( PHP_VERSION, $bfb_min_php, '<' ) ) {
 	return;
 }
 
+$bfb_autoload = BFB_PLUGIN_PATH . 'vendor/autoload.php';
+if ( is_readable( $bfb_autoload ) ) {
+	require_once $bfb_autoload;
+}
+
 require_once BFB_PLUGIN_PATH . 'library.php';

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,40 @@
     "scripts": {
         "build": "./build.sh",
         "lint": "php -l block-format-bridge.php && php -l library.php && find includes tests tools -name '*.php' -print0 | xargs -0 -n1 php -l",
-        "smokes": "php tests/smoke-content-normalization.php && php tests/smoke-transformer-capability-discovery-standalone.php && php tests/smoke-transformer-capability-discovery-class.php"
+        "smokes": "php tests/smoke-content-normalization.php && php tests/smoke-transformer-capability-discovery-standalone.php && php tests/smoke-transformer-capability-discovery-class.php && php tests/smoke-transformer-composer-install.php"
     },
     "autoload": {
         "files": [
             "library.php"
         ]
     },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "automattic/blocks-engine-php-transformer",
+                "version": "dev-trunk",
+                "type": "library",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/Automattic/blocks-engine.git",
+                    "reference": "trunk"
+                },
+                "autoload": {
+                    "psr-4": {
+                        "Automattic\\BlocksEngine\\PhpTransformer\\": "php-transformer/src/"
+                    }
+                },
+                "require": {
+                    "league/commonmark": "^2.5",
+                    "league/html-to-markdown": "^5.1",
+                    "php": ">=8.1"
+                }
+            }
+        }
+    ],
     "require": {
+        "automattic/blocks-engine-php-transformer": "dev-trunk",
         "php": "^8.1"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,12 +4,751 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3aaf42a2969956decd636838ca28da86",
-    "packages": [],
+    "content-hash": "e156c88a74672a5b83c82be0f2dae55f",
+    "packages": [
+        {
+            "name": "automattic/blocks-engine-php-transformer",
+            "version": "dev-trunk",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/blocks-engine.git",
+                "reference": "trunk"
+            },
+            "require": {
+                "league/commonmark": "^2.5",
+                "league/html-to-markdown": "^5.1",
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\BlocksEngine\\PhpTransformer\\": "php-transformer/src/"
+                }
+            }
+        },
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
+            },
+            "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "league/commonmark",
+            "version": "2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
+                "ext-json": "*",
+                "github/gfm": "0.29.0",
+                "michelf/php-markdown": "^1.4 || ^2.0",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
+                "unleashedtech/php-coding-standard": "^3.1.1",
+                "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
+            },
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\CommonMark\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
+            "homepage": "https://commonmark.thephpleague.com",
+            "keywords": [
+                "commonmark",
+                "flavored",
+                "gfm",
+                "github",
+                "github-flavored",
+                "markdown",
+                "md",
+                "parser"
+            ],
+            "support": {
+                "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
+                "issues": "https://github.com/thephpleague/commonmark/issues",
+                "rss": "https://github.com/thephpleague/commonmark/releases.atom",
+                "source": "https://github.com/thephpleague/commonmark"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-19T13:16:38+00:00"
+        },
+        {
+            "name": "league/config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "0b4066eede55c48f38bcee4fb8f0aa85654390fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/0b4066eede55c48f38bcee4fb8f0aa85654390fd",
+                "reference": "0b4066eede55c48f38bcee4fb8f0aa85654390fd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "^1.1.0",
+                "phpstan/phpstan": "^1.8.8",
+                "phpunit/phpunit": "^8.5 || ^9.2",
+                "scrutinizer/ocular": "^1.6",
+                "unleashedtech/php-coding-standard": "^2.7 || ^3.0",
+                "vimeo/psalm": "^4.22 || ^5.0"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/html-to-markdown/issues",
+                "source": "https://github.com/thephpleague/html-to-markdown/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/html-to-markdown",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-12T21:21:09+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.5"
+            },
+            "require-dev": {
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
+            },
+            "time": "2026-02-23T03:47:12+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.2 - 8.5"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.5",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
+            },
+            "time": "2026-05-11T20:49:54+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "automattic/blocks-engine-php-transformer": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/includes/api.php
+++ b/includes/api.php
@@ -61,12 +61,12 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 		$transformer = bfb_transformer_capabilities();
 
 		return array(
-			'bridge'         => array(
+			'bridge'      => array(
 				'version' => defined( 'BFB_VERSION' ) ? BFB_VERSION : null,
 				'path'    => defined( 'BFB_PATH' ) ? BFB_PATH : null,
 			),
-			'formats'        => $formats,
-			'conversions'    => array(
+			'formats'     => $formats,
+			'conversions' => array(
 				'html_to_blocks'            => array(
 					'available' => (bool) $transformer['available'],
 					'provider'  => 'blocks-engine-php-transformer',
@@ -76,8 +76,8 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 					'provider'  => 'block-format-bridge',
 				),
 			),
-			'transformer'    => $transformer,
-			'hooks'          => array(
+			'transformer' => $transformer,
+			'hooks'       => array(
 				'filters' => array(
 					'bfb_register_format_adapter',
 					'bfb_default_format',
@@ -100,7 +100,7 @@ if ( ! function_exists( 'bfb_capabilities' ) ) {
 					'bfb_html_to_markdown_converter',
 				),
 			),
-			'abilities'      => array(
+			'abilities'   => array(
 				'block-format-bridge/get-capabilities',
 				'block-format-bridge/convert',
 				'block-format-bridge/convert-fragment',
@@ -114,13 +114,13 @@ if ( ! function_exists( 'bfb_transformer_class' ) ) {
 	/**
 	 * Resolve an active blocks-engine transformer class.
 	 *
-	 * @param string $class Fully-qualified unscoped class name.
+	 * @param string $class_name Fully-qualified unscoped class name.
 	 * @return string|null Resolved class name.
 	 */
-	function bfb_transformer_class( string $class ): ?string {
-		$class = ltrim( $class, '\\' );
-		if ( class_exists( $class ) ) {
-			return '\\' . $class;
+	function bfb_transformer_class( string $class_name ): ?string {
+		$class_name = ltrim( $class_name, '\\' );
+		if ( class_exists( $class_name ) ) {
+			return '\\' . $class_name;
 		}
 
 		return null;
@@ -137,7 +137,7 @@ if ( ! function_exists( 'bfb_transformer_capabilities' ) ) {
 		$bridge  = bfb_format_bridge();
 		$formats = array();
 
-		if ( $bridge && method_exists( $bridge, 'supportedFormats' ) ) {
+		if ( $bridge ) {
 			try {
 				$formats = $bridge->supportedFormats();
 			} catch ( Throwable $e ) {
@@ -149,7 +149,7 @@ if ( ! function_exists( 'bfb_transformer_capabilities' ) ) {
 			array_filter(
 				array_map(
 					static function ( $format ): string {
-						return is_scalar( $format ) ? (string) $format : '';
+						return (string) $format;
 					},
 					$formats
 				),
@@ -186,12 +186,11 @@ if ( ! function_exists( 'bfb_format_bridge' ) ) {
 			return $bridge;
 		}
 
-		$class = bfb_transformer_class( '\\Automattic\\BlocksEngine\\PhpTransformer\\FormatBridge\\FormatBridge' );
-		if ( null === $class ) {
+		if ( null === bfb_transformer_class( '\\Automattic\\BlocksEngine\\PhpTransformer\\FormatBridge\\FormatBridge' ) ) {
 			return null;
 		}
 
-		$bridge = new $class();
+		$bridge = new \Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge();
 		return $bridge;
 	}
 }
@@ -208,19 +207,16 @@ if ( ! function_exists( 'bfb_transformer_convert_result' ) ) {
 	 */
 	function bfb_transformer_convert_result( string $content, string $from, string $to, array $options = array() ): ?array {
 		if ( function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
-			$result = blocks_engine_php_transformer_convert_format( $content, $from, $to, $options );
-			return is_array( $result ) ? $result : null;
+			return blocks_engine_php_transformer_convert_format( $content, $from, $to, $options );
 		}
 
 		$bridge = bfb_format_bridge();
-		if ( ! $bridge || ! method_exists( $bridge, 'convertResult' ) ) {
+		if ( ! $bridge ) {
 			return null;
 		}
 
 		$result = $bridge->convertResult( $content, $from, $to, $options );
-		$report = is_object( $result ) && method_exists( $result, 'toArray' ) ? $result->toArray() : null;
-
-		return is_array( $report ) ? $report : null;
+		return $result->toArray();
 	}
 }
 
@@ -521,9 +517,11 @@ if ( ! function_exists( 'bfb_transformer_result_report' ) ) {
 				return null;
 			}
 
-			$blocks                      = isset( $report['blocks'] ) && is_array( $report['blocks'] ) ? $report['blocks'] : array();
-			$report['blocks']            = bfb_filter_html_to_blocks_result( $blocks, $content, $options, $args );
-			$report['serialized_blocks'] = serialize_blocks( $report['blocks'] );
+			$blocks           = isset( $report['blocks'] ) && is_array( $report['blocks'] ) ? $report['blocks'] : array();
+			$filtered_blocks  = bfb_filter_html_to_blocks_result( $blocks, $content, $options, $args );
+			$report['blocks'] = $filtered_blocks;
+			/** @var array<int|string, array{blockName: string|null, attrs: array, innerBlocks: array<array>, innerHTML: string, innerContent: array}> $filtered_blocks */
+			$report['serialized_blocks'] = serialize_blocks( $filtered_blocks );
 
 			return $report;
 		}

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -33,7 +33,7 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 	 * @param \Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge|null $bridge Canonical bridge.
 	 */
 	public function __construct( $bridge = null ) {
-		$this->bridge = $bridge ?: ( function_exists( 'bfb_format_bridge' ) ? bfb_format_bridge() : null );
+		$this->bridge = $bridge ? $bridge : ( function_exists( 'bfb_format_bridge' ) ? bfb_format_bridge() : null );
 	}
 
 	/**

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -34,7 +34,7 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 	 * @param \Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge|null $bridge Canonical bridge.
 	 */
 	public function __construct( $bridge = null ) {
-		$this->bridge = $bridge ?: ( function_exists( 'bfb_format_bridge' ) ? bfb_format_bridge() : null );
+		$this->bridge = $bridge ? $bridge : ( function_exists( 'bfb_format_bridge' ) ? bfb_format_bridge() : null );
 	}
 
 	/**

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'BFB_CLI_Command' ) ) {
 				WP_CLI::error( 'Unsupported --format value. Use "summary" or "json".' );
 			}
 
-			$bridge = isset( $report['bridge'] ) && is_array( $report['bridge'] ) ? $report['bridge'] : array();
+			$bridge      = isset( $report['bridge'] ) && is_array( $report['bridge'] ) ? $report['bridge'] : array();
 			$transformer = isset( $report['transformer'] ) && is_array( $report['transformer'] ) ? $report['transformer'] : array();
 			WP_CLI::line( sprintf( 'BFB: %s', isset( $bridge['version'] ) ? (string) $bridge['version'] : 'unknown' ) );
 			WP_CLI::line( sprintf( 'Formats: %s', implode( ', ', array_keys( (array) $report['formats'] ) ) ) );

--- a/tests/smoke-transformer-composer-install.php
+++ b/tests/smoke-transformer-composer-install.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Smoke coverage for Composer-installed Blocks Engine transformer integration.
+ *
+ * @package BlockFormatBridge
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+$bfb_actions = array();
+
+function add_action( string $hook_name, callable $callback, int $priority = 10 ): void {
+	global $bfb_actions;
+	$bfb_actions[ $hook_name ][ $priority ][] = $callback;
+}
+
+function did_action( string $hook_name ): int {
+	return 'plugins_loaded' === $hook_name ? 1 : 0;
+}
+
+function doing_action( string $hook_name ): bool {
+	unset( $hook_name );
+	return false;
+}
+
+function do_action( string $hook_name, ...$args ): void {
+	global $bfb_actions;
+	if ( empty( $bfb_actions[ $hook_name ] ) ) {
+		return;
+	}
+
+	ksort( $bfb_actions[ $hook_name ] );
+	foreach ( $bfb_actions[ $hook_name ] as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$callback( ...$args );
+		}
+	}
+}
+
+function add_filter( string $hook_name, callable $callback, int $priority = 10 ): void {
+	add_action( $hook_name, $callback, $priority );
+}
+
+function apply_filters( string $hook_name, $value, ...$args ) {
+	global $bfb_actions;
+	if ( empty( $bfb_actions[ $hook_name ] ) ) {
+		return $value;
+	}
+
+	ksort( $bfb_actions[ $hook_name ] );
+	foreach ( $bfb_actions[ $hook_name ] as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+	}
+
+	return $value;
+}
+
+function trailingslashit( string $path ): string {
+	return rtrim( $path, '/\\' ) . '/';
+}
+
+function serialize_blocks( array $blocks ): string {
+	$serialized = '';
+	foreach ( $blocks as $block ) {
+		$name  = isset( $block['blockName'] ) ? (string) $block['blockName'] : '';
+		$html  = isset( $block['innerHTML'] ) ? (string) $block['innerHTML'] : '';
+		$name  = str_starts_with( $name, 'core/' ) ? substr( $name, 5 ) : $name;
+		$attrs = empty( $block['attrs'] ) || ! is_array( $block['attrs'] ) ? '' : ' ' . wp_json_encode( $block['attrs'] );
+
+		$serialized .= '' === $name ? $html : sprintf( '<!-- wp:%1$s%2$s -->%3$s<!-- /wp:%1$s -->', $name, $attrs, $html );
+	}
+
+	return $serialized;
+}
+
+function parse_blocks( string $content ): array {
+	return array(
+		array(
+			'blockName'    => null,
+			'attrs'        => array(),
+			'innerBlocks'  => array(),
+			'innerHTML'    => $content,
+			'innerContent' => array( $content ),
+		),
+	);
+}
+
+function wp_json_encode( $value ): string {
+	return (string) json_encode( $value, JSON_UNESCAPED_SLASHES );
+}
+
+function bfb_transformer_composer_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+bfb_transformer_composer_assert( is_readable( $autoload ), 'Composer autoload file should exist after composer install.' );
+
+require_once $autoload;
+
+$capabilities = bfb_transformer_capabilities();
+$blocks       = bfb_to_blocks( '<h2>Composer transformer</h2><p>Installed runtime.</p>', 'html' );
+$serialized   = bfb_convert( '<h2>Composer transformer</h2>', 'html', 'blocks' );
+
+bfb_transformer_composer_assert( true === $capabilities['available'], 'Composer-installed transformer should be available.' );
+bfb_transformer_composer_assert( 'class' === $capabilities['integration'] || 'function' === $capabilities['integration'], 'Transformer should expose a class or helper integration.' );
+bfb_transformer_composer_assert( '\\Automattic\\BlocksEngine\\PhpTransformer\\FormatBridge\\FormatBridge' === $capabilities['bridge_class'], 'FormatBridge class should resolve from Composer autoload.' );
+bfb_transformer_composer_assert( array() !== $blocks, 'HTML should convert to at least one block through the installed transformer.' );
+bfb_transformer_composer_assert( false !== strpos( $serialized, '<!-- wp:' ), 'BFB should serialize converted blocks.' );
+
+echo "PASS: Composer transformer install integration\n";


### PR DESCRIPTION
## Summary
- Require the current Blocks Engine PHP transformer through Composer and lock its runtime dependencies.
- Load Composer autoload when BFB runs as a standalone plugin so the installed transformer class is visible.
- Add a Composer install smoke that exercises BFB HTML-to-blocks conversion through the installed transformer.
- Clean up transformer adapter/API typing and lint issues exposed once the transformer package is installed.

## Tests
- composer install
- composer validate --strict
- composer lint
- composer smokes
- homeboy lint --ci-job lint: passed remotely on homeboy-lab, run id runner-exec-homeboy-lab-0e44f6d5-250b-4eb5-814d-463c24318f05

## Known blocker
- homeboy ci run --profile pr still fails in the Homeboy profile runner before executing jobs: Failed to run CI job 'lint': No such file or directory.
- homeboy test --ci-job wp-codebox-phpunit reaches PHPUnit but fails 18 existing/stale behavioral assertions against the current transformer output shape. I did not weaken or remove those tests in this install-focused PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Composer/runtime diagnosis, code changes, smoke coverage, and verification command execution.