### PR TITLE
Clarify BFB legacy facade posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Block Format Bridge
 
-A WordPress plugin **and Composer package** for content format conversion and declared-format normalization across HTML,
-Blocks, and Markdown.
+A legacy WordPress plugin **and Composer package** that preserves the historical `bfb_*` APIs while delegating content format conversion and declared-format normalization to Blocks Engine.
+
+New consumers should depend on `automattic/blocks-engine-php-transformer` directly and use `Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge`. BFB remains a stable compatibility shim for callers that already depend on the `bfb_*` PHP functions, WP-CLI wrapper, REST read surface, or insert-time normalization hooks.
 
 The bridge owns no parsing logic of its own. It is a public API wrapper around the active Blocks Engine PHP Transformer
 `FormatBridge` class plus WordPress core's block helpers. New formats become available through Blocks Engine support and
@@ -118,24 +119,22 @@ Rules:
 The marker contract belongs in BFB because BFB is the public compatibility/API surface. Runtime HTML-element transforms are
 supplied by Blocks Engine through the public `bfb_convert( $html, 'html', 'blocks' )` path.
 
-## Install
+## Install For Existing BFB Consumers
 
-Install it as a standalone plugin, or bundle it as a Composer package.
+Install BFB only when you need the historical `bfb_*` compatibility surface. New projects should install the canonical Blocks Engine PHP Transformer package directly instead of adding BFB as an active dependency.
 
-Data Machine v0.88.0+ bundles BFB as its content-format substrate. Data Machine-powered sites do not need the standalone
-BFB plugin unless they also want to manage BFB independently.
+Data Machine v0.88.0+ bundles BFB only as a legacy content-format shim. Data Machine-powered sites do not need the standalone BFB plugin unless they also need to manage the compatibility surface independently.
 
 ### Composer via GitHub VCS
 
-BFB has tagged GitHub releases, but it is not currently published on Packagist, WordPress.org, or wp-packages.org. Until
-one of those mirrors exists, Composer consumers should install it from the GitHub VCS repository:
+BFB has tagged GitHub releases, but it is not currently published on Packagist, WordPress.org, or wp-packages.org. Existing BFB consumers that still need the shim can install it from the GitHub VCS repository:
 
 ```bash
 composer config repositories.bfb vcs https://github.com/chubes4/block-format-bridge
 composer require chubes4/block-format-bridge:^0.5
 ```
 
-Use `dev-main` only when intentionally tracking unreleased development commits.
+Use `dev-main` only when intentionally tracking unreleased shim maintenance commits.
 
 ### Blocks Engine Transformer Status
 
@@ -149,20 +148,8 @@ HTML and Markdown conversion require the Blocks Engine PHP Transformer runtime t
 
 ### Publishing status
 
-- **GitHub releases:** available at https://github.com/chubes4/block-format-bridge/releases.
-- **Packagist:** not published yet; publishing there would keep the Composer package name
-  `chubes4/block-format-bridge`.
-- **WordPress.org:** not published yet; `readme.txt` is present to prepare for plugin-directory review, but no submission
-  has been made from this repository.
-- **wp-packages.org:** not published yet. wp-packages.org mirrors WordPress.org plugins as `wp-plugin/<slug>`, so BFB
-  will only appear there after a WordPress.org plugin-directory listing exists.
-
-If BFB is approved on WordPress.org under the `block-format-bridge` slug, the wp-packages.org install path will be:
-
-```bash
-composer config repositories.wp-packages composer https://repo.wp-packages.org
-composer require wp-plugin/block-format-bridge
-```
+- **GitHub releases:** available for existing shim consumers at https://github.com/chubes4/block-format-bridge/releases.
+- **Packagist / WordPress.org / wp-packages.org:** not a priority. New dependency guidance points to `automattic/blocks-engine-php-transformer` instead of publishing or promoting BFB as a standalone package/plugin.
 
 ### Build from source
 
@@ -319,8 +306,7 @@ Resolve a registered adapter directly. Prefer `bfb_to_blocks()` when callers nee
 
 ### Block Theme Compiler Consumers
 
