### PR TITLE
Clarify BFB transformer wrapper ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Rules:
   values are treated as explicit template-part slugs.
 - Missing or malformed marker values should fall back to the normal HTML conversion path rather than guessing.
 
-The marker contract belongs in BFB because BFB is the public conversion substrate. Runtime HTML-element transforms are
+The marker contract belongs in BFB because BFB is the public compatibility/API surface. Runtime HTML-element transforms are
 supplied by Blocks Engine through the public `bfb_convert( $html, 'html', 'blocks' )` path.
 
 ## Install
@@ -319,9 +319,9 @@ Resolve a registered adapter directly. Prefer `bfb_to_blocks()` when callers nee
 
 ### Block Theme Compiler Consumers
 
-Static HTML/CSS to block-theme compilers should treat BFB as the format-conversion substrate, not the layer that infers
+Static HTML/CSS to block-theme compilers should treat BFB as the format-conversion API surface, not the layer that infers
 block-theme or Site Editor intent. The compiler-facing helper and CLI shape are documented in
-[`docs/block-theme-compiler-surface.md`](docs/block-theme-compiler-surface.md). The stack workflow across h2bc, BFB, and
+[`docs/block-theme-compiler-surface.md`](docs/block-theme-compiler-surface.md). The stack workflow across Blocks Engine, BFB, and
 compiler consumers is documented in [`docs/block-theme-conversion-workflow.md`](docs/block-theme-conversion-workflow.md).
 The public mechanical conversion scope matrix is documented in
 [`docs/mechanical-block-theme-conversion.md`](docs/mechanical-block-theme-conversion.md).

--- a/docs/block-theme-compiler-surface.md
+++ b/docs/block-theme-compiler-surface.md
@@ -2,17 +2,17 @@
 
 Issue: https://github.com/chubes4/block-format-bridge/issues/29
 
-This note defines the Block Format Bridge surface a future static HTML/CSS to block-theme compiler should consume. It is intentionally limited to BFB's boundary: format conversion through the block pivot. Block-theme structure, Site Editor behavior, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside html-to-blocks-converter.
+This note defines the Block Format Bridge surface a future static HTML/CSS to block-theme compiler should consume. It is intentionally limited to BFB's boundary: compatibility APIs and format conversion through the block pivot. Block-theme structure, Site Editor behavior, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside Blocks Engine PHP transformer.
 
 ## Boundary
 
