### PR TITLE
Narrow no-transformer report compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,16 @@ formats through the block-array pivot, and exposes one public API for callers th
 library performs a specific conversion. It does **not** own per-block raw transforms.
 
 HTML, markdown, and block transform behavior belongs to the Blocks Engine PHP Transformer. BFB keeps the historical
-`bfb_*` APIs and delegates conversion through `blocks_engine_php_transformer_convert_format()` when the plugin helper is
-available, falling back to the active `Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge` class.
+`bfb_*` APIs and delegates conversion through the active
+`Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge` result surface, with
+`blocks_engine_php_transformer_convert_format()` retained as runtime compatibility for helper-only installs.
 
 The explicit API path is:
 
 ```php
 bfb_convert( $html, 'html', 'blocks' )
     -> BFB_HTML_Adapter::to_blocks()
-    -> blocks_engine_php_transformer_convert_format();
+    -> FormatBridge::convertResult();
 ```
 
 The insert/update hook path is split by source format:

--- a/includes/api.php
+++ b/includes/api.php
@@ -777,12 +777,13 @@ if ( ! function_exists( 'bfb_compat_conversion_report_from_transformer_result' )
 	}
 }
 
-if ( ! function_exists( 'bfb_legacy_conversion_report_from_blocks' ) ) {
+if ( ! function_exists( 'bfb_compat_no_transformer_conversion_report_from_blocks' ) ) {
 	/**
-	 * Project locally converted blocks into BFB's legacy public report shape.
+	 * Project already-converted blocks into BFB's public report shape without a transformer result.
 	 *
-	 * This path is kept only for compatibility when the canonical transformer
-	 * result surface is unavailable or intentionally bypassed by pre-result hooks.
+	 * This compatibility path is kept for callers that intentionally inject
+	 * blocks through BFB's public hooks or run without the canonical transformer
+	 * result surface. Normal conversions should use FormatBridge result data.
 	 *
 	 * @param string            $content                  Source content.
 	 * @param string            $from                     Source format slug.
@@ -792,7 +793,7 @@ if ( ! function_exists( 'bfb_legacy_conversion_report_from_blocks' ) ) {
 	 * @param array<int, array> $materialization_requests Materialization requests collected from public hooks.
 	 * @return array<string, mixed> BFB conversion report.
 	 */
-	function bfb_legacy_conversion_report_from_blocks( string $content, string $from, array $blocks, array $fallback_events = array(), array $conversion_metadata = array(), array $materialization_requests = array() ): array {
+	function bfb_compat_no_transformer_conversion_report_from_blocks( string $content, string $from, array $blocks, array $fallback_events = array(), array $conversion_metadata = array(), array $materialization_requests = array() ): array {
 		$analysis                                  = bfb_analyze_blocks( $blocks );
 		$analysis['from']                          = $from;
 		$analysis['source_bytes']                  = strlen( $content );
@@ -808,6 +809,23 @@ if ( ! function_exists( 'bfb_legacy_conversion_report_from_blocks' ) ) {
 		$analysis['text_retention_ratio']          = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
 
 		return $analysis;
+	}
+}
+
+if ( ! function_exists( 'bfb_legacy_conversion_report_from_blocks' ) ) {
+	/**
+	 * Compatibility alias for the no-transformer report projection helper.
+	 *
+	 * @param string            $content                  Source content.
+	 * @param string            $from                     Source format slug.
+	 * @param array<int, array> $blocks                   Converted blocks.
+	 * @param array<int, array> $fallback_events          BFB-compatible fallback events.
+	 * @param array<int, array> $conversion_metadata      Conversion metadata collected from public hooks.
+	 * @param array<int, array> $materialization_requests Materialization requests collected from public hooks.
+	 * @return array<string, mixed> BFB conversion report.
+	 */
+	function bfb_legacy_conversion_report_from_blocks( string $content, string $from, array $blocks, array $fallback_events = array(), array $conversion_metadata = array(), array $materialization_requests = array() ): array {
+		return bfb_compat_no_transformer_conversion_report_from_blocks( $content, $from, $blocks, $fallback_events, $conversion_metadata, $materialization_requests );
 	}
 }
 
@@ -868,7 +886,7 @@ if ( ! function_exists( 'bfb_conversion_report' ) ) {
 		if ( $transformer_report ) {
 			$analysis = bfb_compat_conversion_report_from_transformer_result( $content, $from, $blocks, $transformer_report, $fallback_events, $conversion_metadata, $materialization_requests );
 		} else {
-			$analysis = bfb_legacy_conversion_report_from_blocks( $content, $from, $blocks, $fallback_events, $conversion_metadata, $materialization_requests );
+			$analysis = bfb_compat_no_transformer_conversion_report_from_blocks( $content, $from, $blocks, $fallback_events, $conversion_metadata, $materialization_requests );
 		}
 
 		$diagnostics = bfb_build_conversion_diagnostics( $analysis );

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -255,6 +255,29 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Result helpers should extract only canonical Blocks Engine result fields.
+	 */
+	public function test_canonical_transformer_result_extraction_uses_format_bridge_fields(): void {
+		$blocks = parse_blocks( '<!-- wp:paragraph --><p>Extracted block</p><!-- /wp:paragraph -->' );
+		$result = array(
+			'schema'            => 'blocks-engine/php-transformer/result/v1',
+			'status'            => 'success',
+			'blocks'            => $blocks,
+			'serialized_blocks' => serialize_blocks( $blocks ),
+			'documents'         => array(
+				array(
+					'format'  => 'html',
+					'content' => '<p>Extracted HTML</p>',
+				),
+			),
+		);
+
+		$this->assertSame( $blocks, bfb_transformer_result_blocks( $result ) );
+		$this->assertSame( serialize_blocks( $blocks ), bfb_transformer_result_content( $result, 'blocks' ) );
+		$this->assertSame( '<p>Extracted HTML</p>', bfb_transformer_result_content( $result, 'html' ) );
+	}
+
+	/**
 	 * Resolved asset metadata should flow through BFB into transformer media transforms.
 	 */
 	public function test_asset_metadata_context_delegates_to_transformer_image_parity(): void {
@@ -662,11 +685,16 @@ MARKDOWN;
 		$this->assertSame( $transformer_result['metrics'], $compat['transformer_metrics'] );
 		$this->assertSame( $transformer_result['coverage'], $compat['coverage'] );
 
-		$legacy = bfb_legacy_conversion_report_from_blocks( '<p>Fixture.</p>', 'html', $blocks );
+		$compat_no_transformer = bfb_compat_no_transformer_conversion_report_from_blocks( '<p>Fixture.</p>', 'html', $blocks );
 		foreach ( $base_public_keys as $key ) {
-			$this->assertArrayHasKey( $key, $legacy, "Legacy fallback projection should preserve public key {$key}." );
+			$this->assertArrayHasKey( $key, $compat_no_transformer, "No-transformer compatibility projection should preserve public key {$key}." );
 		}
-		$this->assertArrayNotHasKey( 'transformer_result', $legacy, 'Legacy fallback projection should not synthesize canonical transformer metadata.' );
+		$this->assertArrayNotHasKey( 'transformer_result', $compat_no_transformer, 'No-transformer compatibility projection should not synthesize canonical transformer metadata.' );
+		$this->assertSame(
+			$compat_no_transformer,
+			bfb_legacy_conversion_report_from_blocks( '<p>Fixture.</p>', 'html', $blocks ),
+			'Legacy helper should remain as a compatibility alias for existing callers.'
+		);
 	}
 
 	/**

--- a/tests/smoke-transformer-capability-discovery-standalone.php
+++ b/tests/smoke-transformer-capability-discovery-standalone.php
@@ -20,8 +20,28 @@ function blocks_engine_php_transformer_path(): string {
 }
 
 function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
-	unset( $content, $from, $to, $options );
-	return array( 'status' => 'success' );
+	unset( $content, $from, $options );
+
+	return array(
+		'schema'            => 'blocks-engine/php-transformer/result/v1',
+		'status'            => 'success',
+		'blocks'            => array(
+			array(
+				'blockName'   => 'core/paragraph',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+				'innerHTML'   => '<p>Standalone result</p>',
+				'innerContent' => array( '<p>Standalone result</p>' ),
+			),
+		),
+		'serialized_blocks' => '<!-- wp:paragraph --><p>Standalone result</p><!-- /wp:paragraph -->',
+		'documents'         => array(
+			array(
+				'format'  => $to,
+				'content' => 'standalone document content',
+			),
+		),
+	);
 }
 
 function bfb_transformer_standalone_assert( bool $condition, string $message ): void {
@@ -39,5 +59,11 @@ bfb_transformer_standalone_assert( true === $report['available'], 'Transformer h
 bfb_transformer_standalone_assert( 'standalone-test-version' === $report['version'], 'Transformer version should come from active helper.' );
 bfb_transformer_standalone_assert( 'function' === $report['integration'], 'Function helper should be the selected integration.' );
 bfb_transformer_standalone_assert( 'blocks_engine_php_transformer_convert_format' === $report['convert_format'], 'Function helper should be reported.' );
+
+$result = bfb_transformer_convert_result( '<p>Standalone result</p>', 'html', 'blocks' );
+bfb_transformer_standalone_assert( is_array( $result ), 'Transformer helper should return a canonical result array.' );
+bfb_transformer_standalone_assert( 'core/paragraph' === ( bfb_transformer_result_blocks( $result )[0]['blockName'] ?? null ), 'Canonical result block extraction should work.' );
+bfb_transformer_standalone_assert( '<!-- wp:paragraph --><p>Standalone result</p><!-- /wp:paragraph -->' === bfb_transformer_result_content( $result, 'blocks' ), 'Canonical serialized block extraction should work.' );
+bfb_transformer_standalone_assert( 'standalone document content' === bfb_transformer_result_content( $result, 'html' ), 'Canonical document content extraction should work.' );
 
 echo "PASS: standalone transformer capability discovery\n";


### PR DESCRIPTION
## Summary
- Rename the no-transformer report projection path behind explicit compatibility naming.
- Keep the legacy \ helper as a delegating compatibility alias.
- Document canonical FormatBridge result delegation and add coverage for canonical result extraction.

## Verification
- \No syntax errors detected in block-format-bridge.php
No syntax errors detected in library.php
No syntax errors detected in includes/hooks.php
No syntax errors detected in includes/class-bfb-adapter-registry.php
No syntax errors detected in includes/class-bfb-versions.php
No syntax errors detected in includes/abilities.php
No syntax errors detected in includes/cli.php
No syntax errors detected in includes/bootstrap.php
No syntax errors detected in includes/interface-bfb-format-adapter.php
No syntax errors detected in includes/api.php
No syntax errors detected in includes/rest.php
No syntax errors detected in includes/normalization.php
No syntax errors detected in includes/class-bfb-markdown-adapter.php
No syntax errors detected in includes/class-bfb-html-adapter.php
No syntax errors detected in tests/smoke-normalization-api-branches.php
No syntax errors detected in tests/smoke-transformer-capability-discovery-class.php
No syntax errors detected in tests/smoke-capabilities-abilities.php
No syntax errors detected in tests/smoke-multi-consumer-bundled-load.php
No syntax errors detected in tests/smoke-insert-conversion-measurement.php
No syntax errors detected in tests/smoke-transformer-capability-discovery-standalone.php
No syntax errors detected in tests/smoke-duplicate-version-registry.php
No syntax errors detected in tests/smoke-cli-command.php
No syntax errors detected in tests/smoke-transformer-composer-install.php
No syntax errors detected in tests/smoke-content-normalization.php
No syntax errors detected in tests/BFBConversionUnitTest.php
No syntax errors detected in tools/smoke-test.php
- \PASS: content normalization contract
PASS: standalone transformer capability discovery
PASS: transformer class capability discovery
PASS: Composer transformer install integration
- \
- \Running PHPUnit tests via WP Codebox...
  Plugin: block-format-bridge (/home/chubes/Developer/_lab_workspaces/block-format-bridge-cook-bfb-no-transformer-compat-cleanup-b75be70e4abb-eb0e986d-8f26-45ba-88a6-bf536f85190e-1782058562261153000)
  Backend: wp-codebox
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

..............................                                    30 / 30 (100%)

Time: 00:00.367, Memory: 58.50 MB

OK (30 tests, 325 assertions)


--- Bootstrap notices (non-fatal) ---
NOTICE:runtime ability lifecycle ready: wp_abilities_api_categories_init=0; wp_abilities_api_init=0; wp_codebox_runtime_abilities_ready=[redacted]
NOTICE:phpunit.xml.dist not readable at /wordpress/wp-content/plugins/block-format-bridge/phpunit.xml.dist; using defaults

WP Codebox test run complete.
{
  "success": true,
  "data": {
    "component": "block-format-bridge",
    "exit_code": 0,
    "hints": [
      "Auto-fix lint issues: homeboy refactor block-format-bridge --from lint --write",
      "Collect coverage: homeboy test block-format-bridge --coverage",
      "Save test baseline: homeboy test block-format-bridge --baseline",
      "Pass args to test runner: homeboy test <component> -- [args]",
      "Full options: homeboy docs commands/test"
    ],
    "passed": true,
    "phase": {
      "exit_code": 0,
      "phase": "test",
      "status": "passed",
      "summary": "test phase passed: 30 passed, 0 skipped"
    },
    "status": "passed",
    "test_counts": {
      "failed": 0,
      "passed": 30,
      "skipped": 0,
      "total": 30
    }
  }
} (Lab offload, 30 passed, 325 assertions)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, test updates, verification, and PR drafting.