### PR TITLE
Delegate adapter result extraction

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -262,6 +262,22 @@ if ( ! function_exists( 'bfb_transformer_result_content' ) ) {
 	}
 }
 
+if ( ! function_exists( 'bfb_transformer_result_blocks' ) ) {
+	/**
+	 * Extract parsed blocks from a canonical transformer result.
+	 *
+	 * @param array<string, mixed> $result TransformerResult::toArray() data.
+	 * @return array<int|string, array<string, mixed>> Parsed block array.
+	 */
+	function bfb_transformer_result_blocks( array $result ): array {
+		if ( isset( $result['blocks'] ) && is_array( $result['blocks'] ) ) {
+			return $result['blocks'];
+		}
+
+		return array();
+	}
+}
+
 if ( ! function_exists( 'bfb_prepare_transformer_conversion' ) ) {
 	/**
 	 * Preserve BFB's public input filters before delegating to FormatBridge.

--- a/includes/class-bfb-html-adapter.php
+++ b/includes/class-bfb-html-adapter.php
@@ -109,8 +109,8 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 
 		try {
 			$result = $this->convert_result( $content, 'html', 'blocks', $args );
-			$blocks = is_array( $result ) && isset( $result['blocks'] ) && is_array( $result['blocks'] ) ? $result['blocks'] : null;
-			return bfb_filter_html_to_blocks_result( is_array( $blocks ) ? $blocks : array(), $content, $options, $args );
+			$blocks = is_array( $result ) && function_exists( 'bfb_transformer_result_blocks' ) ? bfb_transformer_result_blocks( $result ) : array();
+			return bfb_filter_html_to_blocks_result( $blocks, $content, $options, $args );
 		} catch ( Throwable $e ) {
 			do_action(
 				'bfb_diagnostic',
@@ -147,11 +147,7 @@ class BFB_HTML_Adapter implements BFB_Format_Adapter {
 
 		try {
 			$result = $this->convert_result( serialize_blocks( $blocks ), 'blocks', 'html', $options );
-			if ( is_array( $result ) && isset( $result['documents'][0]['content'] ) && is_string( $result['documents'][0]['content'] ) ) {
-				return $result['documents'][0]['content'];
-			}
-
-			return '';
+			return is_array( $result ) && function_exists( 'bfb_transformer_result_content' ) ? bfb_transformer_result_content( $result, 'html' ) : '';
 		} catch ( Throwable $e ) {
 			do_action(
 				'bfb_diagnostic',

--- a/includes/class-bfb-markdown-adapter.php
+++ b/includes/class-bfb-markdown-adapter.php
@@ -95,11 +95,7 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 
 		try {
 			$result = $this->convert_result( $content, 'markdown', 'blocks', $options );
-			if ( is_array( $result ) && isset( $result['blocks'] ) && is_array( $result['blocks'] ) ) {
-				return $result['blocks'];
-			}
-
-			return array();
+			return is_array( $result ) && function_exists( 'bfb_transformer_result_blocks' ) ? bfb_transformer_result_blocks( $result ) : array();
 		} catch ( Throwable $e ) {
 			do_action(
 				'bfb_diagnostic',
@@ -138,11 +134,8 @@ class BFB_Markdown_Adapter implements BFB_Format_Adapter {
 		}
 
 		try {
-			$markdown = '';
 			$result = $this->convert_result( serialize_blocks( $blocks ), 'blocks', 'markdown', $options );
-			if ( is_array( $result ) && isset( $result['documents'][0]['content'] ) && is_string( $result['documents'][0]['content'] ) ) {
-				$markdown = $result['documents'][0]['content'];
-			}
+			$markdown = is_array( $result ) && function_exists( 'bfb_transformer_result_content' ) ? bfb_transformer_result_content( $result, 'markdown' ) : '';
 
 			return (string) apply_filters( 'bfb_markdown_output', $markdown, '', $blocks );
 		} catch ( Throwable $e ) {

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -198,6 +198,63 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Built-in adapters should consume canonical Blocks Engine result fields through BFB's facade helpers.
+	 */
+	public function test_adapter_wrappers_consume_canonical_transformer_result_fields(): void {
+		$bridge = new class() {
+			/**
+			 * @return object
+			 */
+			public function convertResult( string $content, string $from, string $to, array $options = array() ) {
+				unset( $content, $options );
+
+				$blocks = parse_blocks( '<!-- wp:paragraph --><p>Canonical block field</p><!-- /wp:paragraph -->' );
+				$data   = array(
+					'schema'            => 'blocks-engine/transformer-result/v1',
+					'status'            => 'success',
+					'blocks'            => $blocks,
+					'serialized_blocks' => serialize_blocks( $blocks ),
+					'documents'         => array(
+						array(
+							'format'  => $to,
+							'content' => "Canonical {$from} to {$to}",
+						),
+					),
+				);
+
+				return new class( $data ) {
+					/**
+					 * @var array<string, mixed>
+					 */
+					private $data;
+
+					/**
+					 * @param array<string, mixed> $data Canonical result payload.
+					 */
+					public function __construct( array $data ) {
+						$this->data = $data;
+					}
+
+					/**
+					 * @return array<string, mixed>
+					 */
+					public function toArray(): array {
+						return $this->data;
+					}
+				};
+			}
+		};
+
+		$html_adapter     = new BFB_HTML_Adapter( $bridge );
+		$markdown_adapter = new BFB_Markdown_Adapter( $bridge );
+
+		$this->assertSame( 'core/paragraph', $html_adapter->to_blocks( '<p>Source</p>' )[0]['blockName'] ?? null );
+		$this->assertSame( 'Canonical blocks to html', $html_adapter->from_blocks( parse_blocks( '<!-- wp:paragraph --><p>Stored</p><!-- /wp:paragraph -->' ) ) );
+		$this->assertSame( 'core/paragraph', $markdown_adapter->to_blocks( 'Source' )[0]['blockName'] ?? null );
+		$this->assertSame( 'Canonical blocks to markdown', $markdown_adapter->from_blocks( parse_blocks( '<!-- wp:paragraph --><p>Stored</p><!-- /wp:paragraph -->' ) ) );
+	}
+
+	/**
 	 * Resolved asset metadata should flow through BFB into transformer media transforms.
 	 */
 	public function test_asset_metadata_context_delegates_to_transformer_image_parity(): void {


### PR DESCRIPTION
## Summary
- Add `bfb_transformer_result_blocks()` as the BFB facade helper for canonical Blocks Engine block arrays.
- Update HTML and Markdown adapters to consume canonical result blocks/content through facade helpers instead of adapter-local field extraction.
- Add behavior coverage with injected bridge doubles proving canonical `blocks` and `documents[0].content` fields flow through built-in adapters.

## Verification
- `composer lint`
- `composer smokes`
- `homeboy test --path .` (offloaded to `homeboy-lab`, WP Codebox: 29 passed, 321 assertions)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Inspecting the post-#138 cleanup surface, implementing the facade-thinning slice, adding tests, and running verification.