-BFB is the substrate between content formats and WordPress block data:
+BFB is the compatibility/API surface between content formats and WordPress block data:
 
 ```
 HTML / Markdown / future formats
         |
         v
-  BFB format adapter
+  BFB compatibility adapter
         |
         v
  WordPress block arrays
@@ -32,7 +32,7 @@ BFB's public marker vocabulary is intentionally narrow and explicit:
 - `data-bfb-template-part="area-or-slug"` declares a template part reference.
 
 These markers exist for compiler output, not heuristic discovery. A compiler may emit them after it has already decided
-that a fragment should become a pattern reference or template part. BFB/h2bc must not infer the same primitives from
+that a fragment should become a pattern reference or template part. BFB and the active transformer must not infer the same primitives from
 ordinary wrappers such as `<header>`, `<footer>`, `<section class="hero">`, or a repeated layout shape.
 
 The deterministic targets are:
@@ -43,10 +43,10 @@ The deterministic targets are:
 `data-wp-*` aliases are out of scope unless WordPress itself defines them as source-HTML markers. BFB-owned attributes
 avoid implying a WordPress core contract that does not exist.
 
-Implementation note: the marker contract is documented here because BFB owns the public conversion substrate. The actual
-HTML-element transforms currently live in html-to-blocks-converter, the library BFB delegates to for HTML → Blocks. That
-is a shared extension contract: h2bc may recognize these explicitly documented BFB markers, while BFB verifies marker
-behavior through `bfb_convert( $html, 'html', 'blocks' )` instead of adding a parallel pre-parser around h2bc.
+Implementation note: the marker contract is documented here because BFB owns the public compatibility/API surface. The
+actual HTML-element transforms live in Blocks Engine PHP transformer. That is a shared extension contract: the active
+transformer may recognize these explicitly documented BFB markers, while BFB verifies marker behavior through
+`bfb_convert( $html, 'html', 'blocks' )` instead of adding a parallel pre-parser.
 
 ## Answers
 
@@ -130,16 +130,16 @@ This avoids double conversion without changing `bfb_convert()` from a string-ret
 
 ### 4. Metadata preservation contract
 
-BFB should document the metadata contract, but the transform details stay in html-to-blocks-converter.
+BFB should document the metadata contract, but the transform details stay in Blocks Engine PHP transformer.
 
 For HTML to Blocks, BFB's stable contract should be:
 
 - BFB returns WordPress block arrays compatible with `serialize_blocks()` and `parse_blocks()`.
-- Source `class` attributes that html-to-blocks-converter maps into block attributes remain in `attrs` and are serialized by WordPress core.
-- Source `style` attributes that html-to-blocks-converter maps into block attributes remain in `attrs` and are serialized by WordPress core.
-- Source anchors / IDs that html-to-blocks-converter maps into block attributes remain in `attrs` and are serialized by WordPress core.
+- Source `class` attributes that the active transformer maps into block attributes remain in `attrs` and are serialized by WordPress core.
+- Source `style` attributes that the active transformer maps into block attributes remain in `attrs` and are serialized by WordPress core.
+- Source anchors / IDs that the active transformer maps into block attributes remain in `attrs` and are serialized by WordPress core.
 - BFB does not promise semantic inference beyond the attributes emitted by the active adapter.
-- Per-block mapping rules and fidelity fixes belong in html-to-blocks-converter tests and releases.
+- Per-block mapping rules and fidelity fixes belong in Blocks Engine PHP transformer tests and releases.
 
 That gives compiler consumers a stable integration target without moving transform ownership into BFB.
 

--- a/docs/block-theme-conversion-workflow.md
+++ b/docs/block-theme-conversion-workflow.md
@@ -2,12 +2,11 @@
 
 Issue: https://github.com/chubes4/block-format-bridge/issues/75
 
-This document defines the stack workflow for deterministic block-theme conversion across
-[`chubes4/html-to-blocks-converter`](https://github.com/chubes4/html-to-blocks-converter) (h2bc), Block Format Bridge
-(BFB), and higher-level compiler consumers such as Studio, Data Machine, or site-generation agents.
+This document defines the stack workflow for deterministic block-theme conversion across Blocks Engine PHP transformer,
+Block Format Bridge (BFB), and higher-level compiler consumers such as Studio, Data Machine, or site-generation agents.
 
 Use current WordPress language for this work: Site Editor, block themes, templates, template parts, Styles, and
-`theme.json`. BFB is a conversion substrate; it is not a site compiler.
+`theme.json`. BFB is a compatibility/API surface; it is not a site compiler.
 
 ## What "Every Block" Means
 
@@ -17,7 +16,7 @@ Complete coverage starts with inventory and classification:
 
 1. Generate the core block inventory from WordPress/Gutenberg `block.json` metadata.
 2. Classify each block by the layer that can safely decide it.
-3. Implement h2bc raw transforms only for blocks whose intent is present in source markup.
+3. Implement Blocks Engine raw transforms only for blocks whose intent is present in source markup.
 4. Expose the active support matrix through BFB capability surfaces.
 5. Let compiler consumers own the blocks that require site, template, query, entity, or design-system intent.
 
@@ -29,14 +28,14 @@ This keeps "complete coverage" honest. A block can be covered by being classifie
 WordPress / Gutenberg block.json metadata
         |
         v
-h2bc core-block inventory + classification
+Blocks Engine core-block inventory + classification
         |
         +--> safe raw HTML transforms
         +--> explicit-marker transforms
         +--> compiler-only classifications
         |
         v
-BFB conversion substrate
+BFB compatibility/API surface
         |
         +--> PHP APIs: bfb_convert(), bfb_to_blocks(), bfb_normalize()
         +--> Abilities API: machine-readable capability + conversion operations
@@ -52,11 +51,11 @@ Compiler consumers
         +--> Styles and theme.json
 ```
 