-Static HTML/CSS to block-theme compilers should treat BFB as the format-conversion API surface, not the layer that infers
-block-theme or Site Editor intent. The compiler-facing helper and CLI shape are documented in
+Legacy static HTML/CSS to block-theme compilers that already use BFB should treat it as the compatibility format-conversion API surface, not the layer that infers block-theme or Site Editor intent. New compiler layers should use Blocks Engine directly. The historical compiler-facing helper and CLI shape are documented in
 [`docs/block-theme-compiler-surface.md`](docs/block-theme-compiler-surface.md). The stack workflow across Blocks Engine, BFB, and
 compiler consumers is documented in [`docs/block-theme-conversion-workflow.md`](docs/block-theme-conversion-workflow.md).
 The public mechanical conversion scope matrix is documented in

--- a/block-format-bridge.php
+++ b/block-format-bridge.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Block Format Bridge
  * Plugin URI: https://github.com/chubes4/block-format-bridge
- * Description: Orchestrates bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API. Composes existing plugins/libraries — owns no parsing logic of its own.
+ * Description: Legacy BFB compatibility facade; new consumers should use automattic/blocks-engine-php-transformer directly.
  * Version: 0.8.2
  * Author: Chris Huber
  * Author URI: https://chubes.net

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "chubes4/block-format-bridge",
     "type": "wordpress-plugin",
