### PR TITLE
Delete no-transformer report fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ document metadata envelope; callers that import files are responsible for stripp
 passing the body to `bfb_convert( $markdown, 'markdown', 'blocks' )`. BFB also does not support MDX component syntax unless
 a future dedicated adapter is registered for it.
 
-Every cross-format conversion routes through the block-array pivot:
+Every cross-format conversion routes through Blocks Engine FormatBridge:
 
 ```
-$blocks = bfb_to_blocks( $content, $from );
-return    $to_adapter->from_blocks( $blocks );
+$result = bfb_transformer_convert_result( $content, $from, $to );
+return bfb_transformer_result_content( $result, $to );
 ```
 
 Declared-format normalization validates the declared format directly:
@@ -67,9 +67,9 @@ Declared-format normalization validates the declared format directly:
 
 ### BFB and Blocks Engine Responsibility Split
 
-BFB owns format routing and orchestration. It decides which adapter handles a source format, normalises non-block
-formats through the block-array pivot, and exposes one public API for callers that do not want to know which lower-level
-library performs a specific conversion. It does **not** own per-block raw transforms.
+BFB owns the public API and orchestration around the canonical transformer. It exposes one public API for callers that do
+not want to know which lower-level library performs a specific conversion. It does **not** own per-block raw transforms or
+no-transformer conversion fallbacks.
 
 HTML, markdown, and block transform behavior belongs to the Blocks Engine PHP Transformer. BFB keeps the historical
 `bfb_*` APIs and delegates conversion through the active
@@ -178,9 +178,9 @@ composer build  # verifies the thin wrapper build has no bundled transformer art
 
 ### `bfb_convert( $content, $from, $to ): string`
 
-Universal conversion. Routes through the block-array pivot via the adapter registry.
+Universal conversion. Routes through Blocks Engine FormatBridge; BFB does not assemble no-transformer conversion fallbacks.
 
