### PR TITLE
Prove BFB delegates parity transforms

### DIFF
--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -274,30 +274,59 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	/**
 	 * Resolved asset metadata should flow through BFB into transformer media transforms.
 	 */
-	public function test_asset_metadata_context_enriches_transformer_image_blocks(): void {
-		$serialized = bfb_convert(
-			'<img src="assets/hero.jpg" alt="Source alt" width="1200" height="800">',
-			'html',
-			'blocks',
-			array(
-				'context' => array(
-					'asset_metadata' => array(
-						'assets/hero.jpg' => array(
-							'id'  => 42,
-							'url' => 'https://example.test/wp-content/uploads/hero.jpg',
-						),
+	public function test_asset_metadata_context_delegates_to_transformer_image_parity(): void {
+		$options = array(
+			'context' => array(
+				'asset_metadata' => array(
+					'assets/hero.jpg' => array(
+						'id'  => 42,
+						'url' => 'https://example.test/wp-content/uploads/hero.jpg',
 					),
 				),
-			)
+			),
+		);
+
+		$serialized = bfb_convert(
+			'<main><img src="assets/hero.jpg" alt="Hero alt"></main>',
+			'html',
+			'blocks',
+			$options
 		);
 
 		$blocks = parse_blocks( $serialized );
 		$image  = $this->first_block_named( $blocks, 'core/image' );
 
 		$this->assertNotNull( $image );
-		$this->assertArrayHasKey( 'url', $image['attrs'] ?? array() );
-		$this->assertStringContainsString( 'alt="Source alt"', $image['innerHTML'] ?? '' );
-		$this->assertStringContainsString( 'src="assets/hero.jpg"', $image['innerHTML'] ?? '' );
+		$this->assertSame( 42, $image['attrs']['id'] ?? null );
+		$this->assertSame( 'https://example.test/wp-content/uploads/hero.jpg', $image['attrs']['url'] ?? null );
+		$this->assertSame( 'Hero alt', $image['attrs']['alt'] ?? null );
+		$this->assertStringContainsString( 'src="https://example.test/wp-content/uploads/hero.jpg"', $serialized );
+		$this->assertStringContainsString( 'class="wp-image-42"', $serialized );
+
+		$array_blocks = bfb_to_blocks( '<main><img src="assets/hero.jpg" alt="Hero alt"></main>', 'html', $options );
+		$array_image  = $this->first_block_named( $array_blocks, 'core/image' );
+		$this->assertNotNull( $array_image );
+		$this->assertSame( 42, $array_image['attrs']['id'] ?? null );
+		$this->assertSame( 'https://example.test/wp-content/uploads/hero.jpg', $array_image['attrs']['url'] ?? null );
+	}
+
+	/**
+	 * Spacer parity should be exposed through BFB without local spacer transforms.
+	 */
+	public function test_spacer_html_delegates_to_transformer_block_parity(): void {
+		$serialized = bfb_convert( '<div class="wp-block-spacer" style="height:72px"></div>', 'html', 'blocks' );
+		$blocks     = parse_blocks( $serialized );
+		$spacer     = $this->first_block_named( $blocks, 'core/spacer' );
+
+		$this->assertNotNull( $spacer );
+		$this->assertSame( '72px', $spacer['attrs']['height'] ?? null );
+		$this->assertStringContainsString( '<!-- wp:spacer {"className":"wp-block-spacer","height":"72px"} -->', $serialized );
+		$this->assertStringContainsString( 'style="height:72px"', $serialized );
+
+		$array_blocks = bfb_to_blocks( '<div class="spacer" style="height:4rem"></div>', 'html' );
+		$array_spacer = $this->first_block_named( $array_blocks, 'core/spacer' );
+		$this->assertNotNull( $array_spacer );
+		$this->assertSame( '4rem', $array_spacer['attrs']['height'] ?? null );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Strengthens public BFB facade coverage for Blocks Engine asset metadata parity.
- Adds spacer parity coverage through bfb_convert() and bfb_to_blocks().
- Keeps BFB as a thin delegation facade without adding local spacer or asset transforms.

## Verification
- composer lint
- composer smokes
- git diff --check
- homeboy test: 31 passed, 0 skipped, persisted run runner-exec-homeboy-lab-06324a3e-c115-4914-837c-56d34a3cb952

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Auditing the post-#135 facade surface, updating tests, and running verification.