### PR TITLE
Clarify BFB transformer independence

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,13 @@ The explicit API path is:
 
 ```php
 bfb_convert( $html, 'html', 'blocks' )
-    -> BFB_HTML_Adapter::to_blocks()
     -> FormatBridge::convertResult();
 ```
 
 The insert/update hook path is split by source format:
 
 - **BFB priority 5:** `wp_insert_post_data` handles non-HTML source formats, such as Markdown, before WordPress stores
-  the post. The adapter path normalises those formats to block markup.
+  the post. The conversion path normalizes those formats to block markup through `bfb_convert()`.
 
 The path is server-side and deterministic. There is no AI conversion pass in BFB or the transformer.
 
@@ -187,23 +186,23 @@ $md = bfb_convert( '<h1>X</h1>', 'html', 'markdown' );
 // Markdown → HTML (composes via blocks)
 $html = bfb_convert( '# X', 'markdown', 'html' );
 
-// HTML → blocks with importer-neutral per-call context forwarded to transformer args.
+// HTML → blocks with caller-owned per-call context forwarded to transformer args.
 $blocks = bfb_convert(
     '<h1>Hello</h1><p>World</p>',
     'html',
     'blocks',
     array(
         'context' => array(
-            'source' => 'static-site-importer',
-            'mode'   => 'import',
+            'source' => 'site-compiler',
+            'mode'   => 'fragment',
         ),
     )
 );
 ```
 
 The optional fourth argument is a generic per-call options array. For HTML → Blocks, BFB forwards those options alongside
-the reserved `HTML` argument passed to the active transformer, so downstream tools can pass structured `context` without
-BFB gaining importer-specific API.
+the reserved `HTML` argument passed to the active transformer, so callers can pass structured `context` without BFB
+depending on any importer, compiler, or conversion package other than the Blocks Engine PHP Transformer.
 
 ### `bfb_to_blocks( $content, $from ): array`
 
@@ -221,7 +220,7 @@ foreach ( $blocks as $block ) {
 Contract:
 
 - `from === 'blocks'` parses serialized block markup with `parse_blocks()`.
-- Other formats resolve through `bfb_get_adapter( $from )` and call the adapter's `to_blocks()` method.
+- Other supported formats route through Blocks Engine PHP Transformer's `FormatBridge` result surface.
 - Unsupported source formats return an empty array and log the same style of error as `bfb_convert()`.
 
 ### WP-CLI: `wp bfb convert`

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 #
 # Build the distributable form of block-format-bridge.
 #
-# BFB is a thin compatibility wrapper around the canonical Blocks Engine PHP
-# Transformer plugin/classes. It intentionally does not vendor-prefix or bundle
-# the transformer package.
+# BFB is a thin compatibility facade over the canonical Blocks Engine PHP
+# Transformer classes. It intentionally does not vendor-prefix converter
+# packages into its own source tree.
 #
 # Run via `composer build` (also wired up in composer.json scripts).
 
@@ -12,10 +12,8 @@ set -euo pipefail
 
 blocked_paths=(
 	"vendor_prefixed/automattic/blocks-engine-php-transformer"
-	"vendor_prefixed/chubes4/html-to-blocks-converter"
 	"vendor_prefixed/chubes4/block-artifact-compiler"
 	"includes/blocks-engine-php-transformer"
-	"includes/html-to-blocks-converter"
 	"includes/block-artifact-compiler"
 )
 
@@ -26,4 +24,4 @@ for blocked_path in "${blocked_paths[@]}"; do
 	fi
 done
 
-echo "==> Build complete: BFB ships without bundled transformer dependencies."
+echo "==> Build complete: BFB ships without source-tree converter bundles."

--- a/docs/block-theme-compiler-surface.md
+++ b/docs/block-theme-compiler-surface.md
@@ -70,7 +70,7 @@ function bfb_to_blocks( string $content, string $from ): array;
 Behavior:
 
 - `from === 'blocks'` parses serialized block markup with `parse_blocks()`.
-- Other formats resolve through `bfb_get_adapter( $from )` and call `to_blocks()`.
+- Other supported formats route through Blocks Engine PHP Transformer's `FormatBridge` result surface.
 - Unsupported formats return an empty array and log the same style of error as `bfb_convert()`.
 - The helper should be the internal source of truth for `bfb_convert()` once implemented, avoiding two conversion paths.
 

--- a/tests/BFBConversionUnitTest.php
+++ b/tests/BFBConversionUnitTest.php
@@ -46,9 +46,9 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Conversion options should flow from the public API into adapters and transformer args.
+	 * Conversion options should flow from the public API into transformer args.
 	 */
-	public function test_conversion_options_flow_to_adapters_and_transformer_args(): void {
+	public function test_conversion_options_flow_to_public_api_and_transformer_args(): void {
 		$html = '<h2>Options Heading</h2><p>Options paragraph.</p>';
 
 		$default = bfb_convert( $html, 'html', 'blocks' );
@@ -88,8 +88,8 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 				'blocks',
 				array(
 					'context' => array(
-						'source' => 'static-site-importer',
-						'mode'   => 'import',
+						'source' => 'site-compiler',
+						'mode'   => 'fragment',
 					),
 					'mode'    => 'fidelity',
 				)
@@ -99,12 +99,12 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 		}
 
 		$this->assertNotSame( '', $with_options, '4-argument conversion should produce serialized blocks.' );
-		$this->assertIsArray( $seen_args, 'HTML adapter should expose transformer arguments.' );
+		$this->assertIsArray( $seen_args, 'BFB should expose transformer arguments.' );
 		$this->assertSame( 'fidelity', $seen_args['args']['mode'] ?? null, 'Mode option should be forwarded to transformer args.' );
 		$this->assertSame(
 			array(
-				'source' => 'static-site-importer',
-				'mode'   => 'import',
+				'source' => 'site-compiler',
+				'mode'   => 'fragment',
 			),
 			$seen_args['args']['context'] ?? null,
 			'Generic conversion context should be forwarded to transformer args.'
@@ -113,13 +113,13 @@ class BFBConversionUnitTest extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'context' => array(
-					'source' => 'static-site-importer',
-					'mode'   => 'import',
+					'source' => 'site-compiler',
+					'mode'   => 'fragment',
 				),
 				'mode'    => 'fidelity',
 			),
 			$seen_args['options'] ?? null,
-			'HTML adapter should receive public conversion options.'
+			'BFB should receive public conversion options.'
 		);
 
 		$probe = new class() implements BFB_Format_Adapter {


### PR DESCRIPTION
## Summary

- Clarifies BFB as an independent facade over Blocks Engine PHP Transformer.
- Removes stale Static Site Importer / H2BC coupling examples from docs and tests.
- Keeps `bfb_convert()` public behavior backed by the transformer result surface.

## Verification

```sh
composer validate --strict
composer lint
composer smokes
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Repository inspection, dependency-chain cleanup, focused edits, and verification command selection.
