### PR TITLE
Guard against bundled transformer artifacts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,20 @@
 
 set -euo pipefail
 
+blocked_paths=(
+	"vendor_prefixed/automattic/blocks-engine-php-transformer"
+	"vendor_prefixed/chubes4/html-to-blocks-converter"
+	"vendor_prefixed/chubes4/block-artifact-compiler"
+	"includes/blocks-engine-php-transformer"
+	"includes/html-to-blocks-converter"
+	"includes/block-artifact-compiler"
+)
+
+for blocked_path in "${blocked_paths[@]}"; do
+	if [[ -e "${blocked_path}" ]]; then
+		echo "Refusing to build: bundled transformer artifact found at ${blocked_path}" >&2
+		exit 1
+	fi
+done
+
 echo "==> Build complete: BFB ships without bundled transformer dependencies."


### PR DESCRIPTION
## Summary
- make the build-time no-bundled-transformer contract executable
- fail builds when prefixed or copied transformer artifacts are present in release paths
- allow normal Composer `vendor/` development dependencies

## Testing
- `composer run build`
- `composer run lint`
- `composer run smokes`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Adding the build guard and running focused verification.