-## h2bc Responsibilities
+## Blocks Engine Transformer Responsibilities
 
-h2bc owns deterministic raw HTML to core block-array transforms.
+Blocks Engine PHP transformer owns deterministic raw HTML to core block-array transforms.
 
-h2bc should:
+Blocks Engine PHP transformer should:
 
 - Generate a core-block inventory and classification map from WordPress/Gutenberg `block.json` metadata.
 - Keep the generated coverage documentation in sync with that map.
@@ -65,7 +64,7 @@ h2bc should:
   documents the public marker vocabulary.
 - Fall back safely when markup is ambiguous.
 
-h2bc should not:
+Blocks Engine PHP transformer should not:
 
 - Create or update WordPress entities such as `wp_navigation` posts.
 - Infer template hierarchy from arbitrary wrappers such as `<header>` or `<footer>`.
@@ -80,7 +79,7 @@ Tracking:
 
 ## BFB Responsibilities
 
-BFB owns the public conversion substrate and consumer-facing ergonomics.
+BFB owns the public compatibility/API surface and consumer-facing ergonomics.
 
 BFB should expose conversion and capability operations through an ability-first machine surface. The WordPress Abilities
 API is the primitive for agent and automation consumers. WP-CLI and REST should be wrappers around the same conversion
@@ -92,12 +91,12 @@ BFB should:
 - Expose `bfb_convert()`, `bfb_to_blocks()`, and `bfb_normalize()` for PHP callers.
 - Expose ability operations for machine callers, including conversion and capability reporting.
 - Keep WP-CLI ergonomics thin and script-friendly for humans and shell-based tools.
-- Report what the active substrate supports so compiler consumers can plan fallbacks.
-- Consume h2bc's public capability API when available instead of reflecting over h2bc internals.
+- Report what the active transformer supports so compiler consumers can plan fallbacks.
+- Consume Blocks Engine transformer capabilities instead of duplicating transform internals.
 
 BFB should not:
 
-- Duplicate h2bc raw transforms.
+- Duplicate Blocks Engine raw transforms.
 - Infer site structure or design intent.
 - Depend on Studio, Data Machine, or any specific compiler consumer.
 - Treat CLI or REST output as a richer contract than the underlying ability/API operation.
@@ -120,7 +119,7 @@ Compiler consumers should:
 - Generate or update Styles and `theme.json` from site-wide design-system choices.
 - Ask BFB for capabilities before delegating static fragments to conversion.
 
-Compiler consumers should not expect BFB or h2bc to recover missing intent from arbitrary HTML. If the source does not
+Compiler consumers should not expect BFB or Blocks Engine to recover missing intent from arbitrary HTML. If the source does not
 name the WordPress concept, the compiler must decide it before conversion or accept a safe static fallback.
 
 ## Why Compiler-Only Blocks Stay Above BFB
@@ -140,9 +139,9 @@ conversion.
 
 ## Workflow
 
-1. h2bc generates and publishes the core-block inventory and classification map.
-2. h2bc implements deterministic transforms and explicit-marker transforms for safe classes.
-3. BFB refreshes its bundled h2bc dependency and exposes the resulting support through capabilities.
+1. Blocks Engine PHP transformer publishes the core-block inventory and classification map.
+2. Blocks Engine PHP transformer implements deterministic transforms and explicit-marker transforms for safe classes.
+3. BFB exposes the resulting support through compatibility capabilities.
 4. Compiler consumers request the BFB capability report through the Abilities API.
 5. Compiler consumers split work into deterministic fragments and site-intent decisions.
 6. Deterministic fragments go through BFB conversion.

--- a/docs/mechanical-block-theme-conversion.md
+++ b/docs/mechanical-block-theme-conversion.md
@@ -2,12 +2,12 @@
 
 Issue: https://github.com/chubes4/block-format-bridge/issues/64
 