-    "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
+    "description": "Legacy BFB compatibility facade; new consumers should use automattic/blocks-engine-php-transformer directly.",
     "license": "GPL-2.0-or-later",
     "homepage": "https://github.com/chubes4/block-format-bridge",
     "authors": [

--- a/docs/block-theme-compiler-surface.md
+++ b/docs/block-theme-compiler-surface.md
@@ -2,7 +2,7 @@
 
 Issue: https://github.com/chubes4/block-format-bridge/issues/29
 
-This note defines the Block Format Bridge surface a future static HTML/CSS to block-theme compiler should consume. It is intentionally limited to BFB's boundary: compatibility APIs and format conversion through the block pivot. Block-theme structure, Site Editor behavior, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside Blocks Engine PHP transformer.
+This note records the legacy Block Format Bridge surface for static HTML/CSS to block-theme compilers that already consume BFB. New compiler integrations should use `automattic/blocks-engine-php-transformer` directly. The BFB surface is intentionally limited to compatibility APIs and format conversion through the block pivot. Block-theme structure, Site Editor behavior, template intent, theme.json generation, and per-block transform behavior belong above BFB or inside Blocks Engine PHP transformer.
 
 ## Boundary
 
@@ -22,7 +22,7 @@ HTML / Markdown / future formats
         +--> markdown adapter    -> Markdown
 ```
 
-A site compiler can use BFB for deterministic conversion once it has already decided what belongs in templates, template parts, patterns, posts, or global styles.
+Existing site compilers can use BFB for deterministic conversion once they have already decided what belongs in templates, template parts, patterns, posts, or global styles. New compilers should call Blocks Engine directly.
 
 ## Explicit Site Editor Primitive Markers
 
@@ -74,13 +74,13 @@ Behavior:
 - Unsupported formats return an empty array and log the same style of error as `bfb_convert()`.
 - The helper should be the internal source of truth for `bfb_convert()` once implemented, avoiding two conversion paths.
 
-Use this helper instead of reaching into adapters directly.
+Existing BFB consumers should use this helper instead of reaching into adapters directly.
 
 ### 2. WP-CLI conversion command
 
 BFB exposes a CLI command for non-PHP callers.
 
-Node-based tools such as Studio can already call WordPress through WP-CLI. A command like this would let those tools use the server-side converter without embedding PHP glue:
+Node-based tools such as Studio can already call WordPress through WP-CLI. For legacy BFB integrations, a command like this lets those tools use the server-side shim without embedding PHP glue:
 
 ```bash
 wp bfb convert --from=html --to=blocks < input.html
@@ -98,14 +98,14 @@ The CLI is a thin wrapper around `bfb_convert()` for serialized output and `bfb_
 
 ### 3. Arrays plus serialized markup in one call
 
-BFB should support this as a convenience for compiler workflows, but keep it separate from `bfb_convert()`.
+BFB may keep this as a compatibility convenience for existing compiler workflows, but it should remain separate from `bfb_convert()`.
 
 Compiler consumers often need both representations:
 
 - Block arrays for inspection, splitting, policy checks, and template/pattern assembly.
 - Serialized block markup for writing to WordPress files or `post_content`.
 
-Recommended future helper:
+Legacy helper shape:
 
 ```php
 /**
@@ -141,11 +141,11 @@ For HTML to Blocks, BFB's stable contract should be:
 - BFB does not promise semantic inference beyond the attributes emitted by the active adapter.
 - Per-block mapping rules and fidelity fixes belong in Blocks Engine PHP transformer tests and releases.
 
-That gives compiler consumers a stable integration target without moving transform ownership into BFB.
+That gives existing BFB compiler consumers a stable shim target without moving transform ownership into BFB.
 
 ## Recommended Sequence
 
-1. Document this surface now.
-2. Use `bfb_to_blocks()` when a compiler consumer needs block arrays directly.
-3. Add `bfb_to_block_document()` if callers repeatedly need arrays plus serialized markup from the same source.
-4. Use `wp bfb convert` for non-PHP callers that need server-side conversion.
+1. Keep this surface documented for existing BFB consumers.
+2. Use `bfb_to_blocks()` when an existing BFB consumer needs block arrays directly.
+3. Keep any arrays-plus-markup helper as shim compatibility, not a new transform layer.
+4. Use `wp bfb convert` only for legacy non-PHP callers that already route through BFB.

--- a/readme.txt
+++ b/readme.txt
@@ -8,11 +8,13 @@ Stable tag: 0.5.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Server-side content format conversion between HTML, WordPress blocks, and Markdown through one deterministic bridge API.
+Legacy BFB compatibility facade over Blocks Engine content format conversion.
 
 == Description ==
 
-Block Format Bridge is a WordPress plugin and Composer package for converting content between HTML, WordPress block markup, and Markdown.
+Block Format Bridge is a legacy WordPress plugin and Composer package that preserves the historical `bfb_*` APIs for converting content between HTML, WordPress block markup, and Markdown.
+
+New consumers should depend on `automattic/blocks-engine-php-transformer` directly and use the canonical Blocks Engine PHP Transformer `FormatBridge` class instead of adding BFB as an active dependency.
 
 The bridge owns format routing and orchestration. It delegates conversion to the canonical Blocks Engine PHP Transformer `FormatBridge` class instead of adding a separate parser or fallback converter.
 
@@ -27,7 +29,9 @@ BFB also includes a thin WP-CLI wrapper and a REST read surface using `?content_
 
 This plugin does not use AI, telemetry, remote services, or external API calls. Conversion runs locally inside WordPress.
 
-== Installation ==
+== Installation For Existing BFB Consumers ==
+
+Install BFB only when you need the historical PHP functions, WP-CLI wrapper, REST read surface, or insert-time normalization hooks.
 
 = WordPress plugin =
 
@@ -37,7 +41,7 @@ This plugin does not use AI, telemetry, remote services, or external API calls. 
 
 = Composer =
 
-BFB is not currently published on Packagist, WordPress.org, or wp-packages.org. Composer consumers can install tagged GitHub releases through a VCS repository:
+BFB is not currently published on Packagist, WordPress.org, or wp-packages.org. Existing BFB consumers that still need the shim can install tagged GitHub releases through a VCS repository:
 
 `
 composer config repositories.bfb vcs https://github.com/chubes4/block-format-bridge
@@ -59,13 +63,9 @@ composer build
 
 == Frequently Asked Questions ==
 
-= Is this plugin already available on WordPress.org? =
+= Is this plugin/package being promoted for new installs? =
 
-No. This `readme.txt` prepares the repository for a future WordPress.org plugin-directory submission, but the plugin has not been submitted from this repository yet.
-
-= Is this package already available on Packagist or wp-packages.org? =
-
-No. GitHub VCS installation is the current Composer path. wp-packages.org mirrors plugins from WordPress.org under `wp-plugin/<slug>`, so BFB will only appear there after a WordPress.org plugin-directory listing exists.
+No. BFB remains a compatibility shim for existing `bfb_*` integrations. New installs should use `automattic/blocks-engine-php-transformer` directly.
 
 = Does the plugin require Blocks Engine PHP Transformer? =
 


### PR DESCRIPTION
## Summary
- Reframe BFB as a stable legacy shim for existing bfb_* consumers.
- Point new format-conversion and compiler consumers to automattic/blocks-engine-php-transformer / FormatBridge directly.
- Remove Packagist/WordPress.org/wp-packages promotion language and narrow install docs to existing shim consumers.

## Verification
- composer lint
- composer smokes
- composer build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing active-dependency surfaces, editing docs/plugin/package metadata, and running verification.