### PR TITLE
Use tagged Blocks Engine transformer release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
             "type": "package",
             "package": {
                 "name": "automattic/blocks-engine-php-transformer",
-                "version": "dev-trunk",
+                "version": "0.1.0",
                 "type": "library",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/Automattic/blocks-engine.git",
-                    "reference": "trunk"
+                    "reference": "php-transformer-v0.1.0"
                 },
                 "autoload": {
                     "psr-4": {
@@ -46,7 +46,7 @@
         }
     ],
     "require": {
-        "automattic/blocks-engine-php-transformer": "dev-trunk",
+        "automattic/blocks-engine-php-transformer": "0.1.0",
         "php": "^8.1"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e156c88a74672a5b83c82be0f2dae55f",
+    "content-hash": "46f205a25a20dc045c362b842e4cc704",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "dev-trunk",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "trunk"
+                "reference": "php-transformer-v0.1.0"
             },
             "require": {
                 "league/commonmark": "^2.5",
@@ -746,9 +746,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "automattic/blocks-engine-php-transformer": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary
- Pin the Blocks Engine PHP transformer dependency to the tagged `0.1.0` release.
- Resolve the inline Composer package from `php-transformer-v0.1.0` instead of `trunk`.
- Regenerate `composer.lock` so installs prove the tagged release path.

## Verification
- `composer update automattic/blocks-engine-php-transformer --no-interaction --prefer-dist`
- `composer show automattic/blocks-engine-php-transformer --all` reported `versions : * 0.1.0` and `source : [git] https://github.com/Automattic/blocks-engine.git php-transformer-v0.1.0`
- `composer smokes`
- `php tests/smoke-transformer-composer-install.php`
- `composer lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Dependency pin update, Composer lock regeneration, and verification run orchestration.