-This matrix defines the public scope boundary for deterministic conversion from static HTML/CSS into WordPress block data for block themes. It is written for site-builder and compiler consumers that need to decide which work belongs in Block Format Bridge (BFB), which work belongs in html-to-blocks-converter (h2bc), and which work belongs in a higher-level compiler.
+This matrix defines the public scope boundary for deterministic conversion from static HTML/CSS into WordPress block data for block themes. It is written for site-builder and compiler consumers that need to decide which work belongs in Block Format Bridge (BFB), which work belongs in Blocks Engine PHP transformer, and which work belongs in a higher-level compiler.
 
-For the stack-level workflow across h2bc inventory/classification, BFB capability surfaces, and compiler consumers, see
+For the stack-level workflow across Blocks Engine inventory/classification, BFB capability surfaces, and compiler consumers, see
 [`block-theme-conversion-workflow.md`](block-theme-conversion-workflow.md).
 
-BFB and h2bc handle deterministic conversion. They can map explicit source markup into WordPress block arrays and serialized block markup. They do not infer creative intent, site strategy, editorial structure, navigation decisions, template hierarchy, global Styles, or theme.json design systems from arbitrary markup. Those decisions belong above BFB.
+BFB and Blocks Engine handle deterministic conversion. They can map explicit source markup into WordPress block arrays and serialized block markup. They do not infer creative intent, site strategy, editorial structure, navigation decisions, template hierarchy, global Styles, or theme.json design systems from arbitrary markup. Those decisions belong above BFB.
 
 ## Categories
 
@@ -15,31 +15,31 @@ BFB and h2bc handle deterministic conversion. They can map explicit source marku
 | --- | --- |
 | Handled mechanically | Deterministic conversion can happen directly from source markup without extra site intent. |
 | Explicit marker only | Conversion is safe only when the source carries an explicit marker naming the WordPress concept. |
-| Compiler-only | A site compiler or generation layer must decide the intent before BFB/h2bc can serialize the result. |
-| Unsupported/deferred | Not part of the current BFB/h2bc scope; tracked for later design or implementation. |
+| Compiler-only | A site compiler or generation layer must decide the intent before BFB/Blocks Engine can serialize the result. |
+| Unsupported/deferred | Not part of the current BFB/Blocks Engine scope; tracked for later design or implementation. |
 
 ## Matrix
 
 | Feature | Category | Scope boundary | Tracking |
 | --- | --- | --- | --- |
-| Groups and containers | Handled mechanically | Wrapper elements can become `core/group` or related layout blocks when the markup exposes a deterministic container boundary. h2bc owns the per-block transform; BFB routes the conversion. | h2bc #40: https://github.com/chubes4/html-to-blocks-converter/issues/40 |
+| Groups and containers | Handled mechanically | Wrapper elements can become `core/group` or related layout blocks when the markup exposes a deterministic container boundary. Blocks Engine owns the per-block transform; BFB routes the compatibility conversion. | Blocks Engine transformer coverage |
 | Columns | Handled mechanically | Repeated column-like child containers can map to `core/columns` and `core/column` when the source structure is explicit enough to preserve ordering and nesting. | h2bc #40: https://github.com/chubes4/html-to-blocks-converter/issues/40 |
-| Cover and spacer | Handled mechanically | Background-image sections and spacing-only elements can map mechanically when the source element carries concrete image or spacing data. | h2bc transform coverage |
-| Buttons | Handled mechanically | Anchor or button-like controls can map to `core/buttons` / `core/button` when the source exposes link, text, and button grouping directly. | h2bc transform coverage |
+| Cover and spacer | Handled mechanically | Background-image sections and spacing-only elements can map mechanically when the source element carries concrete image or spacing data. | Blocks Engine transformer coverage |
+| Buttons | Handled mechanically | Anchor or button-like controls can map to `core/buttons` / `core/button` when the source exposes link, text, and button grouping directly. | Blocks Engine transformer coverage |
 | Media, gallery, embed, and file | Handled mechanically | Media elements and recognized external embeds can map to their corresponding content blocks when source URLs and captions are explicit. BFB does not choose media strategy or replace assets. | h2bc transform coverage |