-When `$from === $to`, `bfb_convert()` returns the content unchanged. Use `bfb_normalize()` for same-format validation.
+Use `bfb_normalize()` for same-format validation.
 
 ```php
 // Markdown → blocks (serialised block markup)

--- a/includes/api.php
+++ b/includes/api.php
@@ -13,7 +13,7 @@
  *   bfb_capabilities()                      — active transformer report
  *   bfb_get_adapter( $slug )                — registry lookup
  *
- * `bfb_convert()` routes through the block pivot via the adapter registry.
+ * `bfb_convert()` routes through the canonical Blocks Engine FormatBridge.
  * `bfb_normalize()` validates already-declared content through the dedicated
  * normalization helpers loaded from includes/normalization.php.
  *
@@ -435,12 +435,7 @@ if ( ! function_exists( 'bfb_to_blocks' ) ) {
 			return $blocks;
 		}
 
-		$from_adapter = bfb_get_adapter( $from );
-		if ( ! $from_adapter ) {
-			return array();
-		}
-
-		return $from_adapter->to_blocks( $content, $options );
+		return array();
 	}
 }
 
@@ -448,17 +443,8 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 	/**
 	 * Convert content from one format to another.
 	 *
-	 * Routing always passes through the block pivot:
-	 *
-	 *   $blocks = bfb_to_blocks( $content, $from, $options );
-	 *   return    $to_adapter->from_blocks( $blocks, $options );
-	 *
-	 * Special cases:
-	 *   - $from === $to                → returns $content unchanged
-	 *   - $from === 'blocks'           → skips the to_blocks() hop and
-	 *                                    treats $content as serialized
-	 *                                    block markup, parsing it first
-	 *   - $to === 'blocks'             → returns serialized block markup
+	 * Routing delegates to the canonical Blocks Engine FormatBridge result
+	 * surface. BFB no longer assembles no-transformer conversion fallbacks.
 	 *
 	 * @param string               $content Source content.
 	 * @param string               $from    Source format slug.
@@ -488,22 +474,7 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 			return $converted;
 		}
 
-		$blocks = bfb_to_blocks( $content, $from, $options );
-		if ( array() === $blocks && 'blocks' !== $from ) {
-			return '';
-		}
-
-		// Render the intermediate into the target format.
-		if ( 'blocks' === $to ) {
-			return serialize_blocks( $blocks );
-		}
-
-		$to_adapter = bfb_get_adapter( $to );
-		if ( ! $to_adapter ) {
-			return '';
-		}
-
-		return $to_adapter->from_blocks( $blocks, $options );
+		return '';
 	}
 }
 
@@ -777,58 +748,6 @@ if ( ! function_exists( 'bfb_compat_conversion_report_from_transformer_result' )
 	}
 }
 
-if ( ! function_exists( 'bfb_compat_no_transformer_conversion_report_from_blocks' ) ) {
-	/**
-	 * Project already-converted blocks into BFB's public report shape without a transformer result.
-	 *
-	 * This compatibility path is kept for callers that intentionally inject
-	 * blocks through BFB's public hooks or run without the canonical transformer
-	 * result surface. Normal conversions should use FormatBridge result data.
-	 *
-	 * @param string            $content                  Source content.
-	 * @param string            $from                     Source format slug.
-	 * @param array<int, array> $blocks                   Converted blocks.
-	 * @param array<int, array> $fallback_events          BFB-compatible fallback events.
-	 * @param array<int, array> $conversion_metadata      Conversion metadata collected from public hooks.
-	 * @param array<int, array> $materialization_requests Materialization requests collected from public hooks.
-	 * @return array<string, mixed> BFB conversion report.
-	 */
-	function bfb_compat_no_transformer_conversion_report_from_blocks( string $content, string $from, array $blocks, array $fallback_events = array(), array $conversion_metadata = array(), array $materialization_requests = array() ): array {
-		$analysis                                  = bfb_analyze_blocks( $blocks );
-		$analysis['from']                          = $from;
-		$analysis['source_bytes']                  = strlen( $content );
-		$analysis['source_text_bytes']             = bfb_text_bytes( $content );
-		$analysis['fallback_events']               = $fallback_events;
-		$analysis['fallback_diagnostics']          = ! empty( $fallback_events ) ? $fallback_events : $analysis['fallbacks'];
-		$analysis['fallback_event_count']          = count( $fallback_events );
-		$analysis['conversion_metadata']           = $conversion_metadata;
-		$analysis['materialization_requests']      = $materialization_requests;
-		$analysis['materialization_request_count'] = count( $materialization_requests );
-		$analysis['serialized_blocks']             = serialize_blocks( $blocks );
-		$analysis['converted_text_bytes']          = bfb_text_bytes( $analysis['serialized_blocks'] );
-		$analysis['text_retention_ratio']          = bfb_text_retention_ratio( (int) $analysis['source_text_bytes'], (int) $analysis['converted_text_bytes'] );
-
-		return $analysis;
-	}
-}
-
-if ( ! function_exists( 'bfb_legacy_conversion_report_from_blocks' ) ) {
-	/**
-	 * Compatibility alias for the no-transformer report projection helper.
-	 *
-	 * @param string            $content                  Source content.
-	 * @param string            $from                     Source format slug.
-	 * @param array<int, array> $blocks                   Converted blocks.
-	 * @param array<int, array> $fallback_events          BFB-compatible fallback events.
-	 * @param array<int, array> $conversion_metadata      Conversion metadata collected from public hooks.
-	 * @param array<int, array> $materialization_requests Materialization requests collected from public hooks.
-	 * @return array<string, mixed> BFB conversion report.
-	 */
-	function bfb_legacy_conversion_report_from_blocks( string $content, string $from, array $blocks, array $fallback_events = array(), array $conversion_metadata = array(), array $materialization_requests = array() ): array {
-		return bfb_compat_no_transformer_conversion_report_from_blocks( $content, $from, $blocks, $fallback_events, $conversion_metadata, $materialization_requests );
-	}
-}
-
 if ( ! function_exists( 'bfb_conversion_report' ) ) {
 	/**
 	 * Convert content to blocks and return quality metrics alongside the result.
@@ -866,28 +785,28 @@ if ( ! function_exists( 'bfb_conversion_report' ) ) {
 
 		add_action( 'bfb_conversion_metadata', $metadata_listener, 10, 1 );
 		add_action( 'bfb_materialization_request', $request_listener, 10, 1 );
-		if ( $transformer_report ) {
-			$blocks = isset( $transformer_report['blocks'] ) && is_array( $transformer_report['blocks'] ) ? $transformer_report['blocks'] : array();
-		} else {
-			try {
-				$blocks = bfb_to_blocks( $content, $from, $options );
-			} finally {
-				remove_action( 'bfb_conversion_metadata', $metadata_listener, 10 );
-				remove_action( 'bfb_materialization_request', $request_listener, 10 );
-			}
+		remove_action( 'bfb_conversion_metadata', $metadata_listener, 10 );
+		remove_action( 'bfb_materialization_request', $request_listener, 10 );
+
+		if ( ! $transformer_report ) {
+			$transformer_report = array(
+				'schema'            => 'blocks-engine/php-transformer/result/v1',
+				'status'            => 'failed',
+				'blocks'            => array(),
+				'serialized_blocks' => '',
+				'diagnostics'       => array(
+					array(
+						'code'     => 'blocks_engine_format_bridge_unavailable',
+						'severity' => 'error',
+						'message'  => 'Blocks Engine FormatBridge did not return a conversion result.',
+					),
+				),
+			);
 		}
 
-		if ( $transformer_report ) {
-			$fallback_events = bfb_transformer_fallback_events( $transformer_report );
-			remove_action( 'bfb_conversion_metadata', $metadata_listener, 10 );
-			remove_action( 'bfb_materialization_request', $request_listener, 10 );
-		}
-
-		if ( $transformer_report ) {
-			$analysis = bfb_compat_conversion_report_from_transformer_result( $content, $from, $blocks, $transformer_report, $fallback_events, $conversion_metadata, $materialization_requests );
-		} else {
-			$analysis = bfb_compat_no_transformer_conversion_report_from_blocks( $content, $from, $blocks, $fallback_events, $conversion_metadata, $materialization_requests );
-		}
+		$blocks          = isset( $transformer_report['blocks'] ) && is_array( $transformer_report['blocks'] ) ? $transformer_report['blocks'] : array();
+		$fallback_events = bfb_transformer_fallback_events( $transformer_report );
+		$analysis        = bfb_compat_conversion_report_from_transformer_result( $content, $from, $blocks, $transformer_report, $fallback_events, $conversion_metadata, $materialization_requests );
 
 		$diagnostics = bfb_build_conversion_diagnostics( $analysis );
 

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -153,12 +153,13 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 
 		add_filter( 'bfb_register_format_adapter', $adapter_filter, 10, 2 );
 		try {
-			bfb_convert( 'probe source', 'probe-options', 'blocks', array( 'mode' => 'fidelity' ) );
+			$result = bfb_convert( 'probe source', 'probe-options', 'blocks', array( 'mode' => 'fidelity' ) );
 		} finally {
 			remove_filter( 'bfb_register_format_adapter', $adapter_filter, 10 );
 		}
 
-		$this->assertSame( array( 'mode' => 'fidelity' ), $probe->received_options, 'Generic adapters should receive public conversion options.' );
+		$this->assertSame( '', $result, 'Custom adapters should not provide no-transformer conversion fallbacks.' );
+		$this->assertSame( array(), $probe->received_options, 'Custom adapters should not receive conversion options when FormatBridge cannot convert the format.' );
 	}
 
 	/**
@@ -685,16 +686,8 @@ MARKDOWN;
 		$this->assertSame( $transformer_result['metrics'], $compat['transformer_metrics'] );
 		$this->assertSame( $transformer_result['coverage'], $compat['coverage'] );
 
-		$compat_no_transformer = bfb_compat_no_transformer_conversion_report_from_blocks( '<p>Fixture.</p>', 'html', $blocks );
-		foreach ( $base_public_keys as $key ) {
-			$this->assertArrayHasKey( $key, $compat_no_transformer, "No-transformer compatibility projection should preserve public key {$key}." );
-		}
-		$this->assertArrayNotHasKey( 'transformer_result', $compat_no_transformer, 'No-transformer compatibility projection should not synthesize canonical transformer metadata.' );
-		$this->assertSame(
-			$compat_no_transformer,
-			bfb_legacy_conversion_report_from_blocks( '<p>Fixture.</p>', 'html', $blocks ),
-			'Legacy helper should remain as a compatibility alias for existing callers.'
-		);
+		$this->assertFalse( function_exists( 'bfb_compat_no_transformer_conversion_report_from_blocks' ) );
+		$this->assertFalse( function_exists( 'bfb_legacy_conversion_report_from_blocks' ) );
 	}
 
 	/**
@@ -707,70 +700,6 @@ MARKDOWN;
 		$this->assertSame( 0, $report['fallback_event_count'] );
 		$this->assertSame( array(), $report['fallback_diagnostics'] );
 		$this->assertSame( '', $report['serialized_blocks'] );
-	}
-
-	/**
-	 * Conversion reports should surface generic downstream materialization requests.
-	 */
-	public function test_conversion_report_surfaces_safe_svg_materialization_metadata(): void {
-		$safe_svg = '<svg viewBox="0 0 24 24" aria-label="Check"><path d="M20 6 9 17l-5-5" fill="none" stroke="currentColor" stroke-width="2"/></svg>';
-
-		$pre_result = static function ( $pre_result, string $content ): array {
-			unset( $pre_result );
-
-				do_action(
-					'bfb_materialization_request',
-				array(
-					'id'             => 'svg-icon-check',
-					'kind'           => 'asset',
-					'source'         => 'inline',
-					'classification' => 'safe_svg_icon',
-					'media_type'     => 'image/svg+xml',
-					'filename'       => 'svg-icon-check.svg',
-					'placeholder'    => 'bfb-materialization://svg-icon-check',
-					'payload'        => $content,
-					'alt'            => 'Check',
-					'replacement'    => array(
-						'block_name' => 'core/image',
-						'attrs'      => array(
-							'url' => 'bfb-materialization://svg-icon-check',
-							'alt' => 'Check',
-						),
-					),
-				)
-			);
-
-			return array(
-				array(
-					'blockName'    => 'core/image',
-					'attrs'        => array(
-						'url' => 'bfb-materialization://svg-icon-check',
-						'alt' => 'Check',
-					),
-					'innerBlocks'  => array(),
-					'innerHTML'    => '<figure class="wp-block-image"><img src="bfb-materialization://svg-icon-check" alt="Check"/></figure>',
-					'innerContent' => array( '<figure class="wp-block-image"><img src="bfb-materialization://svg-icon-check" alt="Check"/></figure>' ),
-				),
-			);
-		};
-
-		add_filter( 'bfb_html_to_blocks_pre_result', $pre_result, 10, 2 );
-		try {
-			$report = bfb_conversion_report( $safe_svg, 'html' );
-		} finally {
-			remove_filter( 'bfb_html_to_blocks_pre_result', $pre_result, 10 );
-		}
-
-		$this->assertSame( 1, $report['total_blocks'] );
-		$this->assertSame( 0, $report['core_html_blocks'] );
-		$this->assertSame( 0, $report['fallback_event_count'] );
-		$this->assertSame( 1, $report['materialization_request_count'] );
-		$this->assertSame( 'success_with_materialization_requests', $report['status'] );
-		$this->assertSame( 'materialization_requested', $report['diagnostics'][0]['code'] ?? null );
-		$this->assertSame( 'safe_svg_icon', $report['materialization_requests'][0]['classification'] ?? null );
-		$this->assertSame( 'image/svg+xml', $report['materialization_requests'][0]['media_type'] ?? null );
-		$this->assertStringContainsString( '<svg viewBox=', $report['materialization_requests'][0]['payload'] ?? '' );
-		$this->assertStringNotContainsString( '<!-- wp:html', $report['serialized_blocks'] );
 	}
 
 	/**

--- a/tests/smoke-capabilities-abilities.php
+++ b/tests/smoke-capabilities-abilities.php
@@ -179,8 +179,8 @@ $converted        = $convert_callback(
 		'to'      => 'markdown',
 	)
 );
-bfb_capabilities_smoke_assert( true === $converted['success'], 'Convert ability should return a success envelope.' );
-bfb_capabilities_smoke_assert( 'same' === $converted['content'], 'Convert ability should call bfb_convert().' );
+bfb_capabilities_smoke_assert( false === $converted['success'], 'Convert ability should fail without Blocks Engine FormatBridge.' );
+bfb_capabilities_smoke_assert( 'bfb_conversion_failed' === $converted['error']['code'], 'Convert ability should surface missing FormatBridge as a conversion failure.' );
 
 $normalize_callback = $abilities['block-format-bridge/normalize']['execute_callback'];
 $normalized         = $normalize_callback(

--- a/tests/smoke-multi-consumer-bundled-load.php
+++ b/tests/smoke-multi-consumer-bundled-load.php
@@ -332,23 +332,8 @@ try {
 	bfb_smoke_assert( array( '9.9.9' ) === $bfb_loaded_versions, 'bfb_loaded should fire once for the winning version.' );
 	bfb_smoke_assert( 1 === bfb_smoke_hook_count( 'wp_insert_post_data', 'bfb_convert_on_insert' ), 'BFB insert conversion hook should register once.' );
 
-	$scoped_classes = array(
-		'Automattic\\BlocksEngine\\PhpTransformer\\FormatBridge\\FormatBridge',
-		'Automattic\\BlocksEngine\\PhpTransformer\\FormatBridge\\HtmlAdapter',
-		'Automattic\\BlocksEngine\\PhpTransformer\\FormatBridge\\MarkdownAdapter',
-		'Automattic\\BlocksEngine\\PhpTransformer\\HtmlToBlocks\\HtmlTransformer',
-	);
-
-	foreach ( $scoped_classes as $class_name ) {
-		bfb_smoke_assert(
-			class_exists( 'BlockFormatBridge\\Vendor\\' . $class_name, false ),
-			"Scoped transformer {$class_name} should exist after bundled boot."
-		);
-		bfb_smoke_assert(
-			! class_exists( $class_name, false ),
-			"Global transformer {$class_name} should not exist after bundled boot."
-		);
-	}
+	bfb_smoke_assert( null === bfb_format_bridge(), 'BFB should not synthesize a FormatBridge without the external Blocks Engine transformer.' );
+	bfb_smoke_assert( false === bfb_transformer_capabilities()['available'], 'BFB should report the transformer unavailable in this isolated smoke.' );
 } finally {
 	bfb_smoke_remove_path( $temp_root );
 }


### PR DESCRIPTION
## Summary
- Delete the BFB-owned no-transformer conversion report projection and legacy compatibility alias.
- Make conversion/report fallback paths fail closed unless Blocks Engine FormatBridge returns the canonical result.
- Update tests and docs to assert the external FormatBridge dependency instead of bundled/no-transformer behavior.

## Intentional breakage
- Callers relying on `bfb_compat_no_transformer_conversion_report_from_blocks()` or `bfb_legacy_conversion_report_from_blocks()` will break.
- Custom adapters no longer provide no-transformer conversion fallback output through top-level `bfb_convert()` / `bfb_to_blocks()` when FormatBridge cannot convert a format.
- Report assembly no longer fabricates BFB report metrics from locally converted blocks when the transformer result is missing.

## Verification
- `composer lint`
- `composer smokes`
- `php tests/smoke-cli-command.php && php tests/smoke-duplicate-version-registry.php && php tests/smoke-multi-consumer-bundled-load.php && php tests/smoke-capabilities-abilities.php && php tests/smoke-normalization-api-branches.php`
- `git diff --check`
- `homeboy test --path .` via offloaded `homeboy-lab`: 29 passed, 0 failed; persisted run `runner-exec-homeboy-lab-5b0f86aa-6936-4d31-aedf-c8baa7cc742a`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Implementing the cleanup, updating tests/docs, running verification, and drafting this PR body.