### PR TITLE
Isolate BFB conversion report compatibility

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -718,6 +718,49 @@ if ( ! function_exists( 'bfb_transformer_fallback_events' ) ) {
 	}
 }
 
+if ( ! function_exists( 'bfb_compat_conversion_report_from_transformer_result' ) ) {
+	/**
+	 * Project a canonical transformer result into BFB's legacy public report shape.
+	 *
+	 * @param string               $content                  Source content.
+	 * @param string               $from                     Source format slug.
+	 * @param array<int, array>    $blocks                   Converted blocks.
+	 * @param array<string, mixed> $transformer_report       TransformerResult::toArray() data.
+	 * @param array<int, array>    $fallback_events          BFB-compatible fallback events.
+	 * @param array<int, array>    $conversion_metadata      Conversion metadata collected from public hooks.
+	 * @param array<int, array>    $materialization_requests Materialization requests collected from public hooks.
+	 * @return array<string, mixed> BFB conversion report.
+	 */
+	function bfb_compat_conversion_report_from_transformer_result( string $content, string $from, array $blocks, array $transformer_report, array $fallback_events = array(), array $conversion_metadata = array(), array $materialization_requests = array() ): array {
+		$analysis                                  = bfb_analyze_blocks( $blocks );
+		$analysis['from']                          = $from;
+		$analysis['source_bytes']                  = strlen( $content );
+		$analysis['source_text_bytes']             = bfb_text_bytes( $content );
+		$analysis['fallback_events']               = $fallback_events;
+		$analysis['fallback_diagnostics']          = ! empty( $fallback_events ) ? $fallback_events : $analysis['fallbacks'];
+		$analysis['fallback_event_count']          = count( $fallback_events );
+		$analysis['conversion_metadata']           = $conversion_metadata;
+		$analysis['materialization_requests']      = $materialization_requests;
+		$analysis['materialization_request_count'] = count( $materialization_requests );
+		$analysis['serialized_blocks']             = isset( $transformer_report['serialized_blocks'] ) && is_string( $transformer_report['serialized_blocks'] ) && '' !== $transformer_report['serialized_blocks'] ? $transformer_report['serialized_blocks'] : serialize_blocks( $blocks );
+		$analysis['converted_text_bytes']          = bfb_text_bytes( $analysis['serialized_blocks'] );
+		$analysis['text_retention_ratio']          = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
+		$analysis['transformer_result']            = $transformer_report;
+
+		if ( isset( $transformer_report['metrics'] ) && is_array( $transformer_report['metrics'] ) ) {
+			$analysis['transformer_metrics'] = $transformer_report['metrics'];
+		}
+		if ( isset( $transformer_report['source_reports'] ) && is_array( $transformer_report['source_reports'] ) ) {
+			$analysis['source_reports'] = $transformer_report['source_reports'];
+		}
+		if ( isset( $transformer_report['coverage'] ) && is_array( $transformer_report['coverage'] ) ) {
+			$analysis['coverage'] = $transformer_report['coverage'];
+		}
+
+		return $analysis;
+	}
+}
+
 if ( ! function_exists( 'bfb_conversion_report' ) ) {
 	/**
 	 * Convert content to blocks and return quality metrics alongside the result.
@@ -772,30 +815,22 @@ if ( ! function_exists( 'bfb_conversion_report' ) ) {
 			remove_action( 'bfb_materialization_request', $request_listener, 10 );
 		}
 
-		$analysis                                  = bfb_analyze_blocks( $blocks );
-		$analysis['from']                          = $from;
-		$analysis['source_bytes']                  = strlen( $content );
-		$analysis['source_text_bytes']             = bfb_text_bytes( $content );
-		$analysis['fallback_events']               = $fallback_events;
-		$analysis['fallback_diagnostics']          = ! empty( $fallback_events ) ? $fallback_events : $analysis['fallbacks'];
-		$analysis['fallback_event_count']          = count( $fallback_events );
-		$analysis['conversion_metadata']           = $conversion_metadata;
-		$analysis['materialization_requests']      = $materialization_requests;
-		$analysis['materialization_request_count'] = count( $materialization_requests );
-		$analysis['serialized_blocks']             = isset( $transformer_report['serialized_blocks'] ) && is_string( $transformer_report['serialized_blocks'] ) && '' !== $transformer_report['serialized_blocks'] ? $transformer_report['serialized_blocks'] : serialize_blocks( $blocks );
-		$analysis['converted_text_bytes']          = bfb_text_bytes( $analysis['serialized_blocks'] );
-		$analysis['text_retention_ratio']          = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
 		if ( $transformer_report ) {
-			$analysis['transformer_result'] = $transformer_report;
-			if ( isset( $transformer_report['metrics'] ) && is_array( $transformer_report['metrics'] ) ) {
-				$analysis['transformer_metrics'] = $transformer_report['metrics'];
-			}
-			if ( isset( $transformer_report['source_reports'] ) && is_array( $transformer_report['source_reports'] ) ) {
-				$analysis['source_reports'] = $transformer_report['source_reports'];
-			}
-			if ( isset( $transformer_report['coverage'] ) && is_array( $transformer_report['coverage'] ) ) {
-				$analysis['coverage'] = $transformer_report['coverage'];
-			}
+			$analysis = bfb_compat_conversion_report_from_transformer_result( $content, $from, $blocks, $transformer_report, $fallback_events, $conversion_metadata, $materialization_requests );
+		} else {
+			$analysis                                  = bfb_analyze_blocks( $blocks );
+			$analysis['from']                          = $from;
+			$analysis['source_bytes']                  = strlen( $content );
+			$analysis['source_text_bytes']             = bfb_text_bytes( $content );
+			$analysis['fallback_events']               = $fallback_events;
+			$analysis['fallback_diagnostics']          = ! empty( $fallback_events ) ? $fallback_events : $analysis['fallbacks'];
+			$analysis['fallback_event_count']          = count( $fallback_events );
+			$analysis['conversion_metadata']           = $conversion_metadata;
+			$analysis['materialization_requests']      = $materialization_requests;
+			$analysis['materialization_request_count'] = count( $materialization_requests );
+			$analysis['serialized_blocks']             = serialize_blocks( $blocks );
+			$analysis['converted_text_bytes']          = bfb_text_bytes( $analysis['serialized_blocks'] );
+			$analysis['text_retention_ratio']          = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
 		}
 
 		$diagnostics = bfb_build_conversion_diagnostics( $analysis );

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -667,6 +667,57 @@ MARKDOWN;
 	}
 
 	/**
+	 * Conversion reports should preserve BFB keys while passing canonical metadata through.
+	 */
+	public function test_conversion_report_preserves_public_keys_and_canonical_metadata(): void {
+		$report = bfb_conversion_report( '<h2>Canonical Report</h2><p>Metadata should pass through.</p>', 'html' );
+
+		$this->assertSame( 'html', $report['from'] );
+		$this->assertSame( 2, $report['total_blocks'] );
+		$this->assertArrayHasKey( 'block_counts', $report );
+		$this->assertArrayHasKey( 'fallbacks', $report );
+		$this->assertArrayHasKey( 'fallback_events', $report );
+		$this->assertArrayHasKey( 'fallback_diagnostics', $report );
+		$this->assertArrayHasKey( 'fallback_event_count', $report );
+		$this->assertArrayHasKey( 'serialized_blocks', $report );
+		$this->assertArrayHasKey( 'status', $report );
+		$this->assertArrayHasKey( 'diagnostics', $report );
+		$this->assertArrayHasKey( 'agent_guidance', $report );
+
+		$this->assertSame( $report['transformer_result']['source_reports'] ?? array(), $report['source_reports'] ?? array() );
+		$this->assertSame( $report['transformer_result']['metrics'], $report['transformer_metrics'] );
+
+		$blocks             = parse_blocks( '<!-- wp:paragraph --><p>Fixture.</p><!-- /wp:paragraph -->' );
+		$transformer_result = array(
+			'serialized_blocks' => '<!-- wp:paragraph --><p>Fixture.</p><!-- /wp:paragraph -->',
+			'blocks'            => $blocks,
+			'source_reports'    => array(
+				'conversion_report' => array(
+					'schema'         => 'blocks-engine/php-transformer/conversion-report/v1',
+					'source_summary' => array(
+						'block_count' => 1,
+					),
+				),
+			),
+			'metrics'           => array(
+				'block_count' => 1,
+			),
+			'coverage'          => array(
+				array( 'fallback_count' => 0 ),
+			),
+		);
+
+		$compat = bfb_compat_conversion_report_from_transformer_result( '<p>Fixture.</p>', 'html', $blocks, $transformer_result );
+
+		$this->assertSame( 1, $compat['total_blocks'] );
+		$this->assertSame( '<!-- wp:paragraph --><p>Fixture.</p><!-- /wp:paragraph -->', $compat['serialized_blocks'] );
+		$this->assertSame( 'blocks-engine/php-transformer/conversion-report/v1', $compat['source_reports']['conversion_report']['schema'] ?? null );
+		$this->assertSame( $transformer_result['source_reports'], $compat['source_reports'] );
+		$this->assertSame( $transformer_result['metrics'], $compat['transformer_metrics'] );
+		$this->assertSame( $transformer_result['coverage'], $compat['coverage'] );
+	}
+
+	/**
 	 * Native reports should keep fallback diagnostics empty.
 	 */
 	public function test_conversion_report_exposes_structured_fallback_diagnostics(): void {


### PR DESCRIPTION
## Summary
- Isolates BFB's legacy conversion report projection into a dedicated compatibility helper fed by Blocks Engine transformer results.
- Keeps public report keys such as from, block_counts, fallbacks, fallback_events, fallback_diagnostics, serialized_blocks, status, diagnostics, and agent_guidance intact.
- Adds behavior coverage proving canonical transformer source_reports, metrics, and coverage flow through the compatibility projection.

## Verification
- composer lint
- composer smokes
- git diff --check
- homeboy test --path . (offloaded to homeboy-lab, WP Codebox: 32 passed, 0 failed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Implementing the compatibility helper extraction, adding behavior coverage, and running verification.