-| Block supports | Handled mechanically | Classes, inline styles, anchors, spacing, alignment, and color-like values can be preserved when h2bc maps them to block attributes that WordPress core serializes. BFB's contract is preserving the block arrays it receives. | h2bc #39: https://github.com/chubes4/html-to-blocks-converter/issues/39 |
-| Patterns | Explicit marker only | BFB/h2bc should not infer that an arbitrary repeated layout is a reusable pattern. A compiler may emit explicit pattern markers that BFB/h2bc can preserve or expand. | BFB #67: https://github.com/chubes4/block-format-bridge/issues/67 |
+| Block supports | Handled mechanically | Classes, inline styles, anchors, spacing, alignment, and color-like values can be preserved when Blocks Engine maps them to block attributes that WordPress core serializes. BFB's contract is preserving the block arrays it receives. | Blocks Engine transformer coverage |
+| Patterns | Explicit marker only | BFB/Blocks Engine should not infer that an arbitrary repeated layout is a reusable pattern. A compiler may emit explicit pattern markers that BFB/Blocks Engine can preserve or expand. | BFB #67: https://github.com/chubes4/block-format-bridge/issues/67 |
 | Template parts | Explicit marker only | Header, footer, sidebar, and other template-part boundaries require explicit source markers. Without markers, they are just containers. | BFB #63: https://github.com/chubes4/block-format-bridge/issues/63 |
 | Static navigation | Explicit marker only | Static navigation HTML can be represented as block markup only when source intent is explicit enough to distinguish menu structure from ordinary lists and links. | h2bc #41: https://github.com/chubes4/html-to-blocks-converter/issues/41 |
 | Navigation persistence | Compiler-only | Creating or updating persisted WordPress navigation entities is a site decision, not a format-conversion decision. A compiler can decide persistence, then hand resulting block markup to BFB. | BFB #62: https://github.com/chubes4/block-format-bridge/issues/62 |
-| Query, comments, and post theme blocks | Explicit marker only | Dynamic theme blocks represent WordPress runtime queries and post context. BFB/h2bc can only emit them safely from explicit markers, not from similar-looking static markup. | h2bc #42: https://github.com/chubes4/html-to-blocks-converter/issues/42 |
+| Query, comments, and post theme blocks | Explicit marker only | Dynamic theme blocks represent WordPress runtime queries and post context. BFB/Blocks Engine can only emit them safely from explicit markers, not from similar-looking static markup. | Blocks Engine transformer coverage |
 | theme.json generation | Compiler-only | Global Styles, design tokens, presets, and theme.json settings require site-wide design decisions. BFB does not generate theme.json. | BFB #61: https://github.com/chubes4/block-format-bridge/issues/61 |
 | Block-array helper surface | Unsupported/deferred | Compiler consumers may need a public block-array helper so they can inspect and split converted output before serialization. That is an API addition, not part of this docs change. | BFB #65: https://github.com/chubes4/block-format-bridge/issues/65 |
 | WP-CLI conversion command | Unsupported/deferred | Non-PHP compiler tools may need a CLI wrapper around BFB's public API. The command should be a thin wrapper after the PHP helper surface stabilizes. | BFB #66: https://github.com/chubes4/block-format-bridge/issues/66 |
 
 ## Boundary In Practice
 
-Use BFB/h2bc for deterministic format conversion:
+Use BFB/Blocks Engine for deterministic format conversion:
 
 ```text
 HTML / Markdown / declared source format
@@ -48,7 +48,7 @@ HTML / Markdown / declared source format
      BFB adapter
         |
         v
-   h2bc block transforms
+Blocks Engine transforms
         |
         v
 WordPress block arrays / serialized block markup
@@ -68,7 +68,7 @@ Site goal / design system / content strategy
         +--> Styles and theme.json
         |
         v
- BFB/h2bc for deterministic block serialization
+ BFB/Blocks Engine for deterministic block serialization
 ```
 
 The split is intentional: BFB should make the mechanical conversion reliable and boring. Creative intent, editorial hierarchy, design-token selection, and site assembly should remain explicit inputs to the layer that calls BFB.

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -56,7 +56,7 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 			'block-format-bridge/get-capabilities',
 			array(
 				'label'               => __( 'Get Block Format Bridge Capabilities', 'block-format-bridge' ),
-				'description'         => __( 'Return the active content-format conversion substrate capabilities.', 'block-format-bridge' ),
+				'description'         => __( 'Return the active content-format transformer capabilities.', 'block-format-bridge' ),
 				'category'            => BFB_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -139,7 +139,7 @@ if ( ! function_exists( 'bfb_register_abilities' ) ) {
 
 if ( ! function_exists( 'bfb_ability_permission_callback' ) ) {
 	/**
-	 * Permission callback for read-only conversion substrate abilities.
+	 * Permission callback for read-only conversion backend abilities.
 	 *
 	 * @return bool
 	 */

--- a/includes/api.php
+++ b/includes/api.php
@@ -10,7 +10,7 @@
  *   bfb_analyze_blocks( $blocks )           — block quality report
  *   bfb_conversion_report( $content, $from ) — conversion quality report
  *   bfb_convert_fragment( $html, $options )  — scoped fragment conversion
- *   bfb_capabilities()                      — conversion substrate report
+ *   bfb_capabilities()                      — active transformer report
  *   bfb_get_adapter( $slug )                — registry lookup
  *
  * `bfb_convert()` routes through the block pivot via the adapter registry.
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'bfb_capabilities' ) ) {
 	/**
-	 * Return a machine-readable report of the active conversion substrate.
+	 * Return a machine-readable report of the active transformer.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -373,9 +373,9 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 
 if ( ! function_exists( 'bfb_filter_html_to_blocks_result' ) ) {
 	/**
-	 * Filter block arrays returned by the HTML conversion substrate.
+	 * Filter block arrays returned by the HTML conversion backend.
 	 *
-	 * This hook lets generic conversion substrate integrations expose a final
+	 * This hook lets generic conversion backend integrations expose a final
 	 * block array without coupling BFB to any filesystem or importer behavior.
 	 *
 	 * @param array<int, array<string, mixed>> $blocks  Converted block list.
@@ -386,7 +386,7 @@ if ( ! function_exists( 'bfb_filter_html_to_blocks_result' ) ) {
 	 */
 	function bfb_filter_html_to_blocks_result( array $blocks, string $content, array $options, array $args ): array {
 		/**
-		 * Filters block arrays returned by the HTML conversion substrate.
+		 * Filters block arrays returned by the HTML conversion backend.
 		 *
 		 * @since 0.5.0
 		 *
@@ -763,7 +763,7 @@ if ( ! function_exists( 'bfb_build_conversion_diagnostics' ) ) {
 					'text_retention_ratio' => $text_retention_ratio,
 				),
 			);
-			$guidance      = 'Potential warning-only content loss. Capture this report for the conversion substrate and retry with simpler source structure if needed; do not work around it by manually authoring wp:html blocks.';
+			$guidance      = 'Potential warning-only content loss. Capture this report for the active transformer and retry with simpler source structure if needed; do not work around it by manually authoring wp:html blocks.';
 		}
 
 		return array(
@@ -776,7 +776,7 @@ if ( ! function_exists( 'bfb_build_conversion_diagnostics' ) ) {
 
 if ( ! function_exists( 'bfb_normalize_conversion_metadata' ) ) {
 	/**
-	 * Normalize conversion metadata emitted by conversion substrates.
+	 * Normalize conversion metadata emitted by conversion backends.
 	 *
 	 * BFB stores only structured, filesystem-agnostic data. Downstream consumers
 	 * decide whether and where to write assets, then replace any placeholders.

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'BFB_CLI_Command' ) ) {
 	class BFB_CLI_Command {
 
 		/**
-		 * Report active conversion substrate capabilities.
+		 * Report active transformer capabilities.
 		 *
 		 * ## OPTIONS
 		 *


### PR DESCRIPTION
## Summary
- update BFB docs to describe BFB as the compatibility/API surface over Blocks Engine PHP transformer
- replace stale “conversion substrate” wording with active transformer/backend language
- preserve historical changelog/test compatibility references while clarifying current ownership

## Testing
- `composer install --no-interaction`
- `composer run lint`
- `composer run smokes`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting docs/comment cleanup, running verification, and preparing the PR.
